### PR TITLE
[DLStreamer] Add option to schedule incoming frames according to their presentation time

### DIFF
--- a/libraries/dl-streamer/docs/source/elements/gvaclassify.rst
+++ b/libraries/dl-streamer/docs/source/elements/gvaclassify.rst
@@ -101,6 +101,9 @@ input and outputs classification results with metadata.
     model-instance-id   : Identifier for sharing resources between inference elements of the same type. Elements with the instance-id will share model and other properties. If not specified, a unique identifier will be generated.
                           flags: readable, writable
                           String. Default: ""
+    scheduling-policy   : Scheduling policy across streams sharing same model instance: throughput (select first incoming frame), latency (select frames with earliest presentation time).
+                          flags: readable, writable
+                          String. Default: "throughput"
     model-proc          : Path to JSON file with description of input/output layers pre-processing/post-processing
                           flags: readable, writable
                           String. Default: ""

--- a/libraries/dl-streamer/docs/source/elements/gvadetect.rst
+++ b/libraries/dl-streamer/docs/source/elements/gvadetect.rst
@@ -101,6 +101,9 @@ ResNet), YOLOv5 - YOLO11, YOLOX and FasterRCNN-like object detection models.
     model-instance-id   : Identifier for sharing resources between inference elements of the same type. Elements with the instance-id will share model and other properties. If not specified, a unique identifier will be generated.
                           flags: readable, writable
                           String. Default: ""
+    scheduling-policy   : Scheduling policy across streams sharing same model instance: throughput (select first incoming frame), latency (select frames with earliest presentation time).
+                          flags: readable, writable
+                          String. Default: "throughput"
     model-proc          : Path to JSON file with description of input/output layers pre-processing/post-processing
                           flags: readable, writable
                           String. Default: ""

--- a/libraries/dl-streamer/docs/source/elements/gvainference.rst
+++ b/libraries/dl-streamer/docs/source/elements/gvainference.rst
@@ -100,6 +100,9 @@ Runs deep learning inference using any model with an RGB or BGR input.
     model-instance-id   : Identifier for sharing resources between inference elements of the same type. Elements with the instance-id will share model and other properties. If not specified, a unique identifier will be generated.
                           flags: readable, writable
                           String. Default: ""
+    scheduling-policy   : Scheduling policy across streams sharing same model instance: throughput (select first incoming frame), latency (select frames with earliest presentation time).
+                          flags: readable, writable
+                          String. Default: "throughput"
     model-proc          : Path to JSON file with description of input/output layers pre-processing/post-processing
                           flags: readable, writable
                           String. Default: ""

--- a/libraries/dl-streamer/src/monolithic/gst/inference_elements/base/gva_base_inference.cpp
+++ b/libraries/dl-streamer/src/monolithic/gst/inference_elements/base/gva_base_inference.cpp
@@ -21,6 +21,7 @@
 
 #define DEFAULT_MODEL nullptr
 #define DEFAULT_MODEL_INSTANCE_ID nullptr
+#define DEFAULT_SCHEDULING_POLICY "throughput"
 #define DEFAULT_MODEL_PROC nullptr
 #define DEFAULT_DEVICE "CPU"
 #define DEFAULT_PRE_PROC "" // empty = autoselection
@@ -88,6 +89,7 @@ enum {
     PROP_NO_BLOCK,
     PROP_NIREQ,
     PROP_MODEL_INSTANCE_ID,
+    PROP_SCHEDULING_POLICY,
     PROP_PRE_PROC_BACKEND,
     PROP_MODEL_PROC,
     PROP_CPU_THROUGHPUT_STREAMS,
@@ -194,6 +196,14 @@ void gva_base_inference_class_init(GvaBaseInferenceClass *klass) {
             "Identifier for sharing a loaded model instance between elements of the same type. Elements with the "
             "same model-instance-id will share all model and inference engine related properties",
             DEFAULT_MODEL_INSTANCE_ID, param_flags));
