### PR TITLE
[DLStreamer-Pipeline-Server]Sanity tests for DLSPS

### DIFF
--- a/microservices/dlstreamer-pipeline-server/tests/scripts/common_library/dlsps_utils.py
+++ b/microservices/dlstreamer-pipeline-server/tests/scripts/common_library/dlsps_utils.py
@@ -1,0 +1,184 @@
+import os, sys, time, json, yaml, subprocess, os.path, requests
+from collections import OrderedDict
+
+current_dir = os.path.abspath(os.path.dirname(__file__))
+repo_path = os.path.abspath(os.path.join(os.getcwd(), "../../../"))
+
+sys.path.extend([
+    os.path.abspath(current_dir),
+    os.path.abspath(os.path.join(current_dir, '../configs'))
+])
+
+hostIP = subprocess.check_output("ip route get 1 | awk '{print $7}'|head -1", shell=True).decode('utf-8').strip()
+
+base_source_uri = {"uri": "file:///home/pipeline-server/resources/videos/warehouse.avi", "type": "uri"}
+base_detection_properties = {"model": "/home/pipeline-server/resources/models/geti/pallet_defect_detection/deployment/Detection/model/model.xml", "device": "CPU"}
+base_rtsp_frame = {"type": "rtsp", "path": "pallet_defect_detection"}
+
+def create_pipeline_config(source, destination_frame, detection_properties=None):
+    return {
+        "source": source,
+        "destination": {"frame": destination_frame},
+        **({"parameters": {"detection-properties": detection_properties}} if detection_properties else {})
+    }
+
+dlsps_data_gvadetect_rtsp = create_pipeline_config(
+    source={"uri": f"rtsp://{hostIP}:8555/live.sdp", "type": "uri"},
+    destination_frame=base_rtsp_frame,
+    detection_properties=base_detection_properties
+)
+dlsps_data_gvadetect = create_pipeline_config(
+    source=base_source_uri,
+    destination_frame=base_rtsp_frame,
+    detection_properties=base_detection_properties
+)
+
+eii_utils = {
+    'genops': {'log_param': {'dlstreamer-pipeline-server': "dlsps_log_param"}},
+}
+
+class dlsps_utils():
+    def __init__(self):
+        self.repo_path = repo_path
+        self.eii_utils_genops = eii_utils['genops']
+        self.dlsps_path = f"{repo_path}/docker"
+        self.dlsps_config = f"{repo_path}/configs/default/config.json"
+        print(f"dlsps_path: {self.dlsps_path}")
+        print(f"dlsps_config: {self.dlsps_config}")
+
+
+    def json_reader(self, tc, JSON_PATH):
+        print('\n********** Reading json **********')
+        with open(JSON_PATH, "r") as jsonFile:
+            json_config = json.load(jsonFile)
+        for key, value in json_config.items():
+            if key == tc:
+                print("**********Test Case : ", key, "**********","\n**********Value : ", value, "**********")
+                return key, value
+
+
+    def change_docker_compose_for_standalone(self):
+        print('\n********** Updating docker-compose.yml **********')
+        os.chdir(self.dlsps_path)
+        self.set_env({'RTSP_CAMERA_IP': hostIP})
+        with open("docker-compose.yml", 'r') as file:
+            data = yaml.safe_load(file)
+        service = data.get('services', {}).get('dlstreamer-pipeline-server', {})
+        volumes = service.get('volumes', [])
+        config_path = "../configs/default/config.json"
+        if os.path.exists(os.path.abspath(config_path)):
+            volumes.append(f"{os.path.abspath(config_path)}:/home/pipeline-server/config.json")
+        else:
+            print(f"Warning: The directory {config_path} does not exist.")
+        service['volumes'] = volumes
+        with open("docker-compose.yml", 'w') as file:
+            yaml.safe_dump(data, file)
+
+
+    def _execute_cmd(self, cmd):
+        return subprocess.check_output(cmd, shell=True, executable='/bin/bash')
+
+
+    def set_env(self, configdict):
+        os.chdir('{}'.format(self.dlsps_path))
+        for key, value in configdict.items():
+            self._execute_cmd("sed -i 's#{Key}=.*#{Key}={Value}#g' .env".format(Key=key, Value=value))
+
+
+    def common_service_steps_dlsps(self):
+        print('********** Building and running dlsps **********')
+        os.chdir(self.dlsps_path)
+        self._execute_cmd('docker compose build')
+        self._execute_cmd('docker compose up -d')
+
+
+    def change_config_for_dlsps_standalone(self, value):
+        print('********** Changing config.json **********')
+        with open(self.dlsps_config, "r") as jsonFile:
+            data = json.load(jsonFile, object_pairs_hook=OrderedDict)
+            config_path = "config"
+            if config_path in data:
+                pipeline_config = data[config_path]["pipelines"][0]
+                pipeline_config["source"] = value["source_conifg"]
+                if value.get("type_r")=="autosource":
+                    pipeline_config["pipeline"] = "{auto_source} name=source  ! decodebin ! videoconvert ! gvadetect name=detection model-instance-id=inst0 ! queue ! gvawatermark ! gvafpscounter ! gvametaconvert add-empty-results=true name=metaconvert ! gvametapublish name=destination ! appsink name=appsink"
+                elif value.get("type_r")=="autosource_destination":
+                    pipeline_config["pipeline"] = "{auto_source} name=source  ! decodebin ! videoconvert ! gvadetect name=detection model-instance-id=inst0 ! queue ! gvawatermark ! gvafpscounter ! gvametaconvert add-empty-results=true name=metaconvert ! appsink name=destination"            
+            with open(self.dlsps_config, "w") as jsonFile:
+                json.dump(data, jsonFile, indent=4)
+
+
+    def execute_curl_command(self, value):
+        try:
+            instance_map = {
+                "auto_source_gvadetect": dlsps_data_gvadetect,
+                "auto_source_gvadetect_rtsp": dlsps_data_gvadetect_rtsp,
+            }
+            data = instance_map.get(value.get("instance"), dlsps_data_gvadetect)
+            url = "http://localhost:8080/pipelines/user_defined_pipelines/pallet_defect_detection"
+            dlsps_headers = {'Content-Type': 'application/json'}
+            print(f"Sending POST request to {url} with data: {json.dumps(data, indent=4)}")
+            time.sleep(3)
+            response = requests.post(url, headers=dlsps_headers, data=json.dumps(data))
+            response.raise_for_status()
+            pipeline_id = response.text[1:33]
+            print(f"Pipeline started with ID: {pipeline_id}")
+            status_url = "http://localhost:8080/pipelines/status"
+            time.sleep(3)
+            status_response = requests.get(status_url)
+            status_response.raise_for_status()
+            status_data = status_response.json()
+
+            for status in status_data:
+                if status.get("id") == pipeline_id:
+                    pipeline_state = status.get("state")
+                    print(f"Pipeline {pipeline_id} state: {pipeline_state}")
+                    if pipeline_state in ["RUNNING", "COMPLETED"]:
+                        print("Pipeline is running or completed successfully.")
+                        return
+                    else:
+                        raise Exception(f"Pipeline {pipeline_id} is in unexpected state: {pipeline_state}")
+                else:
+                    raise Exception(f"Pipeline {pipeline_id} not found in status response.")
+            raise Exception(f"Pipeline {pipeline_id} did not reach a running or completed state within the timeout.")
+        except Exception as err:
+            print(f"An error occurred: {err}")
+            raise
+
+
+    def container_logs_checker_dlsps(self, item, tc, value):
+        print('********** Checking container logs **********')
+        time.sleep(3)
+        containers = value.get("check_logs", "").split()
+        log_present = {}
+        for container in containers:
+            log_file = f"logs_{container}_{tc}.txt"
+            print(f"================== {container} ==================")
+            self._execute_cmd(f"docker compose logs --tail=1000 {container} | tee {log_file}")
+            keywords = value.get(self.eii_utils_genops['log_param'].get(container, ""), [])
+            log_present[container] = all(self.search_element(log_file, keyword) for keyword in keywords)
+            if not log_present[container]:
+                print(f"FAIL: Keywords not found in logs for container {container}")
+                return False
+        if log_present.get("dlstreamer-pipeline-server"):
+            print("PASS: All keywords found in logs.")
+            return True
+        print("FAIL: Keywords not found in logs.")
+        return False
+
+
+    def search_element(self, logFile, keyword):
+        keyword_found = False
+        keywords_file = os.path.abspath(logFile)
+        with open(keywords_file, 'rb') as file:
+            for curr_line in file:
+                each_line = curr_line.decode()
+                print(each_line)
+                if keyword in each_line:
+                    keyword_found = True
+        if keyword_found:
+            print("PASS: Keyword Found", keyword)
+            return True
+        else:
+            print("FAIL:Keyword NOT Found", keyword)
+            return False

