### PR TITLE
Deployment package and helm charts for EMF 3.1

### DIFF
--- a/sample-applications/chat-question-and-answer/chart/Chart.yaml
+++ b/sample-applications/chat-question-and-answer/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chat-question-and-answer
 description: A helm chart for deploying Intel ChatQnA sample application
-version: 1.2.0
+version: 1.2.1
 dependencies:
   - name: vllmService
     version: 0.1.0

--- a/sample-applications/chat-question-and-answer/chart/templates/egaisample-deployment.yaml
+++ b/sample-applications/chat-question-and-answer/chart/templates/egaisample-deployment.yaml
@@ -91,11 +91,14 @@ spec:
               value: "{{ .Values.Chatqna.env.SEED }}"
           securityContext:
             allowPrivilegeEscalation: false
+          {{- if .Values.global.OTLP_ENDPOINT }}
           volumeMounts:
             - name: ca-certificates
               mountPath: /usr/local/share/ca-certificates
             - name: ssl-certs
               mountPath: /etc/ssl/certs
+          {{ end}}
+      {{- if .Values.global.OTLP_ENDPOINT }}
       volumes:
         - name: ca-certificates
           hostPath:
@@ -105,3 +108,4 @@ spec:
           hostPath:
             path: /etc/ssl/certs
             type: Directory
+      {{ end}}

--- a/sample-applications/chat-question-and-answer/chart/templates/nginx-deployment.yaml
+++ b/sample-applications/chat-question-and-answer/chart/templates/nginx-deployment.yaml
@@ -99,6 +99,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "nginx.fullname" . }}
+  {{- if .Values.nginxService.annotations }}
+  annotations: {{ toYaml .Values.nginxService.annotations | nindent 4 }}
+  {{- end }}  
 spec:
   ports:
   - port: 80

--- a/sample-applications/chat-question-and-answer/chart/values.yaml
+++ b/sample-applications/chat-question-and-answer/chart/values.yaml
@@ -93,3 +93,6 @@ chatqnaui:
   nameOverride: "ui"
   service:
     port: 80
+
+nginxService:
+  annotations: {}

--- a/sample-applications/chat-question-and-answer/deployment-package/application.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/application.yaml
@@ -80,7 +80,6 @@ profiles:
         displayName: "OTLP Endpoint Trace"
         type: string
         default: ""
-# TODO: Disabled for now due to bug in EMF where "false" is recognized as a string instead of a boolean.
       - name: global.ovmsEmbeddinggpuService.enabled
         displayName: "OVMS Embedding GPU Service"
         type: boolean

--- a/sample-applications/chat-question-and-answer/deployment-package/application.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/application.yaml
@@ -8,8 +8,6 @@ $schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
 name: chatqna-app
 version: 1.2.1
 description: "Chat Q&A Sample Application"
-#helmRegistry: "harbor-helm-oci"
-#chartName: "chat-question-and-answer"
 helmRegistry: "docker-hub"
 chartName: "intel/chat-question-and-answer"
 
@@ -83,24 +81,24 @@ profiles:
         type: string
         default: ""
 # TODO: Disabled for now due to bug in EMF where "false" is recognized as a string instead of a boolean.
-#      - name: global.ovmsEmbeddinggpuService.enabled
-#        displayName: "OVMS Embedding GPU Service"
-#        type: boolean
-#        suggestedValues: ["false", "true"]
-#        mandatory: true
-#      - name: global.gpu.enabled
-#        displayName: Enable GPU Device
-#        type: boolean
-#        suggestedValues: ["false", "true"]
-#        mandatory: true
-#      - name: global.gpu.key
-#        displayName: GPU Node Label Key
-#        type: string
-#        default: ""
-#      - name: global.gpu.device
-#        displayName: GPU Device
-#        type: string
-#        default: ""
+      - name: global.ovmsEmbeddinggpuService.enabled
+        displayName: "OVMS Embedding GPU Service"
+        type: boolean
+        suggestedValues: ["false", "true"]
+        mandatory: true
+      - name: global.gpu.enabled
+        displayName: Enable GPU Device
+        type: boolean
+        suggestedValues: ["false", "true"]
+        mandatory: true
+      - name: global.gpu.key
+        displayName: GPU Node Label Key
+        type: string
+        default: ""
+      - name: global.gpu.device
+        displayName: GPU Device
+        type: string
+        default: ""
   - name: "vllm"
     valuesFileName: "chatqna-values-vllm.yaml"
     parameterTemplates:

