### PR TITLE
time-series-analytics: Save downloaded model by name uuid

### DIFF
--- a/microservices/time-series-analytics/src/classifier_startup.py
+++ b/microservices/time-series-analytics/src/classifier_startup.py
@@ -396,12 +396,15 @@ def main():
     with open("/tmp/" + conf_file, 'r') as file:
         config_data = tomlkit.parse(file.read())
     udf_name = config['task']['udfs']['name']
+    dir_name = udf_name
+    if mrHandlerObj is not None and mrHandlerObj.fetch_from_model_registry:
+        dir_name = mrHandlerObj.unique_id
     udf_section = config_data.get('udf', {}).get('functions', {})
     udf_section[udf_name] = tomlkit.table()
 
     udf_section[udf_name]['prog'] = 'python3'
     
-    udf_section[udf_name]['args'] = ["-u", "/tmp/"+udf_name+"/udfs/" + udf_name + ".py"]
+    udf_section[udf_name]['args'] = ["-u", "/tmp/"+ dir_name +"/udfs/" + udf_name + ".py"]
     
     udf_section[udf_name]['timeout'] = "60s"
     udf_section[udf_name]['env'] = {

--- a/microservices/time-series-analytics/src/mr_interface.py
+++ b/microservices/time-series-analytics/src/mr_interface.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 from zipfile import ZipFile
 import requests
+import uuid
 
 
 UDF_API_ENDPOINT = "/models"
@@ -46,6 +47,8 @@ class MRHandler:
         self.base_url = os.getenv("MODEL_REGISTRY_URL")
         self.logger = logger
         self.fetch_from_model_registry = False
+        self.unique_id = str(uuid.uuid4())
+        print(f"Generated UUID: {self.unique_id}")
         os.environ["REQUESTS_CA_BUNDLE"] = "/run/secrets/server-ca.crt"
         if "fetch_from_model_registry" in self.tasks and self.tasks["fetch_from_model_registry"] is True:
             data = self.get_model_info(self.tasks["task_name"], self.tasks["version"])
@@ -128,8 +131,7 @@ class MRHandler:
                 file_path = os.path.join("/tmp", "temp.zip")
                 with open(file_path, 'wb') as f:
                     f.write(response2.content)
-                    f.close()
-                model_dir = os.path.join("/tmp", f"{name}")
+                model_dir = os.path.join("/tmp", f"{self.unique_id}")
                 Path(model_dir).mkdir(parents=True, exist_ok=True)
                 with ZipFile(file_path, 'r') as zobj:
                     zobj.extractall(path=model_dir)

--- a/microservices/time-series-analytics/src/mr_interface.py
+++ b/microservices/time-series-analytics/src/mr_interface.py
@@ -48,7 +48,6 @@ class MRHandler:
         self.logger = logger
         self.fetch_from_model_registry = False
         self.unique_id = str(uuid.uuid4())
-        print(f"Generated UUID: {self.unique_id}")
         os.environ["REQUESTS_CA_BUNDLE"] = "/run/secrets/server-ca.crt"
         if "fetch_from_model_registry" in self.tasks and self.tasks["fetch_from_model_registry"] is True:
             data = self.get_model_info(self.tasks["task_name"], self.tasks["version"])
@@ -131,6 +130,7 @@ class MRHandler:
                 file_path = os.path.join("/tmp", "temp.zip")
                 with open(file_path, 'wb') as f:
                     f.write(response2.content)
+                    f.close()
                 model_dir = os.path.join("/tmp", f"{self.unique_id}")
                 Path(model_dir).mkdir(parents=True, exist_ok=True)
                 with ZipFile(file_path, 'r') as zobj:


### PR DESCRIPTION



### Description

Changes:
 1.mr_interface.py- Change to save downloaded model using uuid
 2.classifier_startup.py - Change to use uuid for model registry
   downloaded model

Fixes # (issue)

### Any Newly Introduced Dependencies

No.

### How Has This Been Tested?

Yes, tested

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

