### PR TITLE
[ViPPET] fix: keep telegraf config in container

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
 
 WORKDIR /app
 
+COPY telegraf.conf /etc/telegraf
 COPY qmassa_reader.py qmassa_reader.py
 COPY read_cpu_freq.sh read_cpu_freq.sh
 RUN chmod +x read_cpu_freq.sh

--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -76,7 +76,6 @@ services:
     ipc: host
     pid: host
     volumes:
-      - ./collector/telegraf.conf:/etc/telegraf/telegraf.conf
       - "collector-signals:/app/.collector-signals"
     restart: on-failure:5
   videogenerator:


### PR DESCRIPTION
### Description

Keep telegraf config in container instead of mounting from host.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

