### PR TITLE
dl-streamer/docs: Added compilation steps for EMT OS

### DIFF
--- a/libraries/dl-streamer/docs/source/dev_guide/advanced_install/advanced_install_guide_compilation.md
+++ b/libraries/dl-streamer/docs/source/dev_guide/advanced_install/advanced_install_guide_compilation.md
@@ -61,6 +61,11 @@ sudo dnf install -y wget libva-utils xz python3-pip python3-gobject gcc gcc-c++ 
     libssh2-devel cmake git valgrind numactl libvpx-devel opus-devel libsrtp-devel libXv-devel paho-c-devel \
     kernel-headers pmix pmix-devel hwloc hwloc-libs hwloc-devel libxcb-devel libX11-devel libatomic intel-media-driver
 ```
+### EMT 3.x
+
+```bash
+sudo dnf install -y uuid libuuid-devel openssl-devel gcc gcc-c++ make curl ca-certificates librdkafka-devel libva-devel alsa-lib-devel unzip glibc libstdc++ libgcc cmake sudo pkgconf pkgconf-pkg-config ocl-icd-devel libva-intel-media-driver python3-devel libXaw-devel ncurses-devel libva2 intel-compute-runtime intel-opencl intel-level-zero-gpu intel-ocloc-devel nasm
+```
 
 ## Step 3: Set up a Python environment
 
@@ -99,7 +104,7 @@ sudo apt-get install --reinstall ffmpeg libpostproc-dev libavfilter-dev libavdev
             libswscale-dev libswresample-dev libavutil-dev libavformat-dev libavcodec-dev
 ```
 
-### Fedora
+### Fedora/EMT
 
 You can uninstall it with the following command (if installed from
 source):
@@ -140,7 +145,7 @@ git clone https://gitlab.freedesktop.org/gstreamer/gstreamer.git
 
 cd ~/gstreamer
 git switch -c "1.26.4" "tags/1.26.4"
-export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/:/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:$PKG_CONFIG_PATH
 sudo ldconfig
 meson setup -Dexamples=disabled -Dtests=disabled -Dvaapi=enabled -Dgst-examples=disabled --buildtype=release --prefix=/opt/intel/dlstreamer/gstreamer --libdir=lib/ --libexecdir=bin/ build/
 ninja -C build
@@ -227,12 +232,14 @@ sudo env PATH=~/python3venv/bin:$PATH ninja install
 
 ```bash
 cd ~
-git clone https://github.com/open-edge-platform/edge-ai-libraries.git
+git clone https://github.com/open-edge-platform/edge-ai-libraries.git -b release-1.2.0
 cd edge-ai-libraries
 git submodule update --init libraries/dl-streamer/thirdparty/spdlog
 ```
 
 ## Step 8: Install OpenVINO™ Toolkit
+
+### Ubuntu/Fedora
 
 Download and install OpenVINO™ Toolkit:
 
@@ -258,6 +265,18 @@ OpenVINO™ Toolkit development environment:
 ```bash
 sudo -E /opt/intel/openvino_2025/install_dependencies/install_openvino_dependencies.sh
 source /opt/intel/openvino_2025/setupvars.sh
+```
+
+### EMT
+
+```bash
+wget https://storage.openvinotoolkit.org/repositories/openvino/packages/2025.2/linux/openvino_toolkit_ubuntu24_2025.2.0.19140.c01cd93e24d_x86_64.tgz
+tar -xvzf openvino_toolkit_ubuntu24_2025.2.0.19140.c01cd93e24d_x86_64.tgz 
+sudo mv openvino_toolkit_ubuntu24_2025.2.0.19140.c01cd93e24d_x86_64 /opt/intel/openvino_2025.2.0
+cd /opt/intel/openvino_2025.2.0/
+sudo -E python3 -m pip install -r ./python/requirements.txt
+cd /opt/intel
+sudo ln -s openvino_2025.2.0 openvino_2025
 ```
 
 ## Step 9: Build Intel DLStreamer
