### PR TITLE
[DOCS] unifying CODEOWNERS for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-README.md @xwu2intel
+README.md @xwu2intel @open-edge-platform/open-edge-platform-docs-write
 LICENSE @xwu2intel
 CONTRIBUTING.md @xwu2intel
 CODE_OF_CONDUCT.md @xwu2intel
@@ -23,9 +23,8 @@ SECURITY.md @xwu2intel
 # documentation content
 /libraries/dl-streamer/docs @open-edge-platform/open-edge-platform-docs-write
 /libraries/dl-streamer/README.md @open-edge-platform/open-edge-platform-docs-write
-/libraries/dl-streamer/*.md @open-edge-platform/open-edge-platform-docs-write
 /microservices/**/docs @open-edge-platform/open-edge-platform-docs-write
 /microservices/**/README.md @open-edge-platform/open-edge-platform-docs-write
 /sample-applications/**/docs @open-edge-platform/open-edge-platform-docs-write
 /sample-applications/**/README.md @open-edge-platform/open-edge-platform-docs-write
-README.md @open-edge-platform/open-edge-platform-docs-write
+


### PR DESCRIPTION
### Description

Adjusting CODEOWNERS for easier documentation adjustments and group management (one documentation group across the organization).

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

