### PR TITLE
[ViPPET] chore: Bump Telegraf to 1.35.3 to address vulnerabilities detected by Trivy

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 
 RUN cargo install --locked qmassa
 
-FROM docker.io/library/telegraf:1.32 AS collector
+FROM docker.io/library/telegraf:1.35.3 AS collector
 
 COPY --from=qmassa /usr/local/cargo/bin/qmassa /usr/local/bin/qmassa
 


### PR DESCRIPTION
### Description

This PR bumps Telegraf to `1.35.3` to address vulnerabilities detected by Trivy.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

