### PR TITLE
[ViPPET] Bump fastapi to 0.120.3

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/requirements.txt
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/requirements.txt
@@ -5,4 +5,4 @@ openvino==2025.1.0
 psutil==6.1.1
 pyyaml==6.0.2
 requests==2.32.4
-fastapi[standard]==0.118.0
+fastapi[standard]==0.120.3


### PR DESCRIPTION
### Description

Fixes [CVE-2025-62727](https://avd.aquasec.com/nvd/2025/cve-2025-62727/)

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

