### PR TITLE
support jinja2 templates in pipeline definition

### DIFF
--- a/microservices/dlstreamer-pipeline-server/src/server/pipeline_manager.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/pipeline_manager.py
@@ -16,6 +16,8 @@ import jsonschema
 from src.server.common.utils import logging
 from src.server.pipeline import Pipeline
 from src.server import schema
+import jinja2
+import copy
 
 class PipelineManager:
 
@@ -107,7 +109,7 @@ class PipelineManager:
                                         config['version'] = version
                                         # validate_config will throw warning of
                                         # missing elements but continue execution
-                                        self._validate_config(config)
+                                        # self._validate_config(config)
                                         self.logger.info("Loading Pipeline: {} version: "
                                                          "{} type: {} from {}".format(
                                                              pipeline,
@@ -272,7 +274,10 @@ class PipelineManager:
             return None, "Invalid Pipeline or Version"
 
         pipeline_type = self.pipelines[name][str(version)]['type']
-        pipeline_config = self.pipelines[name][str(version)]
+        pipeline_config = copy.deepcopy(self.pipelines[name][str(version)])
+
+        if 'template' in pipeline_config:
+            pipeline_config['template'] = jinja2.Environment(undefined=jinja2.StrictUndefined).from_string(pipeline_config['template']).render(request_original)
 
         request = request_original.copy()
 

--- a/microservices/dlstreamer-pipeline-server/src/server/requirements.txt
+++ b/microservices/dlstreamer-pipeline-server/src/server/requirements.txt
@@ -1,2 +1,2 @@
 jsonschema[format_nongpl] == 3.2.0
-jinja2 == 3.1.6
+jinja2 >= 3.1.6

--- a/microservices/dlstreamer-pipeline-server/src/server/requirements.txt
+++ b/microservices/dlstreamer-pipeline-server/src/server/requirements.txt
@@ -1,1 +1,2 @@
 jsonschema[format_nongpl] == 3.2.0
+jinja2 == 3.1.6


### PR DESCRIPTION
### Description

This serves as a POC for supporting jinja2 template in the pipeline definition. Simplify pipeline definition and make it align better with the gstreamer command line. See JIRA ITEP-25482 for more details. The Jinja2 support is backward compatible with the existing json schema. 

### Any Newly Introduced Dependencies

Jinja2, of the BSD license, is used in the code.

### How Has This Been Tested?

Unit tested:
```
# config.json
{
      "name": "pallet_defect_detection_default",
      "source": "gstreamer",
      "queue_maxsize": 50,
      "pipeline": "filesrc location={{ video_file }} ! decodebin ! videoconvert ! gvadetect name=detection pre-process-backend=opencv model={{ model_name }} model-instance-id=detshared ! queue ! gvawatermark ! gvafpscounter ! gvametaconvert add-empty-results=true name=metaconvert ! gvametapublish name=destination file-path={{ results_json }} file-format=json-lines ! appsink name=appsink wait-on-eos=false",
      "auto_start": false
    }
}
```

```
# curl command line:
curl <URL> -X POST -H 'Content-Type:Application/json' -d '{"video_file":"/home/pipeline-server/resources/videos/warehouse.avi","model_name":"/home/pipeline-server/resources/models/geti/pallet_defect_detection/deployment/Detection/model/model.xml","results_json": "/var/cache/pipeline_root/results-1.jsonl"}'
```

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

