### PR TITLE
[DLStreamer] Use tensor wrappers in yolo converter.

### DIFF
--- a/libraries/dl-streamer/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
+++ b/libraries/dl-streamer/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
@@ -616,7 +616,7 @@ void Impl::preparePrimsForKeypoints(const GVA::Tensor &tensor, GVA::Rect<double>
         return;
 
     const auto keypoints_data = tensor.data<float>();
-    const auto confidence = tensor.get_float_vector("confidence");
+    const auto confidence = tensor.get_vector<float>("confidence");
 
     if (keypoints_data.empty())
         throw std::runtime_error("Keypoints array is empty.");


### PR DESCRIPTION
### Description

Use tensor wrapper class instead of direct manipulation of GstStructure metadata.

Fixes # (issue)

### Any Newly Introduced Dependencies

No new dependencies.

### How Has This Been Tested?

Validated with CI system.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