@@ -296,11 +315,13 @@ cmake -DENABLE_PAHO_INSTALLATION=ON -DENABLE_RDKAFKA_INSTALLATION=ON -DENABLE_VA
 make -j "$(nproc)"
 ```
 
-### Fedora
+### Fedora/EMT
 
 ```bash
 cd ~/edge-ai-libraries/libraries/dl-streamer
 
+# The below step of download, compilation and install of librdkafka is not required on EMT as 
+# it is being installed as part of the build dependencies above
 curl -sSL https://github.com/edenhill/librdkafka/archive/v2.3.0.tar.gz | tar -xz
 cd ./librdkafka-2.3.0
 ./configure && make && make INSTALL=install install
@@ -340,6 +361,29 @@ export LIBVA_DRIVER_NAME=iHD
 export GST_PLUGIN_PATH="$HOME/edge-ai-libraries/libraries/dl-streamer/build/intel64/Release/lib:/opt/intel/dlstreamer/gstreamer/lib/gstreamer-1.0:/usr/lib64/gstreamer-1.0"
 export LD_LIBRARY_PATH="/opt/intel/dlstreamer/gstreamer/lib:$HOME/edge-ai-libraries/libraries/dl-streamer/build/intel64/Release/lib:/usr/lib:/usr/local/lib:$LD_LIBRARY_PATH"
 export LIBVA_DRIVERS_PATH="/usr/lib64/dri-nonfree"
+export GST_VA_ALL_DRIVERS="1"
+export PATH="/opt/intel/dlstreamer/gstreamer/bin:$HOME/edge-ai-libraries/libraries/dl-streamer/build/intel64/Release/bin:$HOME/.local/bin:$HOME/python3venv/bin:$PATH"
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$HOME/edge-ai-libraries/libraries/dl-streamer/build/intel64/Release/lib/pkgconfig:/usr/lib64/pkgconfig:/opt/intel/dlstreamer/gstreamer/lib/pkgconfig:$PKG_CONFIG_PATH"
+export GST_PLUGIN_FEATURE_RANK=${GST_PLUGIN_FEATURE_RANK},ximagesink:MAX
+```
+
+### EMT
+
+Follow below steps to enable `i915` graphics driver in the system
+
+```bash
+sudo vim /etc/default/grub
+### Extend the GRUB_CMDLINE_LINUX with i915.force_probe=* ###
+sudo grub2-mkconfig -o /boot/grub2/grub.cfg "$@"
+sudo reboot
+```
+
+Post reboot, set these environment variables before trying the DL Streamer pipelines from the terminal
+```bash
+export LIBVA_DRIVER_NAME=iHD
+export GST_PLUGIN_PATH="$HOME/edge-ai-libraries/libraries/dl-streamer/build/intel64/Release/lib:/opt/intel/dlstreamer/gstreamer/lib/gstreamer-1.0:/usr/lib64/gstreamer-1.0"
+export LD_LIBRARY_PATH="/opt/intel/dlstreamer/gstreamer/lib:$HOME/edge-ai-libraries/libraries/dl-streamer/build/intel64/Release/lib:/usr/lib:/usr/local/lib:$LD_LIBRARY_PATH"
+export LIBVA_DRIVERS_PATH="/usr/lib/dri"
 export GST_VA_ALL_DRIVERS="1"
 export PATH="/opt/intel/dlstreamer/gstreamer/bin:$HOME/edge-ai-libraries/libraries/dl-streamer/build/intel64/Release/bin:$HOME/.local/bin:$HOME/python3venv/bin:$PATH"
 export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$HOME/edge-ai-libraries/libraries/dl-streamer/build/intel64/Release/lib/pkgconfig:/usr/lib64/pkgconfig:/opt/intel/dlstreamer/gstreamer/lib/pkgconfig:$PKG_CONFIG_PATH"

