### PR TITLE
[Model Registry] Helm Chart Scoping and Container Config Enhancements

### DIFF
--- a/microservices/model-registry/helm/templates/model-registry.yaml
+++ b/microservices/model-registry/helm/templates/model-registry.yaml
@@ -45,7 +45,28 @@ spec:
         - name: src-dir
           mountPath: /data
       containers:
-        - env:
+      - name: {{ $.Values.config.model_registry.name }}
+        image: {{ $.Values.DOCKER_REGISTRY }}{{ $.Values.images.model_registry }}
+        volumeMounts:
+        - name: src-dir
+          mountPath: /src
+        - name: tmp-dir
+          mountPath: /tmp
+        imagePullPolicy: {{ $.Values.imagePullPolicy }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: {{ $.Values.env.MR_UID }}
+        ports:
+          - containerPort: 8111
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 300m
+            memory: "4294967296"
+          requests:
+            cpu: 150m
+            memory: "2147483648"
+        env:
           - name: AppName
             value: {{ $.Values.env.AppName }}
           - name: CA_CERT
@@ -84,27 +105,6 @@ spec:
             value: "{{ $.Values.env.no_proxy }}"
           - name: NO_PROXY
             value: "{{ $.Values.env.NO_PROXY }}"
-        image: {{ $.Values.DOCKER_REGISTRY }}{{ $.Values.images.model_registry }}
-        volumeMounts:
-          - name: src-dir
-            mountPath: /src
-          - name: tmp-dir
-            mountPath: /tmp
-        imagePullPolicy: {{ $.Values.imagePullPolicy }}
-        name: {{ $.Values.config.model_registry.name }}
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsUser: {{ $.Values.env.MR_UID }}
-        ports:
-          - containerPort: 8111
-            protocol: TCP
-        resources:
-          limits:
-            cpu: 300m
-            memory: "4294967296"
-          requests:
-            cpu: 150m
-            memory: "2147483648"
       hostname: {{ $.Values.config.model_registry.name }}
       restartPolicy: Always
       volumes:

--- a/microservices/model-registry/helm/templates/model-registry.yaml
+++ b/microservices/model-registry/helm/templates/model-registry.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $.Values.namespace }}
   name: {{ $.Values.config.model_registry.name }}
 spec:
   type: NodePort
@@ -22,7 +22,7 @@ metadata:
   labels:
     app: {{ $.Values.env.AppName }}
   name: deployment-{{ $.Values.config.model_registry.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ $.Values.namespace }}
 spec:
   replicas: 1
   selector:
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       initContainers:
       - name: copy-files
-        image: {{ $.Values.DOCKER_REGISTRY }}{{ .Values.images.model_registry }}
+        image: {{ $.Values.DOCKER_REGISTRY }}{{ $.Values.images.model_registry }}
         command: ['sh', '-c', 'cp -a /src/* /data/']
         volumeMounts:
         - name: src-dir
@@ -49,42 +49,42 @@ spec:
           - name: AppName
             value: {{ $.Values.env.AppName }}
           - name: CA_CERT
-            value: "{{ .Values.env.CA_CERT }}"
+            value: "{{ $.Values.env.CA_CERT }}"
           - name: ENABLE_HTTPS_MODE
-            value: "{{ .Values.env.ENABLE_HTTPS_MODE }}"
+            value: "{{ $.Values.env.ENABLE_HTTPS_MODE }}"
           - name: LSHOST
             value: host.docker.internal
           - name: MINIO_ACCESS_KEY
-            value: "{{ .Values.env.MINIO_ACCESS_KEY }}"
+            value: "{{ $.Values.env.MINIO_ACCESS_KEY }}"
           - name: MINIO_BUCKET_NAME
-            value: "{{ .Values.env.MINIO_BUCKET_NAME }}"
+            value: "{{ $.Values.env.MINIO_BUCKET_NAME }}"
           - name: MINIO_HOSTNAME
-            value: "{{ .Values.env.MINIO_HOSTNAME }}"
+            value: "{{ $.Values.env.MINIO_HOSTNAME }}"
           - name: MINIO_SECRET_KEY
-            value: "{{ .Values.env.MINIO_SECRET_KEY }}"
+            value: "{{ $.Values.env.MINIO_SECRET_KEY }}"
           - name: MINIO_SERVER_PORT
-            value: "{{ .Values.env.MINIO_SERVER_PORT }}"
+            value: "{{ $.Values.env.MINIO_SERVER_PORT }}"
           - name: MIN_LOG_LEVEL
-            value: "{{ .Values.env.MIN_LOG_LEVEL }}"
+            value: "{{ $.Values.env.MIN_LOG_LEVEL }}"
           - name: MLFLOW_S3_ENDPOINT_URL
-            value: "{{ .Values.env.MLFLOW_S3_ENDPOINT_URL }}"
+            value: "{{ $.Values.env.MLFLOW_S3_ENDPOINT_URL }}"
           - name: MLFLOW_TRACKING_URI
