### PR TITLE
[DLStreamer] Add self-hosted runners reboot/restart after workflow execution

### DIFF
--- a/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
+++ b/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
@@ -238,5 +238,5 @@ jobs:
     - name: Schedule reboot
       if: always()
       run: |
-        echo "Scheduling safe reboot in 15 seconds..."
-        sudo systemd-run --on-active=15s /sbin/reboot
+        echo "Scheduling reboot in 15 seconds..."
+        sudo /usr/local/bin/reboot_runner.sh 15

--- a/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
+++ b/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
@@ -234,3 +234,9 @@ jobs:
         docker rmi ${deb_img} || true
         sudo rm -f $HOME/dl-streamer
         rm -rf edge-ai-libraries-repo
+
+    - name: Schedule reboot
+      if: always()
+      run: |
+        echo "Scheduling safe reboot in 15 seconds..."
+        sudo systemd-run --on-active=15s /sbin/reboot

--- a/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
+++ b/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
@@ -238,5 +238,5 @@ jobs:
     - name: Schedule reboot
       if: always()
       run: |
-        echo "Scheduling reboot in 30 seconds..."
-        sudo /usr/local/bin/reboot_runner.sh 30
+        echo "Scheduling reboot in 15 seconds..."
+        sudo /usr/local/bin/reboot_runner.sh 15

--- a/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
+++ b/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
@@ -238,5 +238,5 @@ jobs:
     - name: Schedule reboot
       if: always()
       run: |
-        echo "Scheduling reboot in 15 seconds..."
-        sudo /usr/local/bin/reboot_runner.sh 15
+        echo "Scheduling reboot in 30 seconds..."
+        sudo /usr/local/bin/reboot_runner.sh 30

--- a/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
+++ b/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
@@ -239,4 +239,8 @@ jobs:
       if: always()
       run: |
         echo "Scheduling reboot in 15 seconds..."
-        sudo /usr/local/bin/reboot_runner.sh 15
+        if [ -x /usr/local/bin/reboot_runner.sh ]; then
+          sudo /usr/local/bin/reboot_runner.sh 15
+        else
+          echo "WARNING: /usr/local/bin/reboot_runner.sh not found or not executable. Skipping reboot."
+        fi

--- a/.github/workflows/dls-build-and-test-windows.yaml
+++ b/.github/workflows/dls-build-and-test-windows.yaml
@@ -111,3 +111,9 @@ jobs:
         if (Test-Path ${{ env.DLS_REPO_TARGET_DIRECTORY }}) {
             Remove-Item -Recurse -Force ${{ env.DLS_REPO_TARGET_DIRECTORY }}
         }
+
+    - name: Schedule reboot
+      if: always()
+      shell: powershell
+      run: |
+        Start-Job { Start-Sleep -Seconds 15; Restart-Computer -Force }

--- a/.github/workflows/dls-build-and-test-windows.yaml
+++ b/.github/workflows/dls-build-and-test-windows.yaml
@@ -116,4 +116,4 @@ jobs:
       if: always()
       shell: powershell
       run: |
-        Start-Job { Start-Sleep -Seconds 30; Restart-Computer -Force }
+        Start-Job { Start-Sleep -Seconds 15; Restart-Computer -Force }

--- a/.github/workflows/dls-build-and-test-windows.yaml
+++ b/.github/workflows/dls-build-and-test-windows.yaml
@@ -116,4 +116,4 @@ jobs:
       if: always()
       shell: powershell
       run: |
-        Start-Job { Start-Sleep -Seconds 15; Restart-Computer -Force }
+        Start-Job { Start-Sleep -Seconds 30; Restart-Computer -Force }

--- a/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
+++ b/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
@@ -158,5 +158,5 @@ jobs:
     - name: Schedule reboot
       if: always()
       run: |
-        echo "Scheduling safe reboot in 15 seconds..."
-        sudo systemd-run --on-active=15s /sbin/reboot
+        echo "Scheduling reboot in 15 seconds..."
+        sudo /usr/local/bin/reboot_runner.sh 15

--- a/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
+++ b/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
@@ -158,5 +158,5 @@ jobs:
     - name: Schedule reboot
       if: always()
       run: |