--- a/libraries/dl-streamer/docs/source/dev_guide/advanced_install/advanced_install_guide_compilation.md
+++ b/libraries/dl-streamer/docs/source/dev_guide/advanced_install/advanced_install_guide_compilation.md
@@ -320,8 +320,8 @@ make -j "$(nproc)"
 ```bash
 cd ~/edge-ai-libraries/libraries/dl-streamer
 
-# The below step of download, compilation and install of librdkafka is not required on EMT as 
-# it is being installed as part of the build dependencies above
+# Download, compile and install `librdkafka`. This step is not required on EMT, because `librdkafka`
+# is installed as part of build dependencies, in the steps above. 
 curl -sSL https://github.com/edenhill/librdkafka/archive/v2.3.0.tar.gz | tar -xz
 cd ./librdkafka-2.3.0
 ./configure && make && make INSTALL=install install
@@ -369,7 +369,7 @@ export GST_PLUGIN_FEATURE_RANK=${GST_PLUGIN_FEATURE_RANK},ximagesink:MAX
 
 ### EMT
 
-Follow below steps to enable `i915` graphics driver in the system
+Follow the steps below to enable `i915` graphics driver in the system.
 
 ```bash
 sudo vim /etc/default/grub
@@ -378,7 +378,7 @@ sudo grub2-mkconfig -o /boot/grub2/grub.cfg "$@"
 sudo reboot
 ```
 
-Post reboot, set these environment variables before trying the DL Streamer pipelines from the terminal
+After reboot set the following environment variables before trying the DL Streamer pipelines from the terminal.
 ```bash
 export LIBVA_DRIVER_NAME=iHD
 export GST_PLUGIN_PATH="$HOME/edge-ai-libraries/libraries/dl-streamer/build/intel64/Release/lib:/opt/intel/dlstreamer/gstreamer/lib/gstreamer-1.0:/usr/lib64/gstreamer-1.0"

--- a/libraries/dl-streamer/docs/source/get_started/tutorial.md
+++ b/libraries/dl-streamer/docs/source/get_started/tutorial.md
@@ -389,10 +389,9 @@ gvadetect model=${DETECTION_MODEL} model_proc=${DETECTION_MODEL_PROC} device=CPU
 gvawatermark ! videoconvert ! autovideosink sync=false
 ```
 
-> **Note**: On EMT OS, we don't have X11/wayland display server enabled as per design and to see the 
-> the video for above pipeline, one needs to replace the last gstreamer element `autovideosink sync=false`
-> with `kmssink sync=false`. The pre-requisite for this to work is to have the system on which the
-> pipeline is run on the KVM setup
+> **Note**: On EMT OS the `X11/wayland` display server is by default disabled. To see the 
+> the video for the above pipeline, replace the last gstreamer element `autovideosink sync=false`
+> with `kmssink sync=false`. The system on which the pipeline is running must be working on the KVM setup.
 
 **Expected output**: You will see your video overlaid by bounding boxes
 around persons, vehicles, and bikes.
@@ -471,10 +470,9 @@ gvaclassify model=${VEHICLE_CLASSIFICATION_MODEL} model-proc=${VEHICLE_CLASSIFIC
 gvawatermark ! videoconvert ! autovideosink sync=false
 ```
 
-> **Note**: On EMT OS, we don't have X11/wayland display server enabled as per design and to see the 
-> the video for above pipeline, one needs to replace the last gstreamer element `autovideosink sync=false`
-> with `kmssink sync=false`. The pre-requisite for this to work is to have the system on which the
-> pipeline is run on the KVM setup
+> **Note**: On EMT OS the `X11/wayland` display server is by default disabled. To see the 
+> the video for the above pipeline, replace the last gstreamer element `autovideosink sync=false`
+> with `kmssink sync=false`. The system on which the pipeline is running must be working on the KVM setup.
 
 **Expected output**: Persons, vehicles, and bikes are bound by colored
 boxes, and detection results as well as classification attributes such