+
+    g_object_class_install_property(
+        gobject_class, PROP_SCHEDULING_POLICY,
+        g_param_spec_string(
+            "scheduling-policy", "Scheduling Policy",
+            "Scheduling policy across streams sharing same model instance: "
+            "throughput (select first incoming frame), latency (select frames with earliest presentation time)",
+            DEFAULT_SCHEDULING_POLICY, (GParamFlags)(param_flags)));
 
     g_object_class_install_property(
         gobject_class, PROP_PRE_PROC_BACKEND,
@@ -415,6 +425,7 @@ void gva_base_inference_init(GvaBaseInference *base_inference) {
     base_inference->no_block = DEFAULT_NO_BLOCK;
     base_inference->nireq = DEFAULT_NIREQ;
     base_inference->model_instance_id = g_strdup(DEFAULT_MODEL_INSTANCE_ID);
+    base_inference->scheduling_policy = g_strdup(DEFAULT_SCHEDULING_POLICY);
     base_inference->pre_proc_type = g_strdup(DEFAULT_PRE_PROC);
     // TODO: make one property for streams
     base_inference->cpu_streams = DEFAULT_CPU_THROUGHPUT_STREAMS;
@@ -550,6 +561,10 @@ void gva_base_inference_set_property(GObject *object, guint property_id, const G
     case PROP_MODEL_INSTANCE_ID:
         g_free(base_inference->model_instance_id);
         base_inference->model_instance_id = g_value_dup_string(value);
+        break;
+    case PROP_SCHEDULING_POLICY:
+        g_free(base_inference->scheduling_policy);
+        base_inference->scheduling_policy = g_value_dup_string(value);
         break;
     case PROP_PRE_PROC_BACKEND:
         g_free(base_inference->pre_proc_type);

--- a/libraries/dl-streamer/src/monolithic/gst/inference_elements/base/gva_base_inference.h
+++ b/libraries/dl-streamer/src/monolithic/gst/inference_elements/base/gva_base_inference.h
@@ -46,6 +46,7 @@ typedef struct _GvaBaseInference {
     gboolean no_block;
     guint nireq;
     gchar *model_instance_id;
+    gchar *scheduling_policy;
     guint cpu_streams;
     guint gpu_streams;
     gchar *ie_config;

--- a/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/async_with_va_api/image_inference_async/image_inference_async.cpp
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/async_with_va_api/image_inference_async/image_inference_async.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2024 Intel Corporation
+ * Copyright (C) 2018-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
@@ -169,6 +169,10 @@ void ImageInferenceAsync::SubmitImage(IFrameBase::Ptr frame,
 
 const std::string &ImageInferenceAsync::GetModelName() const {
     return _inference->GetModelName();
+}
+
+size_t ImageInferenceAsync::GetBatchSize() const {
+    return _inference->GetBatchSize();
 }
 
 size_t ImageInferenceAsync::GetNireq() const {

--- a/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/async_with_va_api/image_inference_async/image_inference_async.h
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/async_with_va_api/image_inference_async/image_inference_async.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2024 Intel Corporation
+ * Copyright (C) 2018-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
@@ -37,6 +37,7 @@ class ImageInferenceAsync : public ImageInference {
 
     const std::string &GetModelName() const override;
 
+    size_t GetBatchSize() const override;
     size_t GetNireq() const override;
 
     void GetModelImageInputInfo(size_t &width, size_t &height, size_t &batch_size, int &format,

--- a/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
@@ -1675,6 +1675,10 @@ const std::string &OpenVINOImageInference::GetModelName() const {
     return model_name;
 }
 
+size_t OpenVINOImageInference::GetBatchSize() const {
+    return safe_convert<size_t>(batch_size);
+}
+
 size_t OpenVINOImageInference::GetNireq() const {
     return safe_convert<size_t>(nireq);
 }

--- a/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.h
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018-2024 Intel Corporation
+ * Copyright (C) 2018-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
@@ -34,6 +34,7 @@ class OpenVINOImageInference : public InferenceBackend::ImageInference {
 
     const std::string &GetModelName() const override;
 
+    size_t GetBatchSize() const override;
     size_t GetNireq() const override;
 
     void GetModelImageInputInfo(size_t &width, size_t &height, size_t &batch_size, int &format,

--- a/libraries/dl-streamer/src/monolithic/inference_backend/include/inference_backend/image_inference.h
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/include/inference_backend/image_inference.h
@@ -60,6 +60,7 @@ class ImageInference {
                              const std::map<std::string, std::shared_ptr<InputLayerDesc>> &input_preprocessors) = 0;
 
     virtual const std::string &GetModelName() const = 0;
+    virtual size_t GetBatchSize() const = 0;
     virtual size_t GetNireq() const = 0;
     virtual void GetModelImageInputInfo(size_t &width, size_t &height, size_t &batch_size, int &format,
                                         int &memory_type) const = 0;


### PR DESCRIPTION
### Description

Add latency scheduling across multiple video streams that share common model instance. In this mode, frames are selected according to their presentation time. 

Fixes # (issue)

### Any Newly Introduced Dependencies

No new dependencies added. 

### How Has This Been Tested?

Verified with CI system (no regressions), new feature verified with manual tests. 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