--- a/sample-applications/chat-question-and-answer/deployment-package/application.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/application.yaml
@@ -6,12 +6,14 @@ schemaVersion: "0.1"
 $schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
 
 name: chatqna-app
-version: 1.1.2
+version: 1.2.1
 description: "Chat Q&A Sample Application"
-
+#helmRegistry: "harbor-helm-oci"
+#chartName: "chat-question-and-answer"
 helmRegistry: "docker-hub"
 chartName: "intel/chat-question-and-answer"
-chartVersion: "1.1.2"
+
+chartVersion: "1.2.1"
 defaultProfile: "ovms"
 
 profiles:
@@ -80,24 +82,25 @@ profiles:
         displayName: "OTLP Endpoint Trace"
         type: string
         default: ""
-      - name: global.ovmsEmbeddinggpuService.enabled
-        displayName: "OVMS Embedding GPU Service"
-        type: boolean
-        suggestedValues: ["false", "true"]
-        mandatory: true
-      - name: global.gpu.enabled
-        displayName: Enable GPU Device
-        type: boolean
-        suggestedValues: ["false", "true"]
-        mandatory: true
-      - name: global.gpu.key
-        displayName: GPU Node Label Key
-        type: string
-        default: ""
-      - name: global.gpu.device
-        displayName: GPU Device
-        type: string
-        default: ""
+# TODO: Disabled for now due to bug in EMF where "false" is recognized as a string instead of a boolean.
+#      - name: global.ovmsEmbeddinggpuService.enabled
+#        displayName: "OVMS Embedding GPU Service"
+#        type: boolean
+#        suggestedValues: ["false", "true"]
+#        mandatory: true
+#      - name: global.gpu.enabled
+#        displayName: Enable GPU Device
+#        type: boolean
+#        suggestedValues: ["false", "true"]
+#        mandatory: true
+#      - name: global.gpu.key
+#        displayName: GPU Node Label Key
+#        type: string
+#        default: ""
+#      - name: global.gpu.device
+#        displayName: GPU Device
+#        type: string
+#        default: ""
   - name: "vllm"
     valuesFileName: "chatqna-values-vllm.yaml"
     parameterTemplates:

--- a/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-ovms.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-ovms.yaml
@@ -43,7 +43,7 @@ Chatqna:
   name: chatqna-backend
   image:
     repository: intel/chatqna
-    tag: "1.1.2"
+    tag: "1.2.1"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-ovms.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-ovms.yaml
@@ -16,8 +16,8 @@ global:
   LLM_MODEL: <LLM_MODEL>
   EMBEDDING_MODEL_NAME: <EMBEDDING_MODEL_NAME>
   RERANKER_MODEL: <RERANKER_MODEL>
-  OTLP_ENDPOINT: <otlp-endpoint>
-  OTLP_ENDPOINT_TRACE: <otlp-endpoint-trace>
+  OTLP_ENDPOINT:
+  OTLP_ENDPOINT_TRACE:
   ovmsEmbeddinggpuService:
     enabled: false
   GPU:
@@ -94,3 +94,8 @@ chatqnaui:
   name: chatqna-ui
   service:
     port: 80
+
+nginxService:
+  annotations:
+    service-proxy.app.orchestrator.io/ports: "80"
+    external-dns.alpha.kubernetes.io/hostname: "chatqna.example.org"

