### PR TITLE
upgrade the npu driver to 1.19

### DIFF
--- a/libraries/dl-streamer/docker/ubuntu/ubuntu22.Dockerfile
+++ b/libraries/dl-streamer/docker/ubuntu/ubuntu22.Dockerfile
@@ -75,9 +75,9 @@ RUN \
 WORKDIR /tmp/npu_deps
     
 RUN curl -L -O https://github.com/oneapi-src/level-zero/releases/download/v1.18.5/level-zero_1.18.5+u22.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-driver-compiler-npu_1.13.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-fw-npu_1.13.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-level-zero-npu_1.13.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-driver-compiler-npu_1.19.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-fw-npu_1.19.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-level-zero-npu_1.19.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
     apt-get update && apt-get install --no-install-recommends -y /tmp/npu_deps/*.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/npu_deps
 
@@ -455,9 +455,9 @@ RUN \
 WORKDIR /tmp/npu_deps
     
 RUN curl -L -O https://github.com/oneapi-src/level-zero/releases/download/v1.18.5/level-zero_1.18.5+u22.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-driver-compiler-npu_1.13.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-fw-npu_1.13.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-level-zero-npu_1.13.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-driver-compiler-npu_1.19.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-fw-npu_1.19.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-level-zero-npu_1.19.0.20250131-13074932693_ubuntu22.04_amd64.deb && \
     apt-get update && apt-get install --no-install-recommends -y /tmp/npu_deps/*.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/npu_deps
 

--- a/libraries/dl-streamer/docker/ubuntu/ubuntu24.Dockerfile
+++ b/libraries/dl-streamer/docker/ubuntu/ubuntu24.Dockerfile
@@ -77,9 +77,9 @@ RUN \
 WORKDIR /tmp/npu_deps
     
 RUN curl -L -O https://github.com/oneapi-src/level-zero/releases/download/v1.18.5/level-zero_1.18.5+u24.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-driver-compiler-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-fw-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-level-zero-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-driver-compiler-npu_1.19.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-fw-npu_1.19.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-level-zero-npu_1.19.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
     apt-get update && apt-get install --no-install-recommends -y /tmp/npu_deps/*.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/npu_deps
 
@@ -398,9 +398,9 @@ RUN \
 WORKDIR /tmp/npu_deps
     
 RUN curl -L -O https://github.com/oneapi-src/level-zero/releases/download/v1.18.5/level-zero_1.18.5+u24.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-driver-compiler-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-fw-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
-    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-level-zero-npu_1.13.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-driver-compiler-npu_1.19.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-fw-npu_1.19.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-level-zero-npu_1.19.0.20250131-13074932693_ubuntu24.04_amd64.deb && \
     apt-get update && apt-get install --no-install-recommends -y /tmp/npu_deps/*.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/npu_deps
 

--- a/libraries/dl-streamer/scripts/DLS_install_prerequisites.sh
+++ b/libraries/dl-streamer/scripts/DLS_install_prerequisites.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: MIT
 # ==============================================================================
 
-npu_driver_version='1.13.0'
+npu_driver_version='1.19.0'
 reinstall_npu_driver='no'  # Default value for reinstalling the NPU driver
 on_host_or_docker='host'
 
@@ -533,9 +533,9 @@ install_npu() {
     $SUDO_PREFIX rm -rf ./npu_debs
     mkdir -p ./npu_debs
     dpkg --purge --force-remove-reinstreq intel-driver-compiler-npu intel-fw-npu intel-level-zero-npu
-    wget https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-driver-compiler-npu_1.13.0.20250131-13074932693_ubuntu${ubuntu_version}_amd64.deb -P ./npu_debs
-    wget https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-fw-npu_1.13.0.20250131-13074932693_ubuntu${ubuntu_version}_amd64.deb -P ./npu_debs
-    wget https://github.com/intel/linux-npu-driver/releases/download/v1.13.0/intel-level-zero-npu_1.13.0.20250131-13074932693_ubuntu${ubuntu_version}_amd64.deb -P ./npu_debs
+    wget https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-driver-compiler-npu_1.19.0.20250131-13074932693_ubuntu${ubuntu_version}_amd64.deb -P ./npu_debs
+    wget https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-fw-npu_1.19.0.20250131-13074932693_ubuntu${ubuntu_version}_amd64.deb -P ./npu_debs
+    wget https://github.com/intel/linux-npu-driver/releases/download/v1.19.0/intel-level-zero-npu_1.19.0.20250131-13074932693_ubuntu${ubuntu_version}_amd64.deb -P ./npu_debs
     wget https://github.com/oneapi-src/level-zero/releases/download/v1.18.5/level-zero_1.18.5+u${ubuntu_version}_amd64.deb
     $SUDO_PREFIX apt update
     $SUDO_PREFIX apt install libtbb12


### PR DESCRIPTION
### Description

Upgrade the npu driver to 1.19. Make efficientnet-b0 work.

Fixes [issue](https://github.com/intel-innersource/applications.ai.vpu-accelerators.vpux-plugin/pull/16080)

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

NA

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

