### PR TITLE
Enable CPU only hosts

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/Dockerfile.vippet
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Dockerfile.vippet
@@ -32,6 +32,6 @@ RUN pip install -r requirements.txt
 
 ADD diagrams/ /home/dlstreamer/vippet/diagrams
 
-ADD app.py collect.py optimize.py pipeline.py device.py /home/dlstreamer/vippet/
+ADD app.py collect.py optimize.py pipeline.py device.py explore.py /home/dlstreamer/vippet/
 
 CMD ["python", "app.py"]

--- a/tools/visual-pipeline-and-platform-evaluation-tool/app.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/app.py
@@ -14,6 +14,7 @@ from collect import CollectionReport, MetricsCollectorFactory
 from optimize import OptimizationResult, PipelineOptimizer
 from pipeline import SmartNVRPipeline, Transportation2Pipeline
 from device import DeviceDiscovery
+from explore import GstInspector
 
 css_code = """
 
@@ -93,6 +94,7 @@ theme = gr.themes.Default(
 # pipeline = Transportation2Pipeline()
 pipeline = SmartNVRPipeline()
 device_discovery = DeviceDiscovery()
+gst_inspector = GstInspector()
 
 # Download File
 def download_file(url, local_filename):
@@ -576,6 +578,7 @@ def create_interface():
                         constants=constants,
                         param_grid=param_grid,
                         channels=(recording_channels, inferencing_channels),
+                        elements=gst_inspector.get_elements(),
                     )
                     collector.collect()
                     time.sleep(3)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/explore.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/explore.py
@@ -1,0 +1,67 @@
+import subprocess
+from threading import Lock
+
+class GstInspector:
+    """
+    A singleton class to inspect GStreamer elements using gst-inspect-1.0.
+    This class provides a method to retrieve the list of GStreamer elements
+    and their descriptions.
+
+    These is an example of the output from the command:
+
+    videoanalytics:  gvaclassify: Object classification (requires GstVideoRegionOfInterestMeta on input)
+    videoanalytics:  gvadetect: Object detection (generates GstVideoRegionOfInterestMeta)
+    videoanalytics:  gvainference: Generic full-frame inference (generates GstGVATensorMeta)
+
+    Those elements will be returned in a list of tuples:
+
+    [
+        ("videoanalytics", "gvaclassify", "<description>"),
+        ("videoanalytics", "gvadetect", "<description>"),
+        ("videoanalytics", "gvainference", "<description>")
+    ]
+    """
+    _instance = None
+    _lock = Lock()
+
+    def __new__(cls, *args, **kwargs):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super(GstInspector, cls).__new__(cls)
+                cls._instance._initialize()
+        return cls._instance
+
+    def _initialize(self):
+        self.elements = self._get_gst_elements()
+
+    def _get_gst_elements(self):
+        try:
+            result = subprocess.run(
+                ["gst-inspect-1.0"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True
+            )
+            lines = result.stdout.splitlines()
+            elements = []
+            for line in lines:
+                if ":  " in line:
+                    plugin, rest = line.split(":  ", 1)
+                    if ": " in rest:
+                        element, description = rest.split(": ", 1)
+                        elements.append((plugin.strip(), element.strip(), description.strip()))
+
+            return sorted(elements)
+
+        except subprocess.CalledProcessError as e:
+            print(f"Error running gst-inspect-1.0: {e}")
+            return []
+
+    def get_elements(self):
+        return self.elements
+
+if __name__ == "__main__":
+    inspector = GstInspector()
+    for element in inspector.get_elements():
+        print(element)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/optimize.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/optimize.py
@@ -31,6 +31,7 @@ class PipelineOptimizer:
         param_grid: Dict[str, List[str]],
         poll_interval: int = 1,
         channels: int | tuple[int, int] = 1,
+        elements: List[tuple[str, str, str]] = [],
     ):
 
         # Initialize class variables
@@ -38,6 +39,7 @@ class PipelineOptimizer:
         self.constants = constants
         self.param_grid = param_grid
         self.poll_interval = poll_interval
+        self.elements = elements
 
         # Set the number of channels
         self.channels = (
@@ -65,29 +67,12 @@ class PipelineOptimizer:
 
     def optimize(self):
 
-        # Run gst-inspect-1.0 to get the list of elements
-        process = Popen(["gst-inspect-1.0", "va"], stdout=PIPE, stderr=PIPE)
-        elements = process.communicate()[0].decode("utf-8").split("\n")
-
-        # Log the elements
-        self.logger.info("Elements:")
-        self.logger.info(pprint.pformat(elements))
-
-        # Find the available encoder
-        # Note that the selected encoder is the last one on the list.
-        # This is usually vah264lpenc if the encoder is available.
-        # Otherwise, fallback to the only available encoder, usually vah264enc.
-        encoder = [element for element in elements if "vah264enc" in element or "vah264lpenc" in element][-1]
-        encoder = encoder.split(":")[0].strip()
-
-        # Log the encoder
-        self.logger.info(f"Encoder: {encoder}")
 
         for params in self._iterate_param_grid(self.param_grid):
 
             # Evaluate the pipeline with the given parameters, constants, and channels
             _pipeline = self.pipeline.evaluate(
-                self.constants, params, self.regular_channels, self.inference_channels, encoder
+                self.constants, params, self.regular_channels, self.inference_channels, self.elements
             )
 
             # Log the command

--- a/tools/visual-pipeline-and-platform-evaluation-tool/pipeline.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/pipeline.py
@@ -126,10 +126,6 @@ class SmartNVRPipeline(GstPipeline):
             "  location={VIDEO_OUTPUT_PATH} "
         )
 
-        self._decoder = (
-            "decodebin ! "
-        )
-
         self._recording_stream = (
             "filesrc "
             "  location={VIDEO_PATH} ! "
@@ -238,7 +234,7 @@ class SmartNVRPipeline(GstPipeline):
         )
 
         # Find the available decoder in elements
-        _decoder = next(
+        _decoder_element = next(
             ("vah264dec ! video/x-raw(memory:VAMemory) " for element in elements if element[1] == "vah264dec"),
             next(
                 ("decodebin" for element in elements if element[1] == "decodebin"),
@@ -247,7 +243,7 @@ class SmartNVRPipeline(GstPipeline):
         )
 
         # Find the postprocessing element
-        _postprocessing = next(
+        _postprocessing_element = next(
             ("vapostproc" for element in elements if element[1] == "vapostproc"),
             next(
                 ("videoscale" for element in elements if element[1] == "videoscale"),
@@ -270,8 +266,8 @@ class SmartNVRPipeline(GstPipeline):
                 **parameters,
                 **constants,
                 id=i,
-                decoder=_decoder,
-                postprocessing=_postprocessing
+                decoder=_decoder_element,
+                postprocessing=_postprocessing_element
             )
 
         for i in range(inference_channels, channels):
@@ -279,8 +275,8 @@ class SmartNVRPipeline(GstPipeline):
                 **parameters, 
                 **constants, 
                 id=i, 
-                decoder=_decoder,
-                postprocessing=_postprocessing
+                decoder=_decoder_element,
+                postprocessing=_postprocessing_element
             )
 
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/pipeline.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/pipeline.py
@@ -256,7 +256,8 @@ class SmartNVRPipeline(GstPipeline):
             **constants, 
             sinks=sinks, 
             encoder=_encoder_element, 
-            compositor=_compositor_element)
+            compositor=_compositor_element
+        )
 
         # Create the streams
         streams = ""


### PR DESCRIPTION
### Description

This PR improves the discovery of available elements to use in the pipeline.
Hosts without GPUs don't have the elements that the current pipeline defines.
So now the pipeline will adapt better to the elements available.
This also helps in WSL environments, which has a GPU that DL Streamer don't support

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

No new dependencies.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested in WSL, and Intel Core Ultra 7 155H with multiple profiles, and Arc A770 with GPU profile

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

