### PR TITLE
document-ingestion: Remove obsolete package

### DIFF
--- a/microservices/document-ingestion/pgvector/docker/Dockerfile
+++ b/microservices/document-ingestion/pgvector/docker/Dockerfile
@@ -51,12 +51,6 @@ RUN poetry install --no-dev && \
 FROM python-base AS dev
 ENV FASTAPI_ENV=development
 
-# Install runtime dependency for opencv
-RUN apt-get update && apt-get install --no-install-recommends --fix-missing -y \
-    libgl1-mesa-glx \
-    libglib2.0-0 \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
 WORKDIR $SETUP_PATH
 
 # Copy the poetry installation and the virtual env to current image
@@ -77,12 +71,6 @@ CMD ["uvicorn", "--host", "0.0.0.0", "--reload", "app.main:app"]
 # `prod` image used for runtime
 FROM python-base AS prod
 ENV FASTAPI_ENV=production
-
-# Install runtime dependency for opencv
-RUN apt-get update && apt-get install --no-install-recommends --fix-missing -y \
-    libgl1-mesa-glx \
-    libglib2.0-0 && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder-base $SETUP_PATH $SETUP_PATH
 COPY . /app/


### PR DESCRIPTION
### Description

In document ingestion microservice, libgl1-mesa-glx has been obsoleted and not required by chatqna-core application. Remove it to avoid build error.

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