--- a/microservices/dlstreamer-pipeline-server/tests/scripts/configs/dlsps_config.json
+++ b/microservices/dlstreamer-pipeline-server/tests/scripts/configs/dlsps_config.json
@@ -1,0 +1,26 @@
+{
+    "dlsps001": {
+       "level":"standalone",
+       "source_conifg": "gstreamer",
+       "type_r": "autosource",
+       "instance": "auto_source_gvadetect",
+       "check_logs" : "dlstreamer-pipeline-server",
+       "dlsps_log_param" : ["bounding_box","detection","confidence"]
+    },
+    "dlsps002": {
+       "level":"standalone",
+       "type_r": "autosource",
+       "instance": "auto_source_gvadetect_rtsp",
+       "source_conifg": "gstreamer",
+       "check_logs" : "dlstreamer-pipeline-server",
+       "dlsps_log_param" : ["bounding_box","detection","confidence"]
+    },
+    "dlsps003": {
+       "level":"standalone",
+       "type_r": "autosource_destination",
+       "instance": "auto_source_gvadetect",
+       "source_conifg": "gstreamer",
+       "check_logs" : "dlstreamer-pipeline-server",
+       "dlsps_log_param" : ["number-streams=1","fps"]
+    }
+ }

--- a/microservices/dlstreamer-pipeline-server/tests/scripts/functional_tests/__init__.py
+++ b/microservices/dlstreamer-pipeline-server/tests/scripts/functional_tests/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import os
+import sys
+
+current_dir = os.path.abspath(os.path.dirname(__file__))
+parent_dir = os.path.abspath(current_dir+'../../../../')
+sys.path.append(parent_dir)
+common_library_dir = os.path.abspath(os.path.join(current_dir, '../common_library'))
+sys.path.append(common_library_dir)

