### PR TITLE
[DLStreamer] Force Windows setup_dls_enc.ps1 script to be executed as admin

### DIFF
--- a/libraries/dl-streamer/docs/source/get_started/install/install_guide_windows.md
+++ b/libraries/dl-streamer/docs/source/get_started/install/install_guide_windows.md
@@ -13,7 +13,7 @@ Extract to a new folder, for example `C:\\dlstreamer_dlls`.
 
 ### Step 2: Run setup script
 
-Open a PowerShell prompt, run the following script and follow instructions:
+Open a PowerShell prompt as and administrator, run the following script and follow instructions:
 
 ```bash
 cd C:\\dlstreamer_dlls

--- a/libraries/dl-streamer/scripts/setup_dls_env.ps1
+++ b/libraries/dl-streamer/scripts/setup_dls_env.ps1
@@ -1,3 +1,4 @@
+#Requires -RunAsAdministrator
 # ==============================================================================
 # Copyright (C) 2025 Intel Corporation
 #


### PR DESCRIPTION
### Description

Creating `C:\\gstreamer` and `C:\\openvino` directories require admin access. Aligning with build_dlstreamer_dlls.ps1 script.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

