### PR TITLE
[ViPPET] Add support for different tracking types

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/app.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/app.py
@@ -796,6 +796,14 @@ def create_interface(title: str = "Visual Pipeline and Platform Evaluation Tool"
         elem_id="recording_channels",
     )
 
+    # Tracking type
+    tracking_type = gr.Dropdown(
+        label="Object Tracking Type",
+        choices=["short-term-imageless", "zero-term", "zero-term-imageless"],
+        value="short-term-imageless",
+        elem_id="tracking_type",
+    )
+
     # FPS floor
     fps_floor = gr.Number(
         label="Set FPS Floor",
@@ -1010,6 +1018,7 @@ def create_interface(title: str = "Visual Pipeline and Platform Evaluation Tool"
     components.add(best_config_textbox)
     components.add(inferencing_channels)
     components.add(recording_channels)
+    components.add(tracking_type)
     components.add(fps_floor)
     components.add(ai_stream_rate)
     components.add(object_detection_model)
@@ -1424,6 +1433,8 @@ def create_interface(title: str = "Visual Pipeline and Platform Evaluation Tool"
                                     ],
                                 )
 
+                            # Render tracking_type dropdown
+                            tracking_type.render()
                             # Whether to overlay result with watermarks
                             pipeline_watermark_enabled.render()
                             # Render live_preview_enabled checkbox

--- a/tools/visual-pipeline-and-platform-evaluation-tool/pipelines/simplevs/pipeline.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/pipelines/simplevs/pipeline.py
@@ -40,7 +40,7 @@ class SimpleVideoStructurizationPipeline(GstPipeline):
             "   nireq={object_detection_nireq} ! "
             "queue ! "
             "gvatrack "
-            "  tracking-type=short-term-imageless ! "
+            "  tracking-type={tracking_type} ! "
             "queue ! "
         )
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/pipelines/smartnvr/pipeline.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/pipelines/smartnvr/pipeline.py
@@ -89,7 +89,7 @@ class SmartNVRPipeline(GstPipeline):
             "  nireq={object_detection_nireq} ! "
             "queue2 ! "
             "gvatrack "
-            "  tracking-type=short-term-imageless ! "
+            "  tracking-type={tracking_type} ! "
             "queue2 ! "
         )
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/tests/pipelines_tests/simplevs_tests/pipeline_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/tests/pipelines_tests/simplevs_tests/pipeline_test.py
@@ -26,6 +26,9 @@ class TestSimpleVideoStructurizationPipeline(unittest.TestCase):
         # Check that input is set
         self.assertIn("location=input.mp4", result)
 
+        # Check that tracking is set to short-term-imageless
+        self.assertIn("tracking-type=short-term-imageless", result)
+
         # Check that the number of inference channels is correct
         self.assertEqual(result.count("gvadetect"), self.inference_channels)
         self.assertEqual(result.count("gvaclassify"), self.inference_channels)
@@ -51,6 +54,7 @@ class TestSimpleVideoStructurizationPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": True,
                 "pipeline_video_enabled": True,
                 "live_preview_enabled": False,
@@ -98,6 +102,7 @@ class TestSimpleVideoStructurizationPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": True,
                 "pipeline_video_enabled": True,
                 "live_preview_enabled": False,
@@ -150,6 +155,7 @@ class TestSimpleVideoStructurizationPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": True,
                 "pipeline_video_enabled": True,
                 "live_preview_enabled": False,
@@ -186,6 +192,7 @@ class TestSimpleVideoStructurizationPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": False,
                 "pipeline_video_enabled": True,
                 "live_preview_enabled": False,
@@ -220,6 +227,7 @@ class TestSimpleVideoStructurizationPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": False,
                 "pipeline_video_enabled": False,
                 "live_preview_enabled": False,
@@ -254,6 +262,7 @@ class TestSimpleVideoStructurizationPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": True,
                 "pipeline_video_enabled": False,
                 "live_preview_enabled": False,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/tests/pipelines_tests/smartnvr_tests/pipeline_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/tests/pipelines_tests/smartnvr_tests/pipeline_test.py
@@ -24,6 +24,9 @@ class TestSmartNVRPipeline(unittest.TestCase):
         # Check that gst-launch-1.0 command is present
         self.assertTrue(result.startswith("gst-launch-1.0"))
 
+        # Check that tracking is set to short-term-imageless
+        self.assertIn("tracking-type=short-term-imageless", result)
+
         # Check that the number of inference channels is correct
         self.assertEqual(result.count("gvadetect"), self.inference_channels)
         self.assertEqual(result.count("gvatrack"), self.inference_channels)
@@ -63,6 +66,7 @@ class TestSmartNVRPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": False,
                 "live_preview_enabled": False,
             },
@@ -98,6 +102,7 @@ class TestSmartNVRPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": True,
                 "live_preview_enabled": False,
             },
@@ -137,6 +142,7 @@ class TestSmartNVRPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": True,
                 "live_preview_enabled": False,
             },
@@ -169,6 +175,7 @@ class TestSmartNVRPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": True,
                 "live_preview_enabled": False,
             },
@@ -208,6 +215,7 @@ class TestSmartNVRPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": True,
                 "live_preview_enabled": False,
             },
@@ -257,6 +265,7 @@ class TestSmartNVRPipeline(unittest.TestCase):
                 "object_classification_inference_interval": 1,
                 "object_classification_nireq": 0,
                 "object_classification_reclassify_interval": 1,
+                "tracking_type": "short-term-imageless",
                 "pipeline_watermark_enabled": True,
                 "live_preview_enabled": False,
             },

--- a/tools/visual-pipeline-and-platform-evaluation-tool/utils.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/utils.py
@@ -62,6 +62,7 @@ def prepare_video_and_constants(
         "object_classification_reclassify_interval", 0.0
     )
     object_classification_nireq = kwargs.get("object_classification_nireq", 1)
+    tracking_type = kwargs.get("tracking_type", "short-term-imageless")
     pipeline_watermark_enabled = kwargs.get("pipeline_watermark_enabled", True)
     pipeline_video_enabled = kwargs.get("pipeline_video_enabled", True)
     live_preview_enabled = kwargs.get("live_preview_enabled", False)
@@ -94,6 +95,7 @@ def prepare_video_and_constants(
             object_classification_reclassify_interval
         ],
         "object_classification_nireq": [object_classification_nireq],
+        "tracking_type": [tracking_type],
         "pipeline_watermark_enabled": [pipeline_watermark_enabled],
         "pipeline_video_enabled": [pipeline_video_enabled],
         "live_preview_enabled": [live_preview_enabled],


### PR DESCRIPTION
### Description

This PR adds support for the following tracking types for each pipeline:
-  zero-term        - Zero-term tracker
-  short-term-imageless - Short-term imageless tracker
-  zero-term-imageless - Zero-term imageless tracker

<img width="570" height="400" alt="image" src="https://github.com/user-attachments/assets/f8abc703-29d9-489c-a356-45b004dd386c" />
<img width="563" height="392" alt="image" src="https://github.com/user-attachments/assets/50cf84b1-8712-4434-aa69-43eb786fec76" />

### How Has This Been Tested?

Extended existing unit tests and conducted manual integration testing.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

