### PR TITLE
[DL Streamer Pipeline Server] : Remove default value of MR_REQUEST_TIMEOUT and MR_SAVED_MODELS_DIR

### DIFF
--- a/microservices/dlstreamer-pipeline-server/src/model_updater.py
+++ b/microservices/dlstreamer-pipeline-server/src/model_updater.py
@@ -56,15 +56,12 @@ class ModelRegistryClient:
         """
         self.is_ready = False
         try:
-            default_timeout = 300
-            request_timeout = os.getenv("MR_REQUEST_TIMEOUT", str(default_timeout))
-            try:
-                self._request_timeout = int(request_timeout)
-            except ValueError:
-                self._request_timeout = self._get_env_var_or_default_value(
-                    var_name="MR_REQUEST_TIMEOUT",
-                    default_value=default_timeout,
-                    use_default=True)
+            self._request_timeout = self._get_env_var_or_default_value(
+                var_name="MR_REQUEST_TIMEOUT",
+                default_value="")
+            if not self._request_timeout:
+                raise ValueError("Model Registry Client is not ready. "
+                "MR_REQUEST_TIMEOUT not set in .env")
 
             self._url = self._get_env_var_or_default_value(var_name="MR_URL",
                                                            default_value="")
@@ -76,7 +73,10 @@ class ModelRegistryClient:
 
             self._saved_models_dir = self._get_env_var_or_default_value(
                 var_name="MR_SAVED_MODELS_DIR",
-                default_value="./mr_models")
+                default_value="")
+            if not self._saved_models_dir:
+                raise ValueError("Model Registry Client is not ready. "
+                "MR_SAVED_MODELS_DIR not set in .env")
 
             if self._url:
                 self.is_ready = True


### PR DESCRIPTION
### Description

Removing changes to assume default value for MR_REQUEST_TIMEOUT and MR_SAVED_MODELS_DIR without setting it in .env

Fixes # (issue)

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

Tested against by not setting the value in .env.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

