### PR TITLE
[Sample app VSS] [Fix] Enhance no_proxy configuration to include localhost

### DIFF
--- a/sample-applications/video-search-and-summarization/setup.sh
+++ b/sample-applications/video-search-and-summarization/setup.sh
@@ -72,8 +72,15 @@ export APP_HOST_PORT=12345
 # Export all environment variables
 # Base configuration
 export HOST_IP=$(ip route get 1 | awk '{print $7}')  # Fetch the host IP
-# Add HOST_IP to no_proxy only if not already present
-[[ $no_proxy != *"${HOST_IP}"* ]] && export no_proxy="${no_proxy},${HOST_IP}"
+# Add HOST_IP and localhost to no_proxy
+if [ -n "$no_proxy" ]; then
+    # if no_proxy variable is not null
+    [[ $no_proxy != *"${HOST_IP}"* ]] && no_proxy="${no_proxy},${HOST_IP}"
+    [[ $no_proxy != *"localhost"* ]] && no_proxy="${no_proxy},localhost"
+    export no_proxy=${no_proxy}
+else
+    export no_proxy="localhost,${HOST_IP}"
+fi
 export TAG=${TAG:-latest}
 
 # If REGISTRY_URL is set, ensure it ends with a trailing slash


### PR DESCRIPTION
Fixes # (issue)

EMT devices with no_proxy not defined in env were facing issue that some containers were landing in error state. 

Root Cause: localhost not added to no_proxy was causing the health check api of containers to not reach the local server from docker compose.

Fix: Add `localhost` to no_proxy and check if no_proxy is null then create new and add localhost.

### How Has This Been Tested?

Tested on dev setup.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

