### PR TITLE
[vippet] Increase the maximum number of available channels

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/app.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/app.py
@@ -777,7 +777,7 @@ def create_interface(title: str = "Visual Pipeline and Platform Evaluation Tool"
     # Inferencing channels
     inferencing_channels = gr.Slider(
         minimum=0,
-        maximum=30,
+        maximum=100,
         value=8,
         step=1,
         label="Number of Recording + Inferencing channels",
@@ -788,7 +788,7 @@ def create_interface(title: str = "Visual Pipeline and Platform Evaluation Tool"
     # Recording channels
     recording_channels = gr.Slider(
         minimum=0,
-        maximum=30,
+        maximum=100,
         value=8,
         step=1,
         label="Number of Recording only channels",
@@ -1485,3 +1485,4 @@ if __name__ == "__main__":
         server_name="0.0.0.0",
         server_port=7860,
     )
+


### PR DESCRIPTION
### Description

When tested on Xeon 6th Gen, the recommended value was 49 AI streams. Unfortunately, the current UI limits this to 30.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

