### PR TITLE
chat-question-and-answer: Fix duplicate container_name

### DIFF
--- a/sample-applications/chat-question-and-answer/docker-compose.yaml
+++ b/sample-applications/chat-question-and-answer/docker-compose.yaml
@@ -250,7 +250,7 @@ services:
 
   ovms-service-gpu:
     image: openvino/model_server:2025.0-gpu
-    container_name: ovms-service
+    container_name: ovms-service-gpu
     profiles:
       - GPU-OVMS
     environment:


### PR DESCRIPTION
### Description

Both services (ovms-service and ovms-service-gpu) are trying to use the same container name, which is not allowed in Docker Compose.
Container names must be unique within a Docker host.

Fixes # (NA)

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

Deploy the service with docker compose

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

