### PR TITLE
Bump @babel/runtime from 7.25.7 to 7.27.6 in chatqna sample application

### DIFF
--- a/sample-applications/chat-question-and-answer-core/ui/package-lock.json
+++ b/sample-applications/chat-question-and-answer-core/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chatqna",
       "version": "0.0.0",
       "dependencies": {
+        "@babel/runtime": "^7.26.10",
         "@carbon/react": "^1.67.1",
         "@microsoft/fetch-event-source": "^2.0.1",
         "@reduxjs/toolkit": "^2.2.7",
@@ -316,12 +317,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4701,11 +4699,6 @@
       "peerDependencies": {
         "redux": "^5.0.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/reselect": {
       "version": "5.1.1",

--- a/sample-applications/chat-question-and-answer-core/ui/package.json
+++ b/sample-applications/chat-question-and-answer-core/ui/package.json
@@ -24,6 +24,7 @@
     "@carbon/react": "^1.67.1",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@reduxjs/toolkit": "^2.2.7",
+    "@babel/runtime": "^7.26.10",
     "axios": "^1.8.2",
     "date-fns": "^4.1.0",
     "i18next": "^24.0.2",

--- a/sample-applications/chat-question-and-answer/ui/react/package-lock.json
+++ b/sample-applications/chat-question-and-answer/ui/react/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chatqna",
       "version": "0.0.0",
       "dependencies": {
+        "@babel/runtime": "^7.26.10",
         "@carbon/react": "^1.67.1",
         "@microsoft/fetch-event-source": "^2.0.1",
         "@reduxjs/toolkit": "^2.2.7",
@@ -315,12 +316,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4894,11 +4892,6 @@
       "peerDependencies": {
         "redux": "^5.0.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/reselect": {
       "version": "5.1.1",

--- a/sample-applications/chat-question-and-answer/ui/react/package.json
+++ b/sample-applications/chat-question-and-answer/ui/react/package.json
@@ -24,6 +24,7 @@
     "@carbon/react": "^1.67.1",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@reduxjs/toolkit": "^2.2.7",
+    "@babel/runtime": "^7.26.10",
     "axios": "^1.8.2",
     "date-fns": "^4.1.0",
     "i18next": "^24.0.2",


### PR DESCRIPTION
### Description

Bump @babel/runtime from 7.25.7 to 7.27.6 to fix Dependabot alert

Fixes # (https://github.com/open-edge-platform/edge-ai-libraries/security/dependabot/9, https://github.com/open-edge-platform/edge-ai-libraries/security/dependabot/20)

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

