### PR TITLE
[DLStreamer] Fix memory leak when detection output is augmented.

### DIFF
--- a/libraries/dl-streamer/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/blob_to_roi_converter.cpp
+++ b/libraries/dl-streamer/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/blob_to_roi_converter.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2021-2024 Intel Corporation
+ * Copyright (C) 2021-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
@@ -147,9 +147,12 @@ void BlobToROIConverter::runNms(std::vector<DetectedObject> &candidates) const {
 
             assert(union_area != 0 && "union_area is null. Both of the boxes have zero areas.");
             const double overlap = inter_area / union_area;
-            if (overlap > iou_threshold)
+            if (overlap > iou_threshold) {
+                for (auto tensor : p_candidate->tensors) {
+                    gst_structure_free(tensor);
+                }
                 p_candidate = candidates.erase(p_candidate);
-            else
+            } else
                 ++p_candidate;
         }
     }


### PR DESCRIPTION
Fix memory leak when detection output is augmented with pose/segmentation data.


### Description

There was a memory leak when detection output was augmented with auxiliary data (like pose or segmentation). Auxiliary data was not released when detection object itself was removed by NMS algorithm.

Fixes # (issue)
Fixes issue reported here: https://github.com/dlstreamer/dlstreamer/issues/461

### Any Newly Introduced Dependencies

No new dependencies introduced.

### How Has This Been Tested?

Verified manually the memory leak does not occur for the reported case + automated CI regression validation. 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

