### PR TITLE
Revert "Bump protobuf from 4.24.4 to 4.25.8 in /microservices/time-se…

### DIFF
--- a/microservices/time-series-analytics/requirements.txt
+++ b/microservices/time-series-analytics/requirements.txt
@@ -1,6 +1,6 @@
 scikit-learn-intelex==2025.2.0
 scikit-learn==1.6.1
-protobuf==4.25.8
+protobuf==4.24.4
 modin==0.32.0
 tomlkit==0.13.2
 asyncua==1.1.5


### PR DESCRIPTION
…ries-analytics (#374)"




### Description

This reverts commit 1e41ac8f607707948ac8d7174fae34e61371fd82. 
Changes:
 requirements.txt- Reverted the change as kapacitor is not supporting
the protobuf 4.25 version. Point data ingestion is failing with latest version.

Fixes # (issue)

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

sanity test done

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