@@ -529,10 +527,9 @@ gvaclassify model=${VEHICLE_CLASSIFICATION_MODEL} model-proc=${VEHICLE_CLASSIFIC
 gvawatermark ! videoconvert ! autovideosink sync=false
 ```
 
-> **Note**: On EMT OS, we don't have X11/wayland display server enabled as per design and to see the 
-> the video for above pipeline, one needs to replace the last gstreamer element `autovideosink sync=false`
-> with `kmssink sync=false`. The pre-requisite for this to work is to have the system on which the
-> pipeline is run on the KVM setup
+> **Note**: On EMT OS the `X11/wayland` display server is by default disabled. To see the 
+> the video for the above pipeline, replace the last gstreamer element `autovideosink sync=false`
+> with `kmssink sync=false`. The system on which the pipeline is running must be working on the KVM setup.
 
 **Expected output**: Persons, vehicles, and bikes are bound by colored
 boxes, and detection results as well as classification attributes such

--- a/libraries/dl-streamer/docs/source/get_started/tutorial.md
+++ b/libraries/dl-streamer/docs/source/get_started/tutorial.md
@@ -389,6 +389,11 @@ gvadetect model=${DETECTION_MODEL} model_proc=${DETECTION_MODEL_PROC} device=CPU
 gvawatermark ! videoconvert ! autovideosink sync=false
 ```
 
+> **Note**: On EMT OS, we don't have X11/wayland display server enabled as per design and to see the 
+> the video for above pipeline, one needs to replace the last gstreamer element `autovideosink sync=false`
+> with `kmssink sync=false`. The pre-requisite for this to work is to have the system on which the
+> pipeline is run on the KVM setup
+
 **Expected output**: You will see your video overlaid by bounding boxes
 around persons, vehicles, and bikes.
 
@@ -466,6 +471,11 @@ gvaclassify model=${VEHICLE_CLASSIFICATION_MODEL} model-proc=${VEHICLE_CLASSIFIC
 gvawatermark ! videoconvert ! autovideosink sync=false
 ```
 
+> **Note**: On EMT OS, we don't have X11/wayland display server enabled as per design and to see the 
+> the video for above pipeline, one needs to replace the last gstreamer element `autovideosink sync=false`
+> with `kmssink sync=false`. The pre-requisite for this to work is to have the system on which the
+> pipeline is run on the KVM setup
+
 **Expected output**: Persons, vehicles, and bikes are bound by colored
 boxes, and detection results as well as classification attributes such
 as vehicle type and color are displayed as video overlays.
@@ -518,6 +528,11 @@ gvatrack tracking-type=short-term-imageless ! queue ! \
 gvaclassify model=${VEHICLE_CLASSIFICATION_MODEL} model-proc=${VEHICLE_CLASSIFICATION_MODEL_PROC} device=CPU object-class=vehicle reclassify-interval=10 ! queue ! \
 gvawatermark ! videoconvert ! autovideosink sync=false
 ```
+
+> **Note**: On EMT OS, we don't have X11/wayland display server enabled as per design and to see the 
+> the video for above pipeline, one needs to replace the last gstreamer element `autovideosink sync=false`
+> with `kmssink sync=false`. The pre-requisite for this to work is to have the system on which the
+> pipeline is run on the KVM setup
 
 **Expected output**: Persons, vehicles, and bikes are bound by colored
 boxes, and detection results as well as classification attributes such


### PR DESCRIPTION
### Description

Changes:
1. Added compilation steps for EMT 3.x OS  (tried on the immutable i.e., EMT-D as we need to install packages additionally)
2. Added the note in the tutorial guide which is required  to get the dlstreamer pipeline being rendered

Have verified the tutorial and performance guide DL Streamer tutorials on the EMT OS.

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?
Have verified the tutorial and performance guide DL Streamer tutorials on the EMT OS.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