--- a/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-tgi.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-tgi.yaml
@@ -36,7 +36,7 @@ Chatqna:
   name: chatqna-backend
   image:
     repository: intel/chatqna
-    tag: "1.1.2"
+    tag: "1.2.1"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-tgi.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-tgi.yaml
@@ -16,8 +16,8 @@ global:
   LLM_MODEL: <LLM_MODEL>
   EMBEDDING_MODEL_NAME: <EMBEDDING_MODEL_NAME>
   RERANKER_MODEL: <RERANKER_MODEL>
-  OTLP_ENDPOINT: <otlp-endpoint>
-  OTLP_ENDPOINT_TRACE: <otlp-endpoint-trace>
+  OTLP_ENDPOINT:
+  OTLP_ENDPOINT_TRACE:
   teiEmbeddingService:
     enabled: false
   ovmsEmbeddingService:
@@ -85,3 +85,8 @@ reranker:
 chatqnaui:
   service:
     port: 80
+
+nginxService:
+  annotations:
+    service-proxy.app.orchestrator.io/ports: "80"
+    external-dns.alpha.kubernetes.io/hostname: "chatqna.example.org"

--- a/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-vllm.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-vllm.yaml
@@ -16,8 +16,8 @@ global:
   LLM_MODEL: <LLM_MODEL>
   EMBEDDING_MODEL_NAME: <EMBEDDING_MODEL_NAME>
   RERANKER_MODEL: <RERANKER_MODEL>
-  OTLP_ENDPOINT: <otlp-endpoint>
-  OTLP_ENDPOINT_TRACE: <otlp-endpoint-trace>
+  OTLP_ENDPOINT:
+  OTLP_ENDPOINT_TRACE:
   teiEmbeddingService:
     enabled: false
   ovmsEmbeddingService:
@@ -89,3 +89,8 @@ reranker:
 chatqnaui:
   service:
     port: 80
+
+nginxService:
+  annotations:
+    service-proxy.app.orchestrator.io/ports: "80"
+    external-dns.alpha.kubernetes.io/hostname: "chatqna.example.org"

--- a/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-vllm.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-vllm.yaml
@@ -36,7 +36,7 @@ Chatqna:
   name: chatqna-backend
   image:
     repository: intel/chatqna
-    tag: "1.1.2"
+    tag: "1.2.1"
     pullPolicy: IfNotPresent
   service:
     type: ClusterIP

--- a/sample-applications/chat-question-and-answer/deployment-package/deployment-package.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/deployment-package.yaml
@@ -8,11 +8,11 @@ $schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
 name: "chatqna"
 displayName: "chatqna"
 description: "Chat Q&A Sample Application"
-version: "1.1.2"
+version: "1.2.1"
 
 applications:
   - name: chatqna-app
-    version: 1.1.2
+    version: 1.2.1
 
 defaultNamespaces:
   chatqna-app: chatqna


### PR DESCRIPTION
### Description

Updates deployment package and helm charts for EMF 3.1. Contains the following changes:

Helm Chart:
  * Allows annotations to be specified for the nginx service.
    This allows EMF's Application Service Proxy to be used.
    The default is that no annotations are included.
  * Updates chart version from 1.2.0 to 1.2.1
  * Omit OTLP mounts when OTLP_ENDPOINT is empty. Necessary to work around issue on EMT.

Deployment Package:
  * Uses helm chart 1.2.1
  * Adds application service proxy annotation to the nginx ingress service
  * Removes all boolean parameters from the OVMs parameter template.
    This is due to an error in EMF 3.1 where "false" is misinterpreted as a string instead of a boolean.
    These settings are related to GPU support.
  * Removes the "< ... >" defaults on OTLP_ENDPOINT, because if they are not overridden, they will be passed to the application.

### How Has This Been Tested?

Tested using manual deployment on EMF to Ubuntu and EMT edge nodes.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

