### PR TITLE
[DLStreamer Pipeline Server] revert changes to support both appsrc and appsink destinations during pipeline launch

### DIFF
--- a/microservices/dlstreamer-pipeline-server/src/manager.py
+++ b/microservices/dlstreamer-pipeline-server/src/manager.py
@@ -15,7 +15,7 @@ import re
 from collections import defaultdict
 from distutils.util import strtobool
 from typing import Dict, Any, Tuple, List, Union, Optional
-from src.server.gstreamer_app_destination import GStreamerAppDestination    # required to include in AppDestination subclass list
+from src.server.gstreamer_app_source import GvaFrameData    # required to load AppDestination and AppSource subclasses
 from src.server.pipeline_server import PipelineServer
 from src.server.pipeline import Pipeline as PipelineServer_Pipeline # avoid shadowing
 


### PR DESCRIPTION
### Description

Reverted a change that was commented earlier and was causing error due to incomplete subclass list during request check.

Fixes # (ITEP-70672)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

image ingestor, S3, MQTT based request

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

