### PR TITLE
[ViPPET] Bump DLStreamer to 2025.1.2-ubuntu24 version and apply minor fixes

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/Dockerfile.vippet
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Dockerfile.vippet
@@ -14,7 +14,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM intel/dlstreamer:EAL1.2.RC2_2025.1.RC2-ubuntu24
+FROM intel/dlstreamer:2025.1.2-ubuntu24
 
 USER root
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/app.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/app.py
@@ -915,7 +915,7 @@ def create_interface(title: str = "Visual Pipeline and Platform Evaluation Tool"
             "EfficientNet B0 (INT8)",
             "MobileNet V2 PyTorch (FP16)",
             "ResNet-50 TF (INT8)",
-            "PaddleOCR (FP16)",
+            "PaddleOCR (FP32)",
             "Vehicle Attributes Recognition Barrier 0039 (FP16)",
         ],
         value="ResNet-50 TF (INT8)",

--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -1,5 +1,5 @@
 x-vippet: &vippet
-  image: docker.io/intel/vippet-app:v1.0.1
+  image: docker.io/intel/vippet-app:v1.2
   build:
     context: .
     dockerfile: Dockerfile.vippet
@@ -27,7 +27,7 @@ x-vippet: &vippet
 
 services:
   models:
-    image: intel/dlstreamer:EAL1.2.RC2_2025.1.RC2-ubuntu24
+    image: intel/dlstreamer:2025.1.2-ubuntu24
     container_name: models
     volumes:
       - ./models/:/output
@@ -61,7 +61,7 @@ services:
       - "/dev/accel:/dev/accel"
     profiles: [npu]
   collector:
-    image: docker.io/intel/vippet-collector:v1.0.0
+    image: docker.io/intel/vippet-collector:v1.2
     build:
       context: ./collector
       dockerfile: Dockerfile
@@ -80,7 +80,7 @@ services:
     restart: on-failure:5
   videogenerator:
     profiles: [do-not-start]
-    image: docker.io/intel/vippet-videogenerator:v1.0.2
+    image: docker.io/intel/vippet-videogenerator:v1.2
     build:
       context: video_generator
       dockerfile: Dockerfile

--- a/tools/visual-pipeline-and-platform-evaluation-tool/pipelines/simplevs/config.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/pipelines/simplevs/config.yaml
@@ -31,6 +31,6 @@ parameters:
       - "EfficientNet B0 (INT8)"
       - "MobileNet V2 PyTorch (FP16)"
       - "ResNet-50 TF (INT8)"
-      - "PaddleOCR (FP16)"
+      - "PaddleOCR (FP32)"
       - "Vehicle Attributes Recognition Barrier 0039 (FP16)"
-    classification_model_default: "PaddleOCR (FP16)"
+    classification_model_default: "PaddleOCR (FP32)"

--- a/tools/visual-pipeline-and-platform-evaluation-tool/tests/utils_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/tests/utils_test.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import itertools
 
 import utils
-from utils import prepare_video_and_constants, run_pipeline_and_extract_metrics
+from utils import prepare_video_and_constants, run_pipeline_and_extract_metrics, is_yolov10_model
 
 
 class TestUtils(unittest.TestCase):
@@ -143,6 +143,26 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(results[0]["total_fps"], "N/A")
         self.assertEqual(results[0]["per_stream_fps"], "N/A")
         self.assertEqual(results[0]["num_streams"], "N/A")
+
+    def test_yolov10_model(self):
+        # Test with a valid YOLO v10 model path
+        self.assertTrue(is_yolov10_model("/path/to/yolov10s_model.xml"))
+
+    def test_non_yolov10_model(self):
+        # Test with a non-YOLO v10 model path
+        self.assertFalse(is_yolov10_model("/path/to/other_model.xml"))
+
+    def test_case_insensitivity(self):
+        # Test with mixed-case YOLO v10 model path
+        self.assertTrue(is_yolov10_model("/path/to/YOLOv10m_model.xml"))
+
+    def test_empty_path(self):
+        # Test with an empty string
+        self.assertFalse(is_yolov10_model(""))
+
+    def test_no_yolo_in_path(self):
+        # Test with a path that does not contain "yolov10"
+        self.assertFalse(is_yolov10_model("/path/to/yolo_model.xml"))
 
 
 if __name__ == "__main__":

--- a/tools/visual-pipeline-and-platform-evaluation-tool/utils.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/utils.py
@@ -198,9 +198,9 @@ def prepare_video_and_constants(
             constants["OBJECT_CLASSIFICATION_MODEL_PROC"] = (
                 f"{MODELS_PATH}/public/mobilenet-v2-pytorch/mobilenet-v2.json"
             )
-        case "PaddleOCR (FP16)":
+        case "PaddleOCR (FP32)":
             constants["OBJECT_CLASSIFICATION_MODEL_PATH"] = (
-                f"{MODELS_PATH}/public/ch_PP-OCRv4_rec_infer/FP16/ch_PP-OCRv4_rec_infer.xml"
+                f"{MODELS_PATH}/public/ch_PP-OCRv4_rec_infer/FP32/ch_PP-OCRv4_rec_infer.xml"
             )
             constants["OBJECT_CLASSIFICATION_MODEL_PROC"] = None
         case "Vehicle Attributes Recognition Barrier 0039 (FP16)":
@@ -630,3 +630,15 @@ def run_pipeline_and_extract_metrics(
             logger.error(f"Pipeline execution error: {e}")
             continue
     return results
+
+def is_yolov10_model(model_path: str) -> bool:
+    """
+    Checks if the given model path corresponds to a YOLO v10 model.
+
+    Args:
+        model_path (str): Path to the model file.
+
+    Returns:
+        bool: True if the model is a YOLO v10 model, False otherwise.
+    """
+    return "yolov10" in model_path.lower()

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:EAL1.2.RC2_2025.1.RC2-ubuntu24
+FROM intel/dlstreamer:2025.1.2-ubuntu24
 
 # Set environment variable to non-interactive mode (avoids some prompts)
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Description

This PR bumps the DLStreamer base image from a release candidate version to a stable release (2025.1.2-ubuntu24) and applies several minor fixes including updating PaddleOCR model precision and adding GPU-specific inference configuration for YOLOv10 models.

- Updates DLStreamer base image from RC version to stable 2025.1.2-ubuntu24
- Changes PaddleOCR model from FP16 to FP32 precision across multiple configuration files
- Adds GPU inference configuration parameter for YOLOv10 models to disable Winograd convolution

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

