### PR TITLE
[DLStreamer Pipeline Server] Enable VA-API based pipelines for RTSP and WebRTC

### DIFF
--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_factory.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_factory.py
@@ -22,11 +22,28 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
         ! gvawatermark ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0" 
 
     _RtspVideoPipeline = " ! videoconvert  \
-        ! gvawatermark ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0" 
+        ! gvawatermark ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0"
+    
+    # GPU pipeline variants for hardware-accelerated buffers
+    # _RtspVideoPipeline_GPU_VASurface = " ! vaapipostproc ! vaapijpegenc ! rtpjpegpay name=pay0"
+    
+    # _RtspVideoPipeline_GPU_DMABuf = " ! videoconvert ! gvawatermark ! vaapijpegenc ! rtpjpegpay name=pay0"
+    
+    # _RtspVideoPipeline_GPU_VAMemory = " ! videoconvert ! gvawatermark ! vaapijpegenc ! rtpjpegpay name=pay0" 
 
     # Decoding audio again as there is issue with audio pipeline element audiomixer
     _RtspAudioPipeline = " ! queue ! decodebin ! audioresample ! audioconvert " \
     " ! avenc_aac ! queue ! mpegtsmux ! rtpmp2tpay  name=pay0 pt=96"
+
+    def replace_with_vaelements_VAMemory(self, pipeline):
+        """
+        Replace elements in the pipeline with VA-API equivalents.
+        """
+        if "jpegenc" in pipeline:
+            pipeline = pipeline.replace("jpegenc", "vaapijpegenc")
+        if "jpegdec" in pipeline:
+            pipeline = pipeline.replace("jpegdec", "vajpegdec")        
+        return pipeline        
 
     def __init__(self, rtsp_server):
         GstRtspServer.RTSPMediaFactory.__init__(self)
@@ -49,6 +66,29 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
                     new_caps.append(cap)
         return new_caps
 
+    def _is_gpu_buffer(self, caps):
+        """
+        Determine if the caps indicate GPU buffer based on memory features.
+        Returns tuple: (is_gpu, caps_feature_type)
+        
+        GPU buffer types:
+        - VASurface: Video Acceleration Surface (Intel GPU)
+        - DMABuf: Direct Memory Access Buffer (cross-device)
+        - VAMemory: Video Acceleration Memory (Intel GPU)
+        """
+        caps_string = caps.to_string()
+        
+        # Check for GPU buffer indicators
+        if "memory:VASurface" in caps_string:
+            return True, "VASurface"
+        elif "memory:DMABuf" in caps_string:
+            return True, "DMABuf"  
+        elif "memory:VAMemory" in caps_string:
+            return True, "VAMemory"
+        else:
+            # System memory (CPU)
+            return False, "System"
+
     def do_create_element(self, url):
         # pylint: disable=arguments-differ
         # pylint disable added as pylint comparing do_create_element with some other method with same name.
@@ -64,6 +104,10 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
         overlay = stream.overlay
         new_caps = self._select_caps(caps.to_string())
         s_src = "{} caps=\"{}\"".format(GStreamerRtspFactory._source, ','.join(new_caps))
+        
+        # Determine if we're dealing with GPU or CPU buffers
+        is_gpu, buffer_type = self._is_gpu_buffer(caps)
+        
         if "image/jpeg" in new_caps:
             if overlay:
                 media_pipeline = GStreamerRtspFactory._RtspVideoPipeline_withjpeginput_overlay
@@ -73,6 +117,11 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
             media_pipeline = GStreamerRtspFactory._RtspVideoPipeline
             if overlay is False:
                 media_pipeline = media_pipeline.replace("gvawatermark ! ", "")
+
+        if is_gpu and buffer_type == "VAMemory":
+            self._logger.info("Using GPU pipeline for caps: {} (type: {})".format(caps.to_string(), buffer_type))
+            # Replace elements with VA-API equivalents if necessary
+            media_pipeline = self.replace_with_vaelements_VAMemory(media_pipeline)
         is_audio_pipeline = False
         if caps.to_string().startswith('audio'):
             media_pipeline = GStreamerRtspFactory._RtspAudioPipeline

--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_factory.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_factory.py
@@ -35,14 +35,14 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
     _RtspAudioPipeline = " ! queue ! decodebin ! audioresample ! audioconvert " \
     " ! avenc_aac ! queue ! mpegtsmux ! rtpmp2tpay  name=pay0 pt=96"
 
-    def replace_with_vaelements_VAMemory(self, pipeline):
+    def replace_with_vaelements_when_VAMemory(self, pipeline):
         """
         Replace elements in the pipeline with VA-API equivalents.
         """
         if "jpegenc" in pipeline:
-            pipeline = pipeline.replace("jpegenc", "vaapijpegenc")
+            pipeline = pipeline.replace("jpegenc", "vajpegenc")
         if "jpegdec" in pipeline:
-            pipeline = pipeline.replace("jpegdec", "vajpegdec")        
+            pipeline = pipeline.replace("jpegdec", "vajpegdec")
         return pipeline        
 
     def __init__(self, rtsp_server):
@@ -119,9 +119,9 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
                 media_pipeline = media_pipeline.replace("gvawatermark ! ", "")
 
         if is_gpu and buffer_type == "VAMemory":
-            self._logger.info("Using GPU pipeline for caps: {} (type: {})".format(caps.to_string(), buffer_type))
+            self._logger.debug("Using GPU pipeline for caps: {} (type: {})".format(caps.to_string(), buffer_type))
             # Replace elements with VA-API equivalents if necessary
-            media_pipeline = self.replace_with_vaelements_VAMemory(media_pipeline)
+            media_pipeline = self.replace_with_vaelements_when_VAMemory(media_pipeline)
         is_audio_pipeline = False
         if caps.to_string().startswith('audio'):
             media_pipeline = GStreamerRtspFactory._RtspAudioPipeline

--- a/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_destination.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_destination.py
@@ -75,7 +75,10 @@ class GStreamerWebRTCDestination(AppDestination):
                                        int(self._frame_size*self._cache_length))
         encoder = webrtc_pipeline.get_by_name("h264enc")
         if self.bitrate and encoder:
-            encoder.set_property("bitrate", self.bitrate)
+            # if encoder has the bitrate property, set it
+            if encoder.find_property("bitrate") is not None:
+                self._logger.debug("Setting bitrate to {} for WebRTC stream".format(self.bitrate))
+                encoder.set_property("bitrate", self.bitrate)
         self._app_src.connect('need-data', self._on_need_data)
         self._app_src.connect('enough-data', self._on_enough_data)
 


### PR DESCRIPTION
### Description

RTSP and WebRTC pipelines now use GPU specific pipelines based on incoming caps data.

Fixes # (issue)

decodebin3 in some machines automatically would convert the memory to VAMemory thereby 

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