--- a/microservices/dlstreamer-pipeline-server/tests/scripts/functional_tests/dlsps.py
+++ b/microservices/dlstreamer-pipeline-server/tests/scripts/functional_tests/dlsps.py
@@ -1,0 +1,35 @@
+import json
+import os
+import time
+import unittest
+import dlsps_utils as dlsps_module 
+from configs import *
+
+JSONPATH = os.path.dirname(os.path.abspath(__file__)) + '/../configs/dlsps_config.json'
+
+
+class test_dlsps_cases(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.path = os.path.dirname(os.path.abspath(__file__))
+        cls.dlsps_utils = dlsps_module.dlsps_utils()
+
+    def test_dlsps(self):
+        test_case = os.environ['TEST_CASE']
+        key, value = self.dlsps_utils.json_reader(test_case, JSONPATH)
+        self.dlsps_utils.change_docker_compose_for_standalone()
+        self.dlsps_utils.change_config_for_dlsps_standalone(value)
+        self.dlsps_utils.common_service_steps_dlsps()
+        self.dlsps_utils.execute_curl_command(value)
+        time.sleep(5)
+        self.assertTrue(self.dlsps_utils.container_logs_checker_dlsps("dlsps",test_case,value))
+
+        
+    @classmethod
+    def tearDownClass(self):
+        os.chdir('{}'.format(self.dlsps_utils.dlsps_path))
+        self.dlsps_utils._execute_cmd("docker compose down -v")
+        self.dlsps_utils._execute_cmd("git checkout docker-compose.yml")
+        os.chdir('{}'.format(self.dlsps_utils.dlsps_path + "/../configs/default"))
+        self.dlsps_utils._execute_cmd("git checkout config.json")
+        time.sleep(5)

--- a/microservices/dlstreamer-pipeline-server/tests/scripts/robot_files/test_main_sanity.robot
+++ b/microservices/dlstreamer-pipeline-server/tests/scripts/robot_files/test_main_sanity.robot
@@ -1,0 +1,48 @@
+***Settings***
+Documentation    This is main test case file.
+Library          test_suit_dlsps_cases.py
+
+
+
+***Keywords***
+
+dlsps_Test_case_001
+    [Documentation]     Verify gvadetect element for pallet defect detection model - default pipeline - gvametapublish destination - backend -CPU
+    ${status}          TC_001_dlsps
+    Should Not Be Equal As Integers    ${status}    1
+    RETURN         Run Keyword And Return Status    ${status}
+
+dlsps_Test_case_002
+    [Documentation]     Verify gvadetect element for pallet defect detection model - default pipeline for RTSP Camera - appsink destination backend - CPU
+    ${status}          TC_002_dlsps
+    Should Not Be Equal As Integers    ${status}    1
+    RETURN         Run Keyword And Return Status    ${status}
+
+dlsps_Test_case_003
+    [Documentation]     Verify gvadetect element for pallet defect detection model - default pipeline - appsink destination backend - CPU
+    ${status}          TC_003_dlsps
+    Should Not Be Equal As Integers    ${status}    1
+    RETURN         Run Keyword And Return Status    ${status}
+
+
+***Test Cases***
+
+#ALL the test cases related to dlsps usecase
+
+dlsps_TC_001
+    [Documentation]     Verify gvadetect element for pallet defect detection model - default pipeline - gvametapublish destination - backend -CPU
+    [Tags]      dlsps
+    ${Status}    Run Keyword And Return Status   dlsps_Test_case_001
+    Should Not Be Equal As Integers    ${Status}    0
+
+dlsps_TC_002
+    [Documentation]     Verify gvadetect element for pallet defect detection model - default pipeline for RTSP Camera - appsink destination backend - CPU
+    [Tags]      dlsps
+    ${Status}    Run Keyword And Return Status   dlsps_Test_case_002
+    Should Not Be Equal As Integers    ${Status}    0
+
+dlsps_TC_003
+    [Documentation]     Verify gvadetect element for pallet defect detection model - default pipeline - appsink destination backend - CPU
+    [Tags]      dlsps
+    ${Status}    Run Keyword And Return Status   dlsps_Test_case_003
+    Should Not Be Equal As Integers    ${Status}    0

--- a/microservices/dlstreamer-pipeline-server/tests/scripts/robot_files/test_suit_dlsps_cases.py
+++ b/microservices/dlstreamer-pipeline-server/tests/scripts/robot_files/test_suit_dlsps_cases.py
@@ -1,0 +1,26 @@
+import unittest
+import subprocess
+import os
+env = os.environ.copy()
+
+
+class test_suit_dlsps_cases(unittest.TestCase):
+   
+    def TC_001_dlsps(self):
+        env["TEST_CASE"] = "dlsps001"
+        ret = subprocess.call("nosetests3 --nocapture -v ../functional_tests/dlsps.py:test_dlsps_cases.test_dlsps", shell=True, env=env)
+        return ret
+      
+    def TC_002_dlsps(self):
+        env["TEST_CASE"] = "dlsps002"
+        ret = subprocess.call("nosetests3 --nocapture -v ../functional_tests/dlsps.py:test_dlsps_cases.test_dlsps", shell=True, env=env)
+        return ret
+    
+    def TC_003_dlsps(self):
+        env["TEST_CASE"] = "dlsps003"
+        ret = subprocess.call("nosetests3 --nocapture -v ../functional_tests/dlsps.py:test_dlsps_cases.test_dlsps", shell=True, env=env)
+        return ret
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/microservices/dlstreamer-pipeline-server/tests/scripts/utils/stream_rtsp.sh
+++ b/microservices/dlstreamer-pipeline-server/tests/scripts/utils/stream_rtsp.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+ACTION=$1  # "start" or "stop"
+NUM_INSTANCES=$2
+INPUT_VIDEO=$3
+SYSTEM_IP=$4
+BASE_PORT=8555
+
+if [ "$ACTION" == "start" ]; then
+  # Loop to start multiple cvlc instances
+  for ((i=0; i<NUM_INSTANCES; i++))
+  do
+    PORT=$((BASE_PORT + i))
+    echo "Starting RTSP server on port $PORT"
+    nohup cvlc -vvv file://$INPUT_VIDEO --sout "#gather:rtp{sdp=rtsp://$SYSTEM_IP:$PORT/live.sdp}" --loop --sout-keep > cvlc_$PORT.log 2>&1 &
+    echo $! >> vlc_pids.txt  # Store process IDs
+  done
+  echo "All cvlc instances started in the background."
+
+elif [ "$ACTION" == "stop" ]; then
+  echo "Stopping all cvlc instances..."
+  if [ -f vlc_pids.txt ]; then
+    while read -r pid; do
+      kill "$pid"
+    done < vlc_pids.txt
+    rm vlc_pids.txt
+    echo "All cvlc instances stopped."
+  else
+    echo "No vlc_pids.txt file found. Killing all cvlc processes."
+    pkill -f cvlc
+  fi
+else
+  echo "Usage: $0 {start|stop} [NUM_INSTANCES] [INPUT_VIDEO] [SYSTEM_IP]"
+fi


### PR DESCRIPTION
### Description

Added sanity tests for DLStreamer-Pipeline-Server
1. Verify gvadetect element for pallet defect detection model - default pipeline - gvametapublish destination - backend -CPU
2. Verify gvadetect element for pallet defect detection model - default pipeline for RTSP Camera - appsink destination backend - CPU
3. Verify gvadetect element for pallet defect detection model - default pipeline - appsink destination backend - CPU


### How Has This Been Tested?
1.  cd edge-ai-libraries/microservices/dlstreamer-pipeline-server/tests/scripts/utils
2. Start the rtsp servers
./stream_rtsp.sh start <no_of_streams> <path_to_video> <system_ip>
3. cd edge-ai-libraries/microservices/dlstreamer-pipeline-server/tests/scripts/robot_files
4.  robot test_main_sanity.robot

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

