### PR TITLE
fix no_proxy to build within Intel firewall

### DIFF
--- a/libraries/dl-streamer/docker/dlstreamer_dev_ubuntu22.Dockerfile
+++ b/libraries/dl-streamer/docker/dlstreamer_dev_ubuntu22.Dockerfile
@@ -111,7 +111,7 @@ RUN \
 
 # Intel® Data Center GPU Flex Series drivers (optional)
 # hadolint ignore=SC1091
-RUN \
+RUN export -n no_proxy && \
     apt-get update && \
     . /etc/os-release && \
     if [[ ! "jammy" =~ ${VERSION_CODENAME} ]]; then \
@@ -460,7 +460,7 @@ RUN \
     strip -g "${DLSTREAMER_DIR}"/gstreamer/lib/gstreamer-1.0/libgstrs*.so
 
 # Intel® Distribution of OpenVINO™ Toolkit
-RUN \
+RUN export -n no_proxy && \
     wget -q --no-check-certificate https://storage.openvinotoolkit.org/repositories/openvino/packages/"$OPENVINO_VERSION"/linux/"$OPENVINO_FILENAME".tgz && \
     tar -xf "$OPENVINO_FILENAME".tgz && \
     mv "$OPENVINO_FILENAME" /opt/intel/openvino_"$OPENVINO_VERSION".0 && \

--- a/libraries/dl-streamer/docker/dlstreamer_dev_ubuntu24.Dockerfile
+++ b/libraries/dl-streamer/docker/dlstreamer_dev_ubuntu24.Dockerfile
@@ -95,7 +95,7 @@ RUN \
 
 # Intel® Data Center GPU Flex Series drivers (optional)
 # hadolint ignore=SC1091
-RUN \
+RUN export -n no_proxy && \
     apt-get update && \
     . /etc/os-release && \
     if [[ ! " jammy noble " =~ ${VERSION_CODENAME} ]]; then \
@@ -445,7 +445,7 @@ RUN \
     strip -g "${DLSTREAMER_DIR}"/gstreamer/lib/gstreamer-1.0/libgstrs*.so
 
 # Intel® Distribution of OpenVINO™ Toolkit
-RUN \
+RUN export -n no_proxy && \
     wget -q --no-check-certificate https://storage.openvinotoolkit.org/repositories/openvino/packages/"$OPENVINO_VERSION"/linux/"$OPENVINO_FILENAME".tgz && \
     tar -xf "$OPENVINO_FILENAME".tgz && \
     mv "$OPENVINO_FILENAME" /opt/intel/openvino_"$OPENVINO_VERSION".0 && \

--- a/libraries/dl-streamer/docker/dlstreamer_ubuntu22.Dockerfile
+++ b/libraries/dl-streamer/docker/dlstreamer_ubuntu22.Dockerfile
@@ -28,7 +28,7 @@ RUN \
 
 # Intel® Data Center GPU Flex Series drivers (optional)
 # hadolint ignore=SC1091
-RUN \
+RUN export -n no_proxy && \
     apt-get update && \
     . /etc/os-release && \
     if [[ ! "jammy" =~ ${VERSION_CODENAME} ]]; then \
@@ -47,7 +47,7 @@ RUN \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN \
+RUN export -n no_proxy && \
     echo "deb https://apt.repos.intel.com/openvino/2025 ubuntu22 main" | tee /etc/apt/sources.list.d/intel-openvino-2025.list && \
     wget -q https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
     apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
@@ -58,7 +58,7 @@ RUN \
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN \
+RUN export -n no_proxy && \
     apt-get update -y && \
     apt-get install -y -q --no-install-recommends intel-dlstreamer=\* && \
     apt-get clean -y && \

--- a/libraries/dl-streamer/docker/dlstreamer_ubuntu24.Dockerfile
+++ b/libraries/dl-streamer/docker/dlstreamer_ubuntu24.Dockerfile
@@ -28,7 +28,7 @@ RUN \
 
 # Intel® Data Center GPU Flex Series drivers (optional)
 # hadolint ignore=SC1091
-RUN \
+RUN export -n no_proxy && \
     apt-get update && \
     . /etc/os-release && \
     if [[ ! " jammy noble " =~ ${VERSION_CODENAME} ]]; then \
@@ -48,7 +48,7 @@ RUN \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN \
+RUN export -n no_proxy && \
     echo "deb https://apt.repos.intel.com/openvino/2025 ubuntu24 main" | tee /etc/apt/sources.list.d/intel-openvino-2025.list && \
     wget -q https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
     apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
@@ -59,7 +59,7 @@ RUN \
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN \
+RUN export -n no_proxy && \
     apt-get update -y && \
     apt-get install -y -q --no-install-recommends intel-dlstreamer=\* && \
     apt-get clean -y && \


### PR DESCRIPTION
### Description

The repositories such as `repositories.intel.com` are outside of the Intel firewall. Accessing them must go through `https_proxy` from within Intel. However, Intel IT recommends to add `intel.com` to `no_proxy`. This patch enables build within Intel by temporarily disabling `no_proxy` for specific RUN commands.

Please fix your validation proxy setup. Add `intel.com` to your `no_proxy`, as this is the norm. 

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Build passed after patching the code.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

