### PR TITLE
[DLStreamer] Read optimal batch size from OV device instead of hardcoded heuristics.

### DIFF
--- a/libraries/dl-streamer/src/monolithic/gst/inference_elements/base/inference_impl.cpp
+++ b/libraries/dl-streamer/src/monolithic/gst/inference_elements/base/inference_impl.cpp
@@ -103,14 +103,6 @@ ImagePreprocessorType ImagePreprocessorTypeFromString(const std::string &image_p
                              ". Check element's description for supported property values.");
 }
 
-uint32_t GetOptimalBatchSize(const char *device) {
-    uint32_t batch_size = 1;
-    // if the device has the format GPU.x we assume that these are discrete graphics and choose larger batch
-    if (device and std::string(device).find("GPU.") != std::string::npos)
-        batch_size = 8;
-    return batch_size;
-}
-
 InferenceConfig CreateNestedInferenceConfig(GvaBaseInference *gva_base_inference, const std::string &model_file,
                                             const std::string &custom_preproc_lib) {
     assert(gva_base_inference && "Expected valid GvaBaseInference");
@@ -676,9 +668,6 @@ InferenceImpl::Model InferenceImpl::CreateModel(GvaBaseInference *gva_base_infer
     // It will be parsed in PostProcessor
     model.labels = labels_str;
 
-    if (gva_base_inference->batch_size == 0)
-        gva_base_inference->batch_size = GetOptimalBatchSize(gva_base_inference->device);
-
     UpdateModelReshapeInfo(gva_base_inference);
     InferenceConfig ie_config = CreateNestedInferenceConfig(gva_base_inference, model_file, custom_preproc_lib);
     UpdateConfigWithLayerInfo(model.input_processor_info, ie_config);
@@ -721,6 +710,10 @@ InferenceImpl::Model InferenceImpl::CreateModel(GvaBaseInference *gva_base_infer
         throw std::runtime_error("Failed to create inference instance");
     model.inference = image_inference;
     model.name = image_inference->GetModelName();
+
+    // if auto batch size was requested, use the actual batch size determined by inference instance
+    if (gva_base_inference->batch_size == 0)
+        gva_base_inference->batch_size = model.inference->GetBatchSize();
 
     return model;
 }

--- a/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
@@ -1018,6 +1018,14 @@ class OpenVinoNewApiImpl {
         }
 
         _batch_size = config.batch_size();
+        if (_batch_size == 0) {
+            try {
+                _batch_size = core().get_property(config.device(), ov::optimal_batch_size);
+            } catch (...) {
+                _batch_size = 1; // Fallback if optimal batch size property is not supported
+            }
+        }
+
         GVA_DEBUG("Setting batch size of %d to model", _batch_size);
         ov::set_batch(_model, _batch_size);
 
@@ -1359,6 +1367,7 @@ OpenVINOImageInference::OpenVINOImageInference(const InferenceBackend::Inference
 
         model_name = _impl->_model->get_friendly_name();
         nireq = _impl->_nireq;
+        batch_size = _impl->_batch_size;
         image_layer = _impl->_image_input_name;
 
         for (int i = 0; i < nireq; i++) {

--- a/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.h
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.h
@@ -76,7 +76,7 @@ class OpenVINOImageInference : public InferenceBackend::ImageInference {
     std::string model_name;
     std::string image_layer;
 
-    const int batch_size;
+    int batch_size;
     int nireq;
     SafeQueue<std::shared_ptr<BatchRequest>> freeRequests;
 


### PR DESCRIPTION
This PR updates the OpenVINO inference implementation to use device-specific optimal batch size properties instead of relying on hardcoded heuristics. When batch size is set to 0 (auto), the system now queries the OpenVINO device for its optimal batch size rather than using predefined values based on device type.

### Description

Replaces heuristic-based batch size selection with OpenVINO device property queries
Moves batch size assignment to occur after inference instance creation
Removes hardcoded GPU batch size logic

Fixes # (issue): performance discrepancy between 'device=GPU' and 'device=GPU.0'

### Any Newly Introduced Dependencies

N/A.

### How Has This Been Tested?

Full CI suite run. 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

