### PR TITLE
[DLStreamer Pipeline Server] Bugfix: `appsink` based destinations were not being recognized

### DIFF
--- a/microservices/dlstreamer-pipeline-server/src/manager.py
+++ b/microservices/dlstreamer-pipeline-server/src/manager.py
@@ -15,7 +15,7 @@ import re
 from collections import defaultdict
 from distutils.util import strtobool
 from typing import Dict, Any, Tuple, List, Union, Optional
-# from src.server.gstreamer_app_source import GvaFrameData
+from src.server.gstreamer_app_destination import GStreamerAppDestination    # required to include in AppDestination subclass list
 from src.server.pipeline_server import PipelineServer
 from src.server.pipeline import Pipeline as PipelineServer_Pipeline # avoid shadowing
 


### PR DESCRIPTION
### Description

Fixed an issue where  destination was not being recognized in pipeline server.
The class `GStreamerAppDestination` needs to be loaded in `manager.py` (although unused) before any appsink as destination  based pipeline is launched.


Fixes # (ITEP-70672)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

- appsink as destination based tests with MQTT, S3 write

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

