### PR TITLE
Enable NPU remote context and remote tensors.

### DIFF
--- a/libraries/dl-streamer/src/monolithic/gst/inference_elements/base/inference_impl.cpp
+++ b/libraries/dl-streamer/src/monolithic/gst/inference_elements/base/inference_impl.cpp
@@ -256,7 +256,7 @@ bool IsPreprocSupported(ImagePreprocessorType preproc,
     case ImagePreprocessorType::VAAPI_SYSTEM:
         return IsModelProcSupportedForVaapi(model_input_processor_info, input_video_info);
     case ImagePreprocessorType::VAAPI_SURFACE_SHARING:
-        return !isNpu && IsModelProcSupportedForVaapiSurfaceSharing(model_input_processor_info, input_video_info);
+        return IsModelProcSupportedForVaapiSurfaceSharing(model_input_processor_info, input_video_info);
     case ImagePreprocessorType::OPENCV:
         return true;
     case ImagePreprocessorType::AUTO:

--- a/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
+++ b/libraries/dl-streamer/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
@@ -1306,13 +1306,22 @@ class OpenVinoNewApiImpl {
         return _device.find("GPU") != std::string::npos;
     }
 
+    bool is_device_npu() const {
+        return _device.find("NPU") != std::string::npos;
+     }
+
     bool is_device_multi() const {
         return _device.find("MULTI") != std::string::npos;
     }
 
     dlstreamer::ContextPtr create_remote_context() {
-        // FIXME: invert to reduce nesting
-        if (is_device_gpu() && !is_device_multi() &&
+        
+        // multi device-inference does not support remote context
+        if (is_device_multi()) {
+            // do nothing, no remote context
+        }
+        // use VAAPI display context as remote GPU context
+        else if (is_device_gpu() &&
             (_memory_type == MemoryType::VAAPI || _memory_type == MemoryType::SYSTEM)) {
             if (_app_context) {
                 try {
@@ -1327,6 +1336,16 @@ class OpenVinoNewApiImpl {
                 throw std::runtime_error("Display must be provided for GPU device with vaapi-surface-sharing backend");
             }
         }
+        // use default plugin context as NPU remote context
+        else if (is_device_npu()) {
+            try {
+                _openvino_context = std::make_shared<dlstreamer::OpenVINOContext>(core(), _device);
+            } catch (std::exception &e) {
+                GVA_ERROR("Exception occurred when creating OpenVINO™ toolkit remote context: %s", e.what());
+                std::throw_with_nested(std::runtime_error("couldn't create OV remote context for NPU device"));
+            }
+        }
+
         return _openvino_context;
     }
 };


### PR DESCRIPTION
### Description

This PR creates NPU remote context by default, so pipeline can directly map VA Surfaces into NPU (remote) tensors. 

Fixes # (issue)

### Any Newly Introduced Dependencies

No new dependencies.

### How Has This Been Tested?

Validated with single benchmark pipeline, full CI run to be scheduled. 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

