### PR TITLE
[DL Streamer Pipeline Server] Add 992 render group ID and set termination message path to /tmp instead of /dev which is read only

### DIFF
--- a/microservices/dlstreamer-pipeline-server/helm/templates/dlstreamer-pipeline-server-deployment.yaml
+++ b/microservices/dlstreamer-pipeline-server/helm/templates/dlstreamer-pipeline-server-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: dlstreamer-pipeline-server
     spec:
       securityContext:
-        supplementalGroups: [109,110]
+        supplementalGroups: [109,110,992]
       {{- if and $.Values.DOCKER_USERNAME $.Values.DOCKER_PASSWORD }}
       imagePullSecrets:
       - name: registryauth
@@ -49,7 +49,7 @@ spec:
           value: {{ $.Values.env.no_proxy }}
         securityContext:
           runAsNonRoot: true
-          runAsUser: 1000
+          runAsUser: 1999
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:
@@ -78,6 +78,7 @@ spec:
             drop:
               - ALL
         {{- end }}
+        terminationMessagePath: /tmp/termination-log
         {{- if $.Values.gpu.enabled }}
         resources:
           limits:


### PR DESCRIPTION
### Description

[DL Streamer Pipeline Server] Add 992 render group ID and set termination message path to /tmp instead of /dev which is read only


### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

