### PR TITLE
Bump DL Streamer Version

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/Dockerfile.vippet
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Dockerfile.vippet
@@ -14,7 +14,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM docker.io/intel/dlstreamer:2025.0.1.2-ubuntu24
+FROM docker.io/intel/dlstreamer:2025.0.1.3-ubuntu24
 
 USER root
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/how-to-build-source.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/how-to-build-source.md
@@ -32,7 +32,9 @@ This guide assumes basic familiarity with Git commands, Python virtual environme
 2. **Build and Start the Tool**:
    - Run:
      ```bash
-     docker pull docker.io/intel/dlstreamer:2025.0.1.2-ubuntu24
+     docker pull docker.io/intel/dlstreamer:2025.0.1.3-ubuntu24
+     docker pull docker.io/library/rust:1.87
+     docker pull docker.io/library/telegraf:1.32
      docker compose build
      docker compose up -d
      ```

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM docker.io/intel/dlstreamer:2025.0.1.2-ubuntu24
+FROM docker.io/intel/dlstreamer:2025.0.1.3-ubuntu24
 
 # Set environment variable to non-interactive mode (avoids some prompts)
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

* Use docker.io/intel/dlstreamer:2025.0.1.3-ubuntu24
* Update base image for app and video generator
* Update build docs

Fixes ITEP-67474

The objective of this version bump is to enable [download_public_models.sh]https://github.com/dlstreamer/dlstreamer/blob/master/samples/download_public_models.sh).
The script version in 2025.0.1.2-ubuntu24 has a bug in how ultralytics version is computed.
The one in 2025.0.1.3-ubuntu24 works.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

No new dependencies

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Local build on Intel(R) Xeon(R) Gold 6414U + Intel Corporation DG2 [Arc A380]

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

