### PR TITLE
[DLStreamer] Updated samples to support new INT8 models

### DIFF
--- a/libraries/dl-streamer/docs/source/get_started/install/install_guide_ubuntu.rst
+++ b/libraries/dl-streamer/docs/source/get_started/install/install_guide_ubuntu.rst
@@ -155,6 +155,9 @@ The hello_dlstreamer.sh script assumes the availability of the YOLO11s model. If
 .. note::
 
    The **download_public_models.sh** script will download the YOLO11s model from the Ultralytics website along with other required components and convert it to the OpenVINO™ format.
+
+   If you add the **coco128** argument to the script, the downloaded model will also be quantized to the INT8 precision.
+
    If you already have the model, skip this step and simply export the MODELS_PATH and execute the **hello_dlstreamer.sh** script.
 
 
@@ -162,7 +165,7 @@ The hello_dlstreamer.sh script assumes the availability of the YOLO11s model. If
 
    mkdir -p /home/${USER}/models
    export MODELS_PATH=/home/${USER}/models
-   /opt/intel/dlstreamer/samples/download_public_models.sh yolo11s
+   /opt/intel/dlstreamer/samples/download_public_models.sh yolo11s coco128
 
 
 The **hello_dlstreamer.sh** will set up the required environment variables and runs a sample pipeline to confirm that Intel® DL Streamer is installed correctly.

--- a/libraries/dl-streamer/samples/gstreamer/gst_launch/detection_with_yolo/README.md
+++ b/libraries/dl-streamer/samples/gstreamer/gst_launch/detection_with_yolo/README.md
@@ -50,7 +50,7 @@ The samples demonstrate deployment and inference with GStreamer command line too
 The sample `yolo_detect.sh` script can be used to build and run an object detection pipeline.
 
 ```sh
-./yolo_detect.sh <MODEL> <DEVICE> <INPUT> <OUTPUT_TYPE>
+./yolo_detect.sh <MODEL> <DEVICE> <INPUT> <OUTPUT_TYPE> <PRECISION>
 ```
 > **NOTE**: Prior to running `yolo_detect.sh`, ensure that you execute the `download_public_models.sh` script found in the top-level `samples` directory. This will allow you to download the full suite of YOLO models or select an individual model from the options presented above.
 

--- a/libraries/dl-streamer/scripts/hello_dlstreamer.sh
+++ b/libraries/dl-streamer/scripts/hello_dlstreamer.sh
@@ -15,14 +15,16 @@ This script provides a simple way to construct and execute
 a sample DL Streamer detection pipeline with YOLO model.
 
 Options:
-  -h, --help                  Show this help message and exit
-  -m=MODEL, --model=MODEL     YOLO model name to be used for detection (default: yolo11s)
-                              Available models: yolov5s | yolov8s | yolo11s
-  -o=OUTPUT, --output=OUTPUT  Type of output from a pipeline (default: display)
-                              Available types: display | file
-  -d=DEVICE, --device=DEVICE  Device to perform detection operations on (default: CPU)
-                              Available devices: CPU | GPU | NPU
-                              Note: GPU and NPU devices require drivers (DLS_install_prerequisites.sh)
+  -h, --help                            Show this help message and exit
+  -m=MODEL, --model=MODEL               YOLO model name to be used for detection (default: yolo11s)
+                                        Available models: yolov5su | yolov8s | yolo11s
+  -p=PRECISION, --precision=PRECISION   Selected precision of the model (default: INT8)
+                                        Available types: INT8 | FP32 | FP16
+  -o=OUTPUT, --output=OUTPUT            Type of output from a pipeline (default: display)
+                                        Available types: display | file
+  -d=DEVICE, --device=DEVICE            Device to perform detection operations on (default: GPU)
+                                        Available devices: CPU | GPU | NPU
+                                        Note: GPU and NPU devices require drivers (DLS_install_prerequisites.sh)
 
 Examples:
   $(basename "$0")
