### PR TITLE
chore: use DL Streamer image from docker hub

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/Dockerfile.vippet
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Dockerfile.vippet
@@ -14,7 +14,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/open-edge-platform/edge-ai-libraries/intel/edge-ai-dlstreamer:20250729_EAL1.2_DLS_RC2-ubuntu24
+FROM intel/dlstreamer:EAL1.2.RC2_2025.1.RC2-ubuntu24
 
 USER root
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -25,7 +25,7 @@ x-vippet: &vippet
 
 services:
   models:
-    image: ghcr.io/open-edge-platform/edge-ai-libraries/intel/edge-ai-dlstreamer:20250729_EAL1.2_DLS_RC2-ubuntu24
+    image: intel/dlstreamer:EAL1.2.RC2_2025.1.RC2-ubuntu24
     container_name: models
     volumes:
       - ./models/:/output

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/how-to-build-source.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/how-to-build-source.md
@@ -45,7 +45,7 @@ This guide assumes basic familiarity with Git commands, Python virtual environme
 3. **Build and Start the Tool**:
    - Run:
      ```bash
-     docker pull ghcr.io/open-edge-platform/edge-ai-libraries/intel/edge-ai-dlstreamer:20250729_EAL1.2_DLS_RC2-ubuntu24
+     docker pull intel/dlstreamer:EAL1.2.RC2_2025.1.RC2-ubuntu24
      docker pull docker.io/library/rust:1.87
      docker pull docker.io/library/telegraf:1.32
      docker compose build

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM ghcr.io/open-edge-platform/edge-ai-libraries/intel/edge-ai-dlstreamer:20250729_EAL1.2_DLS_RC2-ubuntu24
+FROM intel/dlstreamer:EAL1.2.RC2_2025.1.RC2-ubuntu24
 
 # Set environment variable to non-interactive mode (avoids some prompts)
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Description

Use DL Streamer image from docker hub. OS PDT requires it.

Cherry-pick of #672 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