-        echo "Scheduling reboot in 30 seconds..."
-        sudo /usr/local/bin/reboot_runner.sh 30
+        echo "Scheduling reboot in 15 seconds..."
+        sudo /usr/local/bin/reboot_runner.sh 15

--- a/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
+++ b/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
@@ -158,5 +158,5 @@ jobs:
     - name: Schedule reboot
       if: always()
       run: |
-        echo "Scheduling reboot in 15 seconds..."
-        sudo /usr/local/bin/reboot_runner.sh 15
+        echo "Scheduling reboot in 30 seconds..."
+        sudo /usr/local/bin/reboot_runner.sh 30

--- a/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
+++ b/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
@@ -159,4 +159,8 @@ jobs:
       if: always()
       run: |
         echo "Scheduling reboot in 15 seconds..."
-        sudo /usr/local/bin/reboot_runner.sh 15
+        if [ -x /usr/local/bin/reboot_runner.sh ]; then
+          sudo /usr/local/bin/reboot_runner.sh 15
+        else
+          echo "WARNING: /usr/local/bin/reboot_runner.sh not found or not executable. Skipping reboot."
+        fi

--- a/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
+++ b/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
@@ -154,3 +154,9 @@ jobs:
       env:
         RESULTS_DIR: test-results
       run: sudo rm -rf ${RESULTS_DIR} edge-ai-libraries-repo
+
+    - name: Schedule reboot
+      if: always()
+      run: |
+        echo "Scheduling safe reboot in 15 seconds..."
+        sudo systemd-run --on-active=15s /sbin/reboot

--- a/.github/workflows/dls-download-models.yaml
+++ b/.github/workflows/dls-download-models.yaml
@@ -260,5 +260,5 @@ jobs:
     - name: Schedule reboot
       if: always()
       run: |
-        echo "Scheduling reboot in 30 seconds..."
-        sudo /usr/local/bin/reboot_runner.sh 30
+        echo "Scheduling reboot in 15 seconds..."
+        sudo /usr/local/bin/reboot_runner.sh 15

--- a/.github/workflows/dls-download-models.yaml
+++ b/.github/workflows/dls-download-models.yaml
@@ -256,3 +256,9 @@ jobs:
       run: |
         rm -rf edge-ai-libraries-repo .virtualenvs
         rm -rf $HOME/.virtualenvs
+
+    - name: Schedule reboot
+      if: always()
+      run: |
+        echo "Scheduling safe reboot in 15 seconds..."
+        sudo systemd-run --on-active=15s /sbin/reboot

--- a/.github/workflows/dls-download-models.yaml
+++ b/.github/workflows/dls-download-models.yaml
@@ -261,4 +261,8 @@ jobs:
       if: always()
       run: |
         echo "Scheduling reboot in 15 seconds..."
-        sudo /usr/local/bin/reboot_runner.sh 15
+        if [[ -x /usr/local/bin/reboot_runner.sh ]]; then
+          sudo /usr/local/bin/reboot_runner.sh 15
+        else
+          echo "WARNING: /usr/local/bin/reboot_runner.sh not found or not executable. Skipping reboot." >&2
+        fi

--- a/.github/workflows/dls-download-models.yaml
+++ b/.github/workflows/dls-download-models.yaml
@@ -260,5 +260,5 @@ jobs:
     - name: Schedule reboot
       if: always()
       run: |
-        echo "Scheduling safe reboot in 15 seconds..."
-        sudo systemd-run --on-active=15s /sbin/reboot
+        echo "Scheduling reboot in 15 seconds..."
+        sudo /usr/local/bin/reboot_runner.sh 15

--- a/.github/workflows/dls-download-models.yaml
+++ b/.github/workflows/dls-download-models.yaml
@@ -260,5 +260,5 @@ jobs:
     - name: Schedule reboot
       if: always()
       run: |
-        echo "Scheduling reboot in 15 seconds..."
-        sudo /usr/local/bin/reboot_runner.sh 15
+        echo "Scheduling reboot in 30 seconds..."
+        sudo /usr/local/bin/reboot_runner.sh 30


### PR DESCRIPTION
### Description

Add restarting/rebooting of self-hosted runners after workflow execution. Reboot is scheduled 15s in advance. This applies to self-hosted runners only.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

