### PR TITLE
[ViPPET] Update Dockerfiles to use the latest DLStreamer base image

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/models/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/models/Dockerfile
@@ -14,7 +14,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM intel/dlstreamer:2025.1.2-ubuntu24
+FROM intel/dlstreamer:weekly-2025.2-20251007-ubuntu24
 
 USER root
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2025.1.2-ubuntu24
+FROM intel/dlstreamer:weekly-2025.2-20251007-ubuntu24
 
 # Set environment variable to non-interactive mode (avoids some prompts)
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -14,7 +14,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM intel/dlstreamer:2025.1.2-ubuntu24 AS prod
+FROM intel/dlstreamer:weekly-2025.2-20251007-ubuntu24 AS prod
 
 USER root
 


### PR DESCRIPTION
### Description

Update Dockerfiles to use the latest DLStreamer base image: `intel/dlstreamer:weekly-2025.2-20251007-ubuntu24`

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