-            value: postgresql+psycopg2://{{ .Values.env.MR_USER_NAME }}:{{ .Values.env.POSTGRES_PASSWORD }}@mr-postgres:5432/{{ .Values.env.POSTGRES_DB }}
+            value: postgresql+psycopg2://{{ $.Values.env.MR_USER_NAME }}:{{ $.Values.env.POSTGRES_PASSWORD }}@mr-postgres:5432/{{ $.Values.env.POSTGRES_DB }}
           - name: SERVER_CERT
-            value: "{{ .Values.env.SERVER_CERT }}"
+            value: "{{ $.Values.env.SERVER_CERT }}"
           - name: SERVER_PORT
-            value: "{{ .Values.env.SERVER_PORT }}"
+            value: "{{ $.Values.env.SERVER_PORT }}"
           - name: SERVER_PRIVATE_KEY
-            value: "{{ .Values.env.SERVER_PRIVATE_KEY }}"
+            value: "{{ $.Values.env.SERVER_PRIVATE_KEY }}"
           - name: https_proxy
-            value: "{{ .Values.env.https_proxy }}"
+            value: "{{ $.Values.env.https_proxy }}"
           - name: http_proxy
-            value: "{{ .Values.env.http_proxy }}"
+            value: "{{ $.Values.env.http_proxy }}"
           - name: no_proxy
-            value: "{{ .Values.env.no_proxy }}"
+            value: "{{ $.Values.env.no_proxy }}"
           - name: NO_PROXY
-            value: "{{ .Values.env.NO_PROXY }}"
-        image: {{ $.Values.DOCKER_REGISTRY }}{{ .Values.images.model_registry }}
+            value: "{{ $.Values.env.NO_PROXY }}"
+        image: {{ $.Values.DOCKER_REGISTRY }}{{ $.Values.images.model_registry }}
         volumeMounts:
           - name: src-dir
             mountPath: /src
@@ -94,7 +94,7 @@ spec:
         name: {{ $.Values.config.model_registry.name }}
         securityContext:
           readOnlyRootFilesystem: true
-          runAsUser: {{ .Values.env.MR_UID }}
+          runAsUser: {{ $.Values.env.MR_UID }}
         ports:
           - containerPort: 8111
             protocol: TCP


### PR DESCRIPTION
### Description
This pull request updates the Helm chart template for the `model-registry` service to improve consistency and ensure proper scoping of Helm template variables. It also includes structural changes to the container configuration, such as reordering and enhancing the `containers` section for improved clarity and functionality.

#### Helm template variable updates:
* Replaced `.Values` with `$.Values` throughout the file to ensure proper scoping of Helm variables, including `namespace`, `CA_CERT`, and other environment variables. [[1]](diffhunk://#diff-450e61a091782a265b5e6c253ace37c857a690614c58d25947c9bb8cbc72e496L7-R7) [[2]](diffhunk://#diff-450e61a091782a265b5e6c253ace37c857a690614c58d25947c9bb8cbc72e496L25-R25) [[3]](diffhunk://#diff-450e61a091782a265b5e6c253ace37c857a690614c58d25947c9bb8cbc72e496L42-R107)

#### Container configuration updates:
* Reorganized the `containers` section to improve readability and maintainability. Added explicit configuration for `volumeMounts`, `imagePullPolicy`, `securityContext`, and resource limits.
* Corrected the `runAsUser` value in the `securityContext` to use `$.Values.env.MR_UID` for consistent scoping.
* Updated all environment variable references to use `$.Values` for consistency and proper scoping.

### How Has This Been Tested?
To verify that the model-registry Helm chart deploys successfully, correctly applies all defined configurations (including environment variables, volume mounts, image pull policy, security context, and resource limits), and that the Helm template variable scoping changes (from .Values to $.Values) have not introduced any regressions.

#### Test Case: Chart Installation and Variable Resolution
* Verified that the `model-registry` Helm chart can be installed successfully with default and custom values, and that all `$.Values` references resolve correctly within the deployed Kubernetes resources.

1.  Edit the `values.yaml` in the Helm chart directory as mentioned in Step 5 of the [How to Deploy with Helm](https://docs.edgeplatform.intel.com/model-registry-as-a-service/1.0.3/user-guide/how-to-deploy-with-helm.html) document.

1.  Install the `model-registry` chart into your Kubernetes cluster.
    ```bash
    helm install mraas . -n apps --create-namespace
    ```

1.  Verify that the Pod is in the Running state.
    ```bash
    kubectl get pods -n apps
    ```

1.  Check the logs of the `model-registry` pod to ensure it started without errors and is performing its expected initializations.
    ```bash
    kubectl logs -f <model-registry-pod-name> -n apps
    ```

1.  After verification, uninstall the Helm chart to clean up resources.
    ```bash
    helm uninstall mraas -n apps
    ```


### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.