### PR TITLE
[ViPPET][main] Platform Ceiling Analysis mustn't use live_preview - fix

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/app.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/app.py
@@ -672,6 +672,9 @@ def on_benchmark(data):
             duration=10,
         )
 
+    # Enable Live Preview checkbox must not be taken into account for benchmarking
+    param_grid["live_preview_enabled"] = [False]
+
     # Initialize the benchmark class
     bm = Benchmark(
         video_path=arguments["input_video_player"],


### PR DESCRIPTION
### Description

This pull request fixes a bug in the Visual Pipeline and Platform Evaluation Tool (ViPPET) where the Platform Ceiling Analysis was incorrectly using the live_preview setting from the UI during benchmarking operations.

- Forces `live_preview_enabled` to `False` in the parameter grid for benchmarking to ensure consistent results

