### PR TITLE
[DOCS] Fixing ref issues in build for DL Streamer docs

### DIFF
--- a/libraries/dl-streamer/docs/source/conf.py
+++ b/libraries/dl-streamer/docs/source/conf.py
@@ -46,6 +46,7 @@ source_suffix = ['.rst', '.md']
 
 myst_enable_extensions = ["colon_fence"]
 myst_heading_anchors = 4
+suppress_warnings = ["myst.xref_missing"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
### Description

Suppressing warning for missing references in api docs of DL Streamer.
Porting: https://github.com/open-edge-platform/edge-ai-libraries/pull/930/commits

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