@@ -35,8 +37,9 @@ EOF
 
 # Parse options
 MODEL="yolo11s"
+PRECISION="INT8"
 OUTPUT="display"
-DEVICE="CPU"
+DEVICE="GPU"
 for arg in "$@"; do
     case $arg in
         -h|--help)
@@ -45,8 +48,15 @@ for arg in "$@"; do
             ;;
         -m=*|--model=*)
             MODEL="${arg#*=}"
-            if [[ "$MODEL" != "yolov5s" ]] && [[ "$MODEL" != "yolov8s" ]] && [[ "$MODEL" != "yolo11s" ]]; then
-                echo "Error! Wrong MODEL parameter. Supported models: yolov5s | yolov8s | yolo11s"
+            if [[ "$MODEL" != "yolov5su" ]] && [[ "$MODEL" != "yolov8s" ]] && [[ "$MODEL" != "yolo11s" ]]; then
+                echo "Error! Wrong MODEL parameter. Supported models: yolov5su | yolov8s | yolo11s"
+                exit 1
+            fi
+        ;;
+        -p=*|--precision=*)
+            PRECISION="${arg#*=}"
+            if [[ "$PRECISION" != "INT8" ]] && [[ "$PRECISION" != "FP32" ]] && [[ "$PRECISION" != "FP16" ]]; then
+                echo "Error! Wrong PRECISION parameter. Supported types: INT8 | FP32 | FP16"
                 exit 1
             fi
         ;;
@@ -71,6 +81,12 @@ for arg in "$@"; do
         ;;
     esac
 done
+
+GPUS=$(find /dev/dri/ -name "render*")
+if [ -z $GPUS ]; then
+    echo "WARN: No GPU detected, switching to CPU"
+    DEVICE=CPU
+fi
 
 # shellcheck source=/dev/null
 . /etc/os-release
@@ -111,11 +127,17 @@ else
 fi
 
 # check if the model exists
-if [ -d "$MODELS_PATH"/public/"$MODEL"/FP32 ]; then
+if [ -d "$MODELS_PATH"/public/"$MODEL"/$PRECISION ]; then
 	echo "$MODEL model exists."
 else
 	echo "Model $MODEL which you want to use cannot be found at $MODELS_PATH!"
-	echo "Please run the script \`/opt/intel/dlstreamer/samples/download_public_models.sh $MODEL\` to download the model."
+
+    if [[ $PRECISION == "INT8" ]]; then
+	    echo "Please run the script \`/opt/intel/dlstreamer/samples/download_public_models.sh $MODEL coco128\` to download the model."
+    else
+	    echo "Please run the script \`/opt/intel/dlstreamer/samples/download_public_models.sh $MODEL\` to download the model."
+    fi
+
 	echo "If the model has already been downloaded, specify the path to its location (for instance: export MODELS_PATH=/home/user/you_path)."
 	exit 1
 fi
@@ -128,4 +150,4 @@ export GST_PLUGIN_FEATURE_RANK=${GST_PLUGIN_FEATURE_RANK},ximagesink:MAX
 
 # print pipeline and run it
 execute() { echo "$*"$'\n' ; "$@" ; }
-execute /opt/intel/dlstreamer/samples/gstreamer/gst_launch/detection_with_yolo/yolo_detect.sh $MODEL "$DEVICE" '' "$OUTPUT"
+execute /opt/intel/dlstreamer/samples/gstreamer/gst_launch/detection_with_yolo/yolo_detect.sh $MODEL "$DEVICE" '' "$OUTPUT" '' "$PRECISION"


### PR DESCRIPTION
### Description

Updated `yolo_detect.sh` and `hello_dlstreamer.sh` to support a new parameter which allows the use to specify the precision of the model they would like to use. Set the default precision to INT8 and default device used to GPU. Implemented a check which will fall back to CPU should a GPU not be available.

### How Has This Been Tested?

Changes manually ran to validate their functionality. Test harness with ground truths has been ran on the `yolo_detect.sh` script to ensure no regression has happened.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

