### PR TITLE
[DOCS] Hiding eval-rst and orphan Sphinx directives

### DIFF
--- a/libraries/dl-streamer/docs/source/_doxygen/index.md
+++ b/libraries/dl-streamer/docs/source/_doxygen/index.md
@@ -1,6 +1,6 @@
----
-orphan: true
----
+<!--hide_directive```{eval-rst}
+:orphan:
+```hide_directive-->
 
 # Deep Learning Streamer (DL Streamer) API reference
 

--- a/microservices/audio-analyzer/docs/user-guide/api-reference.md
+++ b/microservices/audio-analyzer/docs/user-guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 **Version: 1.0.3**
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/openapi.yaml
-```
+```hide_directive-->

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/basler_doc.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/basler_doc.md
@@ -1,6 +1,7 @@
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 :orphan:
-```
+```hide_directive-->
+
 # Basler Camera
 
 **NOTE**:

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/generic_plugin_doc.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/generic_plugin_doc.md
@@ -1,6 +1,7 @@
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 :orphan:
-```
+```hide_directive-->
+
 # Generic Plugin
 
 Generic Plugin is a gstreamer generic source plugin that communicates and streams from a GenICam based camera which provides a GenTL producer. In order to use

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/genicam.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/genicam.md
@@ -1,6 +1,7 @@
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 :orphan:
-```
+```hide_directive-->
+
 # GenICam GigE or USB3 Cameras
 
 For more information or configuration details for the GenICam GigE or the USB3 camera support, refer to the [GenICam GigE/USB3.0 Camera Support](./generic_plugin_doc.md).

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/usb.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/camera/usb.md
@@ -1,6 +1,7 @@
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 :orphan:
-```
+```hide_directive-->
+
 # USB v4l2 Cameras
 
 - Refer the following pipeline for USB v4l2 camera and modify the appropriate config.json file in `[WORKDIR]/edge-ai-libraries/microservices/dlstreamer-pipeline-server/configs` directory.

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/configuration/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/configuration/Overview.md
@@ -1,6 +1,7 @@
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 :orphan:
-```
+```hide_directive-->
+
 # Configuration
 
 Refer to the details [here](./basic.md) to understand how to configure DL Streamer Pipeline Server for deploying pipelines with different parameter options that are supported.

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/publisher/gvapython_mqtt_publish.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/publisher/gvapython_mqtt_publish.md
@@ -1,7 +1,7 @@
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 :orphan:
-```
+```hide_directive-->
 
 # MQTT Publishing via gvapython
 
@@ -27,7 +27,7 @@ The python script `[WORKDIR]/edge-ai-libraries/microservices/dlstreamer-pipeline
 Prior to DL Streamer Pipeline Server publishing, MQTT broker and subscriber needs to be configured and started.
 
 ### Verify MQTT broker has started
-When bringing up DL Streamer Pipeline Server containers in standalone mode using `docker compose up`, MQTT broker is also started listening on port `1883`. 
+When bringing up DL Streamer Pipeline Server containers in standalone mode using `docker compose up`, MQTT broker is also started listening on port `1883`.
 Verify MQTT broker is up and running using `docker ps`.
 
 To configure and start MQTT broker refer [here](./eis_mqtt_publish_doc.md#configure-and-start-mqtt-broker)
@@ -38,9 +38,9 @@ For starting MQTT subscriber, refer [here](./eis_mqtt_publish_doc.md#start-mqtt-
 ## Configure DL Streamer Pipeline Server for MQTT Publishing
 
 ### Configuration options
-Here is a sample configuration which performs Pallet Defect Detection and publishes the inference results to mqtt broker using gvapython script. 
+Here is a sample configuration which performs Pallet Defect Detection and publishes the inference results to mqtt broker using gvapython script.
 
-```bash 
+```bash
 "pipeline": "{auto_source} name=source  ! decodebin ! videoconvert ! gvadetect name=detection ! queue ! gvawatermark ! gvametaconvert name=metaconvert ! gvapython class=MQTTPublisher function=process module=/home/pipeline-server/gvapython/mqtt_publisher/mqtt_publisher.py name=mqtt_publisher ! gvametapublish name=destination ! appsink name=appsink",
 ```
 
@@ -117,10 +117,10 @@ MQTT_HOST=<mqtt broker address>
 MQTT_PORT=1883
 ```
 
-## Secure publishing 
+## Secure publishing
 Publishing to MQTT broker could be over a secure communication channel providing encryption and authentication over TLS.
 
-Follow the steps 1, 2 and 3 from [here](./eis_mqtt_publish_doc.md#secure-publishing). 
+Follow the steps 1, 2 and 3 from [here](./eis_mqtt_publish_doc.md#secure-publishing).
 - Generate certificates
 - Configure and start MQTT broker
 - Configure and start MQTT subscriber
@@ -168,8 +168,8 @@ Upon completing the broker and subscriber setup, refer to the below steps to con
                     }
                 }
     }'
-   
+
     ```
 
 ## Error Handling
