### PR TITLE
Enable command-line overrides of pre-processing parameters in model.xml runtime section.

### DIFF
--- a/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/image_inference.cpp
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/image_inference.cpp
@@ -21,8 +21,9 @@ ImagePreprocessorType getPreProcType(const std::map<std::string, std::string> &b
 
 } // namespace
 
-std::map<std::string, GstStructure *> ImageInference::GetModelInfoPreproc(const std::string model_file) {
-    return OpenVINOImageInference::GetModelInfoPreproc(model_file);
+std::map<std::string, GstStructure *> ImageInference::GetModelInfoPreproc(const std::string model_file,
+                                                                          const gchar *preproc_config) {
+    return OpenVINOImageInference::GetModelInfoPreproc(model_file, preproc_config);
 }
 
 ImageInference::Ptr ImageInference::createImageInferenceInstance(MemoryType input_image_memory_type,

--- a/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
@@ -617,7 +617,8 @@ class OpenVinoNewApiImpl {
     }
 
     // convert ov::Any to GstStructure
-    static std::map<std::string, GstStructure *> get_model_info_preproc(const std::string model_file) {
+    static std::map<std::string, GstStructure *> get_model_info_preproc(const std::string model_file,
+                                                                        const gchar *pre_proc_config) {
         std::map<std::string, GstStructure *> res;
         std::string layer_name("ANY");
         GstStructure *s = nullptr;
@@ -641,6 +642,14 @@ class OpenVinoNewApiImpl {
         if (_model->has_rt_info({"model_info"})) {
             modelConfig = _model->get_rt_info<ov::AnyMap>("model_info");
             s = gst_structure_new_empty(layer_name.data());
+        }
+
+        // override model config with command line pre-processing parameters if provided
+        auto pre_proc_params = Utils::stringToMap(pre_proc_config);
+        for (auto &item : pre_proc_params) {
+            if (modelConfig.find(item.first) != modelConfig.end()) {
+                modelConfig[item.first] = item.second;
+            }
         }
 
         // the parameter parsing loop may use locale-dependent floating point conversion
@@ -1703,8 +1712,9 @@ std::map<std::string, GstStructure *> OpenVINOImageInference::GetModelInfoPostpr
     return info;
 }
 
-std::map<std::string, GstStructure *> OpenVINOImageInference::GetModelInfoPreproc(const std::string model_file) {
-    auto info = OpenVinoNewApiImpl::get_model_info_preproc(model_file);
+std::map<std::string, GstStructure *> OpenVINOImageInference::GetModelInfoPreproc(const std::string model_file,
+                                                                                  const gchar *pre_proc_config) {
+    auto info = OpenVinoNewApiImpl::get_model_info_preproc(model_file, pre_proc_config);
     return info;
 }
 

--- a/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.h
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.h
@@ -43,7 +43,8 @@ class OpenVINOImageInference : public InferenceBackend::ImageInference {
     std::map<std::string, std::vector<size_t>> GetModelInputsInfo() const override;
     std::map<std::string, std::vector<size_t>> GetModelOutputsInfo() const override;
     std::map<std::string, GstStructure *> GetModelInfoPostproc() const override;
-    static std::map<std::string, GstStructure *> GetModelInfoPreproc(const std::string model_file);
+    static std::map<std::string, GstStructure *> GetModelInfoPreproc(const std::string model_file,
+                                                                     const gchar *pre_proc_config);
 
     bool IsQueueFull() override;
 

--- a/libraries/dl-streamer/src/monolithic/inference_backend/include/inference_backend/image_inference.h
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/include/inference_backend/image_inference.h
@@ -70,7 +70,8 @@ class ImageInference {
     // TODO: return map<OutputLayerDesc>
     virtual std::map<std::string, std::vector<size_t>> GetModelOutputsInfo() const = 0;
     virtual std::map<std::string, GstStructure *> GetModelInfoPostproc() const = 0;
-    static std::map<std::string, GstStructure *> GetModelInfoPreproc(const std::string model_file);
+    static std::map<std::string, GstStructure *> GetModelInfoPreproc(const std::string model_file,
+                                                                     const gchar *pre_proc_config);
 
     virtual bool IsQueueFull() = 0;
     virtual void Flush() = 0;


### PR DESCRIPTION
### Description

Pre-processing parameters defined in model.xml run-time section can be overridden with command line parameters, for example: 
     ... gvadetect pre-process-config=resize_type=standard ... 
will force standard (non-aspect-ratio) resize of input image into the input model tensor. 

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A.

### How Has This Been Tested?

Full CI cycle passed.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

