### PR TITLE
Timeseries Analytics: Added support for Ubuntu 24.04 on iGPU usage

### DIFF
--- a/microservices/time-series-analytics/Dockerfile
+++ b/microservices/time-series-analytics/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && \
     apt-get purge -y --auto-remove && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /root/.cache/pip
 
+
 # Copy kapacitor Python UDF agent files from builder image
 COPY --from=builder /tmp/kapacitor/udf/agent/py /app/kapacitor_python
 
@@ -50,6 +51,13 @@ RUN export no_proxy= && \
     va-driver-all=\* vainfo=\* hwinfo=\* clinfo=\* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* 
+
+RUN wget -qO /etc/apt/trusted.gpg.d/intel-oneapi.asc \
+    https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB && \
+    echo "deb https://apt.repos.intel.com/oneapi all main" \
+    | tee /etc/apt/sources.list.d/intel-oneapi.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends intel-oneapi-compiler-dpcpp-cpp-runtime
 
 ARG TIMESERIES_UID
 ARG TIMESERIES_USER_NAME


### PR DESCRIPTION
### Description

Timeseries Analytics: Added support for Ubuntu 24.04 on iGPU usage

Fixes # (issue)

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

Yes

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