-Refer to the section [here](./eis_mqtt_publish_doc.md#error-handling) for error handling details. 
+Refer to the section [here](./eis_mqtt_publish_doc.md#error-handling) for error handling details.

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/api-reference.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/api-reference.md
@@ -1,7 +1,8 @@
 # API Reference
-**Version: 3.1.0** 
+**Version: 3.1.0**
 
 ## Markdown
-```{eval-rst}
+
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/pipeline-server.yaml
-```
+```hide_directive-->

--- a/microservices/model-registry/docs/user-guide/api-reference.md
+++ b/microservices/model-registry/docs/user-guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 **Version: 1.0.3**
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/openapi.yaml
-```
+```hide_directive-->

--- a/microservices/model-registry/docs/user-guide/how-to-build-from-source.md
+++ b/microservices/model-registry/docs/user-guide/how-to-build-from-source.md
@@ -1,6 +1,7 @@
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 :orphan:
-```
+```hide_directive-->
+
 # How to Build from Source
 
 Build the Model Registry from source to customize, debug, or extend its functionality. In this guide, you will:
@@ -30,7 +31,7 @@ This guide assumes basic familiarity with Git commands, Python virtual environme
 1. **Clone the Repository**:
     ```bash
     git clone https://github.com/{{repo-path}}.git
-    
+
     cd {{repo-name}}
     ```
 
@@ -77,7 +78,7 @@ This guide assumes basic familiarity with Git commands, Python virtual environme
     ```bash
     source .env
     ```
-    
+
 1. **Build the model registry and start the containers**
     ```bash
     docker compose build
@@ -96,7 +97,7 @@ This guide assumes basic familiarity with Git commands, Python virtual environme
      http://localhost:{{port}}/docs
      ```
    - Expected result: The microservice’s API documentation page loads successfully.
-   
+
    For more example requests and their responses, refer to the [Get Started Guide](./get-started.md#storing-a-model-in-the-registry).
 
 ## Troubleshooting
@@ -118,4 +119,4 @@ This guide assumes basic familiarity with Git commands, Python virtual environme
 * [Overview](Overview.md)
 * [System Requirements](system-requirements.md)
 * [API Reference](api-reference.md)
-* 
+*

--- a/microservices/multimodal-embedding-serving/docs/user-guide/api-reference.md
+++ b/microservices/multimodal-embedding-serving/docs/user-guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 **Version: 1.0.3**
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/openapi.yaml
-```
+```hide_directive-->

--- a/microservices/time-series-analytics/docs/user-guide/api-reference.md
+++ b/microservices/time-series-analytics/docs/user-guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 **Version: 1.0.0**
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/openapi.yaml
-```
+```hide_directive-->

--- a/microservices/visual-data-preparation-for-retrieval/vdms/docs/user-guide/api-reference.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/docs/user-guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 **Version: 1.0.3**
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/openapi.yaml
-```
+```hide_directive-->

--- a/microservices/vlm-openvino-serving/docs/user-guide/api-reference.md
+++ b/microservices/vlm-openvino-serving/docs/user-guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 **Version: 1.0.3**
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/openapi.yaml
-```
+```hide_directive-->

--- a/sample-applications/chat-question-and-answer-core/docs/user-guide/api-reference.md
+++ b/sample-applications/chat-question-and-answer-core/docs/user-guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 **Version: 1.0.3**
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/chatqna-api.yml
-```
+```hide_directive-->

--- a/sample-applications/chat-question-and-answer/docs/user-guide/api-reference.md
+++ b/sample-applications/chat-question-and-answer/docs/user-guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 **Version: 1.0.3**
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/chatqna-api.yml
-```
+```hide_directive-->

--- a/sample-applications/document-summarization/docs/user-guide/api-reference.md
+++ b/sample-applications/document-summarization/docs/user-guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 **Version: 1.0.0**
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/document-summary.yml
-```
+```hide_directive-->

--- a/sample-applications/video-search-and-summarization/docs/user-guide/api-reference.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 **Version: 1.0.3**
 
-```{eval-rst}
+<!--hide_directive```{eval-rst}
 .. swagger-plugin:: api-docs/vss-api.yaml
-```
+```hide_directive-->


### PR DESCRIPTION
### Description

Hiding the `eval-rst` and `:orphan:` Sphinx directives from preview of Markdown files. 

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

