### PR TITLE
[DOCS] hide toctrees in markdown files

### DIFF
--- a/libraries/dl-streamer/docs/source/architecture_2.0/architecture_2.0.md
+++ b/libraries/dl-streamer/docs/source/architecture_2.0/architecture_2.0.md
@@ -49,6 +49,7 @@ and ③ inside block **Intel® DL Streamer Pipeline Framework**
 > (some changes/renaming may occur). It could be used for evaluation and
 > prototyping, it's not recommended for production usage yet.
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 1
 
@@ -64,3 +65,4 @@ packaging
 samples_2.0
 api_ref/index
 :::
+hide_directive-->

--- a/libraries/dl-streamer/docs/source/dev_guide/advanced_install/advanced_install_guide_index.md
+++ b/libraries/dl-streamer/docs/source/dev_guide/advanced_install/advanced_install_guide_index.md
@@ -33,6 +33,7 @@
   - [Option #2: Intel® DL Streamer Pipeline Framework Docker image](./advanced_uninstall_guide.md#option-2-docker)
   - [Option #3: Compiled version](./advanced_uninstall_guide.md#option-3-compiled-version)
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 2
 :hidden:
@@ -43,3 +44,4 @@ advanced_install_guide_compilation
 advanced_build_docker_image
 advanced_uninstall_guide
 :::
+hide_directive-->

--- a/libraries/dl-streamer/docs/source/dev_guide/dev_guide_index.md
+++ b/libraries/dl-streamer/docs/source/dev_guide/dev_guide_index.md
@@ -68,6 +68,7 @@
   - [Pre-processing description (`input_preproc`)](./model_proc_file.md#pre-processing-description)
   - [Post-processing description (`output_postproc`)](./model_proc_file.md#post-processing-description-output_postproc)
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 2
 :hidden:
@@ -88,3 +89,4 @@ how_to_contribute
 latency_tracer
 model_proc_file
 :::
+hide_directive-->

--- a/libraries/dl-streamer/docs/source/dev_guide/how_to_contribute.md
+++ b/libraries/dl-streamer/docs/source/dev_guide/how_to_contribute.md
@@ -3,9 +3,11 @@
 Learn more about some
 [basic practices in the development process of DL Streamer](./coding_style.md).
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 2
 :hidden:
 
 coding_style
 :::
+hide_directive-->

--- a/libraries/dl-streamer/docs/source/dev_guide/model_preparation.md
+++ b/libraries/dl-streamer/docs/source/dev_guide/model_preparation.md
@@ -129,6 +129,7 @@ pre-processing/post-processing rules:
 gvadetect model=MODEL1_FILE_PATH.xml model-proc=MODEL1_FILE_PATH.json ! gvaclassify model=MODEL2_FILE_PATH.xml model-proc=MODEL2_FILE_PATH.json
 ```
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 2
 
@@ -136,3 +137,4 @@ yolo_models
 lvms
 download_public_models
 :::
+hide_directive-->

--- a/libraries/dl-streamer/docs/source/dev_guide/model_proc_file.md
+++ b/libraries/dl-streamer/docs/source/dev_guide/model_proc_file.md
@@ -298,8 +298,10 @@ Below is an example of `output_postproc` and its parameters:
 ...
 ```
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 2
 
 how_to_create_model_proc_file
 :::
+hide_directive-->

--- a/libraries/dl-streamer/docs/source/elements/elements.md
+++ b/libraries/dl-streamer/docs/source/elements/elements.md
@@ -29,6 +29,7 @@ gst-inspect-1.0 utility.
 | [gvarealsense](./gvarealsense.md) | Provides integration with Intel RealSense cameras, enabling video and depth stream capture for use in GStreamer pipelines. |
 | [gvawatermark](./gvawatermark.md)     | Overlays the metadata on the video frame to visualize the inference results.<br>Example:<br> gst-launch-1.0 … ! decodebin3 ! gvadetect … ! gvawatermark ! … |
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 1
 :hidden:
@@ -49,3 +50,4 @@ gvarealsense
 gvawatermark
 gstelements
 :::
+hide_directive-->

--- a/libraries/dl-streamer/docs/source/elements/gstelements.md
+++ b/libraries/dl-streamer/docs/source/elements/gstelements.md
@@ -8,9 +8,11 @@ combination with Intel® Deep Learning Streamer elements.
 | [`compositor`](./compositor.md) | The `compositor` element allows merging multiple displays into one. |
 | `timecodestamper` | The `timecodestamper` element allows attaching<br>a timecode to every incoming video frame.<br>Example:<br> gst-launch-1.0 rtspsrc location=”rtsp://root:admin_pwd@IP/axis-media/media.amp” ! rtph264depay ! h264parse ! avdec_h264 !<br>timecodestamper set=always source=rtc ! videoconvert  ! gvadetect model=$mDetect device=CPU ! queue ! gvametaconvert timestamp-utc=true json-indent=-1 !<br>gvametapublish method=mqtt file-format=json  mqtt-config=mqtt_config.json ! fakesink sync=false <br> |
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 1
 :hidden:
 
 compositor
 :::
+hide_directive-->

--- a/libraries/dl-streamer/docs/source/get_started/get_started_index.md
+++ b/libraries/dl-streamer/docs/source/get_started/get_started_index.md
@@ -18,6 +18,7 @@
 - [Samples](https://github.com/open-edge-platform/edge-ai-libraries/tree/main/libraries/dl-streamer/samples/gstreamer/README.md)
 
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 2
 :hidden:
@@ -27,3 +28,4 @@ install/install_guide_index
 tutorial
 Samples <https://github.com/open-edge-platform/edge-ai-libraries/tree/release-1.2.0/libraries/dl-streamer/samples/gstreamer/README.md>
 :::
+hide_directive-->

--- a/libraries/dl-streamer/docs/source/get_started/install/install_guide_index.md
+++ b/libraries/dl-streamer/docs/source/get_started/install/install_guide_index.md
@@ -13,6 +13,7 @@
   - [Option #1: Uninstall Intel® Deep Learning Streamer (Intel® DL Streamer) Pipeline Framework from APT repository](./uninstall_guide_ubuntu.md#option-1-uninstall-deep-learning-streamer-pipeline-framework-from-apt-repository)
   - [Option #2: Intel® DL Streamer Pipeline Framework Docker image](./uninstall_guide_ubuntu.md#option-2-remove-deep-learning-streamer-pipeline-framework-docker-image)
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 2
 :hidden:
@@ -22,3 +23,4 @@ install_guide_ubuntu_wsl2
 uninstall_guide_ubuntu
 install_guide_windows
 :::
+hide_directive-->

--- a/libraries/dl-streamer/docs/source/index.md
+++ b/libraries/dl-streamer/docs/source/index.md
@@ -116,6 +116,7 @@ AIVID TECHVISION and others.
 > **\*** *Other names and brands may be claimed as the property of
 > others.*
 
+<!--hide_directive
 :::{toctree}
 :maxdepth: 2
 :hidden:
@@ -128,3 +129,4 @@ api_ref/api_reference
 architecture_2.0/architecture_2.0
 release-notes
 :::
+hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/Overview.md
@@ -48,7 +48,7 @@
 -   [Enable Open Telemetry](./detailed_usage/how-to-advanced/enable-open-telemetry.md)
 -   [Working with other services](./detailed_usage/how-to-advanced/work-with-other-services.md)
 
-
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
@@ -60,3 +60,4 @@ detailed_usage/udf/Overview
 detailed_usage/publisher/Overview
 detailed_usage/how-to-advanced/Overview
 ```
+hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/Overview.md
@@ -3,7 +3,7 @@
     - [RTSP Cameras](#rtsp-cameras)
     <!-- - [GenICam GigE or USB3 Cameras](#eis-genicam-gige-or-usb3-cameras)
     - [USB v4l2 Cameras](#usb-v4l2-cameras) -->
-    
+
 ## Camera configurations
 Following section describes different types of camera sources that are supported by DL Streamer Pipeline Server in a DL Streamer pipeline.
 
@@ -17,9 +17,10 @@ Refer to the [doc](genicam.md) for configuration details on GigE/USB3 cameras.
 Refer to the [doc](usb.md) for configuration details on the USB cameras. To dynamically specify the USB source via REST request, refer to this [section](../rest_api/customizing_pipeline_requests.md#web-camera-source). -->
 
 
-
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
 rtsp.md
 ```
+hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/genicam.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/genicam.md
@@ -5,11 +5,11 @@
 
 For more information or configuration details for the GenICam GigE or the USB3 camera support, refer to the [GenICam GigE/USB3.0 Camera Support](./generic_plugin_doc.md).
 
-## Installation 
+## Installation
 Follow the steps for camera setup and debug tools.
 
 ### Balluff Camera
-Use Impact Acquire tool to view Balluff cameras, allied vision and other Genicam cameras such as GigE, usb basler. 
+Use Impact Acquire tool to view Balluff cameras, allied vision and other Genicam cameras such as GigE, usb basler.
 
 Install Impact Acquire tool:
 
@@ -25,17 +25,17 @@ sudo apt-get install -y libwxbase3.0-0v5 \
                       libwxgtk-webview3.0-gtk3-0v5 \
                       libwxgtk-webview3.0-gtk3-dev \
                       wx3.0-headers \
-                      libgtk2.0-dev 
+                      libgtk2.0-dev
 # download ImpactAcquire-x86_64-linux-3.1.0.sh: https://static.matrix-vision.com/mvIMPACT_Acquire/3.1.0/
 cd ~/Downloads
-chmod a+x ImpactAcquire-x86_64-linux-3.1.0.sh 
+chmod a+x ImpactAcquire-x86_64-linux-3.1.0.sh
 ./ImpactAcquire-x86_64-linux-3.1.0.sh
 ```
 
 #### to open Impact Acquire:
 ```sh
 cd /opt/ImpactAcquire/apps/ImpactControlCenter/x86_64
-./ImpactControlCenter 
+./ImpactControlCenter
 ```
 #### GUI will display
 click on Action -> Use Device --> choose mvBlueFOX3
@@ -58,7 +58,7 @@ Download and extract pylon package (minimum pylon-8.0.2) [here](https://www.basl
 ```sh
   stat /dev/bus/usb
   sudo usermod -a -G dialout $USER
-  cd /opt/pylon/share/pylon 
+  cd /opt/pylon/share/pylon
   ./setup-usb.sh
   sudo reboot
   ```
@@ -121,9 +121,11 @@ dlstreamer-pipeline-server:
 >
 > - If one observes `Feature not writable` message while working with the GenICam cameras, then reset the device using the camera software or using the reset property of the Generic Plugin. For more information, refer the [README](src-gst-gencamsrc/README.md).
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
 basler_doc.md
 generic_plugin_doc.md
 ```
+hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/configuration/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/configuration/Overview.md
@@ -5,8 +5,10 @@
 
 Refer to the details [here](./basic.md) to understand how to configure DL Streamer Pipeline Server for deploying pipelines with different parameter options that are supported.
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
 basic
 ```
+hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/file_ingestion/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/file_ingestion/Overview.md
@@ -18,6 +18,7 @@ The Image ingestion feature is responsible for ingesting the images coming from 
 ### Multifilesrc usage
 Refer this [doc](./multifilesrc_doc.md) for more details.
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
@@ -25,3 +26,4 @@ image_ingestion.md
 video_ingestion.md
 multifilesrc_doc.md
 ```
+hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/how-to-advanced/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/how-to-advanced/Overview.md
@@ -38,6 +38,7 @@ To enable Open Telemetry and capture various runtime statistics, refer this [doc
 ## Working with other services
 To learn how DL Streamer Pipeline Server interacts with other microservices such as Model Registry, refer this [doc](./work-with-other-services.md)
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
@@ -51,3 +52,4 @@ cross-stream-batching.md
 enable-open-telemetry.md
 work-with-other-services.md
 ```
+hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/publisher/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/publisher/Overview.md
@@ -9,7 +9,7 @@
 - [OPCUA Publishing](#opcua-publishing)
 - [S3 frame publishing](#s3-frame-publishing)
 
-Processed metadata/frame from the video analytics pipeline can be published to various destinations over RTSP, WebRTC, MQTT. 
+Processed metadata/frame from the video analytics pipeline can be published to various destinations over RTSP, WebRTC, MQTT.
 
 ## RTSP Streaming
 To send frames over RTSP for streaming, refer to this [doc](../rest_api/customizing_pipeline_requests.md#rtsp).
@@ -35,6 +35,7 @@ To send frames and metadata over OPC UA, refer to this [doc](opcua_publish_doc.m
 ## S3 frame publishing
 To store frames from media source and publish the metadata to MQTT, refer to this [doc](s3_frame_storage.md).
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
@@ -43,3 +44,4 @@ mqtt_publish.md
 opcua_publish_doc.md
 s3_frame_storage.md
 ```
+hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/rest_api/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/rest_api/Overview.md
@@ -26,6 +26,7 @@ Learn how to structure and set parameters for your pipelines using JSON files [h
 
 Learn how to tailor your pipeline requests to meet specific requirements [here](./customizing_pipeline_requests.md).
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
@@ -33,4 +34,4 @@ restapi_reference_guide.md
 defining_pipelines.md
 customizing_pipeline_requests.md
 ```
-   
+hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/udf/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/udf/Overview.md
@@ -62,10 +62,11 @@ To learn how to configure Geti Pallet Defect Detection UDF, refer to this [secti
 ### Add Label
 To learn how to configure Add Label UDF, refer to this [section](./configuring_udfloader.md#add-label).
 
-
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
 UDF_writing_guide.md
 configuring_udfloader.md
 ```
+hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/release_notes/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/release_notes/Overview.md
@@ -9,6 +9,7 @@
 - [September 2024](./september-2024.md)
 - [July 2024](./july-2024.md)
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
@@ -21,3 +22,4 @@ october-2024.md
 september-2024.md
 july-2024.md
 ```
+hide_directive-->

--- a/microservices/time-series-analytics/docs/user-guide/release_notes/Overview.md
+++ b/microservices/time-series-analytics/docs/user-guide/release_notes/Overview.md
@@ -2,8 +2,10 @@
 
 - [August 2025](./aug-2025.md)
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
 aug-2025.md
 ```
+hide_directive-->


### PR DESCRIPTION
### Description

Toctree RST directives hidden, no longer appear on Github docs preview - port for release-1.2.0

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

