### PR TITLE
[DLStreamer] Fix downloading public models script to work inside container

### DIFF
--- a/libraries/dl-streamer/docker/ubuntu/ubuntu22.Dockerfile
+++ b/libraries/dl-streamer/docker/ubuntu/ubuntu22.Dockerfile
@@ -432,7 +432,7 @@ SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 # install prerequisites - gcc and cmake are needed to run .cpp samples
 RUN \
     apt-get update && \
-    apt-get install -y -q --no-install-recommends  libtbb12=\* curl=\* gcc=\* cmake=\*  gpg=\* ca-certificates=\* && \
+    apt-get install -y -q --no-install-recommends  libtbb12=\* curl=\* gcc=\* cmake=\*  gpg=\* ca-certificates=\* git=\* python3-venv=\* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/libraries/dl-streamer/docker/ubuntu/ubuntu24.Dockerfile
+++ b/libraries/dl-streamer/docker/ubuntu/ubuntu24.Dockerfile
@@ -375,7 +375,7 @@ RUN userdel -r ubuntu
 # install prerequisites - gcc and cmake are needed to run .cpp samples
 RUN \
     apt-get update && \
-    apt-get install -y -q --no-install-recommends curl=\* gpg=\* ca-certificates=\* libtbb12=\* && \
+    apt-get install -y -q --no-install-recommends curl=\* gpg=\* ca-certificates=\* libtbb12=\* git=\* python3-venv=\* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/libraries/dl-streamer/samples/download_public_models.sh
+++ b/libraries/dl-streamer/samples/download_public_models.sh
@@ -249,7 +249,7 @@ quantize_yolo_model() {
     mkdir -p "$MODELS_PATH/datasets"
     local DATASET_MANIFEST="$MODELS_PATH/datasets/$QUANTIZE.yaml"
 
-    wget ${SUPPORTED_QUANTIZATION_DATASETS[$QUANTIZE]} -O "$DATASET_MANIFEST"
+    curl -L -o "$DATASET_MANIFEST" ${SUPPORTED_QUANTIZATION_DATASETS[$QUANTIZE]}
     echo "Quantizing: ${MODEL_DIR}"
     mkdir -p "$MODEL_DIR"
 
@@ -377,7 +377,7 @@ if [ "$MODEL" == "yolox_s" ] || [ "$MODEL" == "yolo_all" ] || [ "$MODEL" == "all
     mkdir -p "$MODEL_DIR/FP16"
     mkdir -p "$MODEL_DIR/FP32"
     cd "$MODEL_DIR"
-    wget https://github.com/Megvii-BaseDetection/YOLOX/releases/download/0.1.1rc0/yolox_s.onnx
+    curl -O -L https://github.com/Megvii-BaseDetection/YOLOX/releases/download/0.1.1rc0/yolox_s.onnx
     ovc yolox_s.onnx --compress_to_fp16=True
     mv yolox_s.xml "$MODEL_DIR/FP16"
     mv yolox_s.bin "$MODEL_DIR/FP16"
@@ -488,7 +488,7 @@ for MODEL_NAME in "${YOLOv5_MODELS[@]}"; do
       cd "$MODEL_DIR"
       cp -r "$REPO_DIR" yolov5
       cd yolov5
-      wget "https://github.com/ultralytics/yolov5/releases/download/v7.0/${MODEL_NAME}.pt"
+      curl -L -O "https://github.com/ultralytics/yolov5/releases/download/v7.0/${MODEL_NAME}.pt"
 
       python3 export.py --weights "${MODEL_NAME}.pt" --include openvino --img-size 640 --dynamic
       python3 - <<EOF "${MODEL_NAME}"
@@ -698,7 +698,7 @@ if [[ "$MODEL" == "yolov8_license_plate_detector" ]] || [[ "$MODEL" == "all" ]];
     mkdir -p "$MODEL_DIR"
     cd "$MODEL_DIR"
 
-    wget --no-check-certificate 'https://drive.usercontent.google.com/uc?export=download&id=1Zmf5ynaTFhmln2z7Qvv-tgjkWQYQ9Zdw' -O ${MODEL_NAME}.pt
+    curl -L -k -o ${MODEL_NAME}.pt 'https://drive.usercontent.google.com/uc?export=download&id=1Zmf5ynaTFhmln2z7Qvv-tgjkWQYQ9Zdw'
 
     python3 - <<EOF "$MODEL_NAME"
 from ultralytics import YOLO
@@ -827,7 +827,7 @@ for MODEL_NAME in "${CLIP_MODELS[@]}"; do
       cd "$MODEL_DIR/FP32"
       IMAGE_URL="https://storage.openvinotoolkit.org/data/test_data/images/car.png"
       IMAGE_PATH=car.png
-      wget -O $IMAGE_PATH $IMAGE_URL
+      curl -L -o $IMAGE_PATH $IMAGE_URL
       echo "Image downloaded to $IMAGE_PATH"
       python3 - <<EOF "$MODEL_NAME" "$IMAGE_PATH"
 from transformers import CLIPProcessor, CLIPVisionModel
@@ -922,7 +922,7 @@ if [[ "$MODEL" == "ch_PP-OCRv4_rec_infer" ]] || [[ "$MODEL" == "all" ]]; then
     mkdir -p "$MODEL_DIR"
     echo "Downloading and converting: ${MODEL_DIR}"
     cd "$MODEL_DIR"
-    wget "https://paddleocr.bj.bcebos.com/PP-OCRv4/chinese/$MODEL_NAME.tar"
+    curl -L -O "https://paddleocr.bj.bcebos.com/PP-OCRv4/chinese/$MODEL_NAME.tar"
     python3 - <<EOF "$MODEL_NAME" "$MODEL_DIR" "$DST_FILE1"
 import tarfile
 import openvino as ov


### PR DESCRIPTION
### Description

Replace `wget` with `curl` in script for downloading public models.
Add `python3-venv` to docker image.

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Script was run inside container and checked if it was working

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

