### PR TITLE
[ViPPET] Separate pipeline description from gst invocation

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/gstpipeline.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/gstpipeline.py
@@ -73,7 +73,7 @@ class CustomGstPipeline(GstPipeline):
         launch = self._launch_string.lstrip()
         if launch.startswith("gst-launch-1.0 -q "):
             launch = launch[len("gst-launch-1.0 -q ") :]
-        return "gst-launch-1.0 -q " + (launch * inference_channels)
+        return launch * inference_channels
 
     def get_default_gst_launch(
         self,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/optimize.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/optimize.py
@@ -79,7 +79,7 @@ class PipelineOptimizer:
 
     def _run_and_collect_metrics(self, live_preview=False):
         result = run_pipeline_and_extract_metrics(
-            pipeline_cmd=self.pipeline,
+            pipeline_description=self.pipeline,
             constants=self.constants,
             parameters=self.param_grid,
             channels=(self.regular_channels, self.inference_channels),

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/simplevs/pipeline.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/simplevs/pipeline.py
@@ -243,7 +243,7 @@ class SimpleVideoStructurizationPipeline(GstPipeline):
             else:
                 streams += "fakesink "
 
-        return "gst-launch-1.0 -q " + streams
+        return streams
 
     def get_default_gst_launch(
         self,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/smartnvr/pipeline.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/smartnvr/pipeline.py
@@ -401,7 +401,7 @@ class SmartNVRPipeline(GstPipeline):
             )
 
         # Evaluate the pipeline
-        return "gst-launch-1.0 -q " + streams
+        return streams
 
     def get_default_gst_launch(
         self,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/benchmark_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/benchmark_test.py
@@ -23,7 +23,7 @@ class TestPipeline(GstPipeline):
     def evaluate(
         self, constants, parameters, regular_channels, inference_channels, elements
     ):
-        return "gst-launch-1.0 -q " + " ".join(
+        return " ".join(
             [self._pipeline.format(**parameters, **constants)]
             * (inference_channels + regular_channels)
         )

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/managers_tests/pipeline_manager_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/managers_tests/pipeline_manager_test.py
@@ -14,7 +14,7 @@ class TestPipelineManager(unittest.TestCase):
             version="test-pipeline",
             description="A test pipeline",
             type=PipelineType.GSTREAMER,
-            launch_string="gst-launch-1.0 -q filesrc location=/tmp/dummy-video.mp4 ! decodebin3 ! autovideosink",
+            launch_string="filesrc location=/tmp/dummy-video.mp4 ! decodebin3 ! autovideosink",
             parameters=None,
         )
 
@@ -37,7 +37,7 @@ class TestPipelineManager(unittest.TestCase):
             version="test-pipeline",
             description="A test pipeline",
             type=PipelineType.GSTREAMER,
-            launch_string="gst-launch-1.0 -q filesrc location=/tmp/dummy-video.mp4 ! decodebin3 ! autovideosink",
+            launch_string="filesrc location=/tmp/dummy-video.mp4 ! decodebin3 ! autovideosink",
             parameters=None,
         )
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/optimize_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/optimize_test.py
@@ -20,7 +20,7 @@ class TestPipeline(GstPipeline):
     def evaluate(
         self, constants, parameters, regular_channels, inference_channels, elements
     ):
-        return "gst-launch-1.0 -q " + " ".join(
+        return " ".join(
             [self._pipeline.format(**parameters, **constants)]
             * (inference_channels + regular_channels)
         )

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/pipelines_tests/simplevs_tests/pipeline_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/pipelines_tests/simplevs_tests/pipeline_test.py
@@ -21,8 +21,8 @@ class TestSimpleVideoStructurizationPipeline(unittest.TestCase):
         # Check if the result is a string
         self.assertIsInstance(result, str)
 
-        # Check that gst-launch-1.0 command is present
-        self.assertTrue(result.startswith("gst-launch-1.0"))
+        # Check that gst-launch-1.0 command is not present
+        self.assertFalse(result.startswith("gst-launch-1.0"))
 
         # Check that input is set
         self.assertIn("location=input.mp4", result)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/pipelines_tests/smartnvr_tests/pipeline_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/pipelines_tests/smartnvr_tests/pipeline_test.py
@@ -22,8 +22,8 @@ class TestSmartNVRPipeline(unittest.TestCase):
         # Check if the result is a string
         self.assertIsInstance(result, str)
 
-        # Check that gst-launch-1.0 command is present
-        self.assertTrue(result.startswith("gst-launch-1.0"))
+        # Check that gst-launch-1.0 command is not present
+        self.assertFalse(result.startswith("gst-launch-1.0"))
 
         # Check that tracking is set to short-term-imageless
         self.assertIn("tracking-type=short-term-imageless", result)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/utils_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/utils_test.py
@@ -137,7 +137,7 @@ class TestUtils(unittest.TestCase):
                 inference_channels,
                 elements,
             ):
-                return "gst-launch-1.0 videotestsrc ! fakesink"
+                return "videotestsrc ! fakesink"
 
         # Mock process
         process_mock = MagicMock()
@@ -193,7 +193,7 @@ class TestUtils(unittest.TestCase):
                 inference_channels,
                 elements,
             ):
-                return "gst-launch-1.0 videotestsrc ! fakesink"
+                return "videotestsrc ! fakesink"
 
         # Mock process
         process_mock = MagicMock()

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/utils.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/utils.py
@@ -289,7 +289,7 @@ def get_video_resolution(video_path):
 
 
 def run_pipeline_and_extract_metrics(
-    pipeline_cmd: GstPipeline,
+    pipeline_description: GstPipeline,
     constants: Dict[str, str],
     parameters: Dict[str, List[str]],
     channels: int | tuple[int, int] = 1,
@@ -302,7 +302,7 @@ def run_pipeline_and_extract_metrics(
     Runs a GStreamer pipeline and extracts FPS metrics.
 
     Args:
-        pipeline_cmd (str): The GStreamer pipeline command to execute.
+        pipeline_description (GstPipeline): The GStreamer pipeline description to execute.
         poll_interval (int): Interval to poll the process for metrics.
         channels (int): Number of channels to match in the FPS metrics.
 
@@ -325,7 +325,7 @@ def run_pipeline_and_extract_metrics(
         live_preview_enabled = params.get("live_preview_enabled", False)
 
         # Evaluate the pipeline with the given parameters, constants, and channels
-        _pipeline = pipeline_cmd.evaluate(
+        _pipeline = "gst-launch-1.0 -q " + pipeline_description.evaluate(
             constants, params, regular_channels, inference_channels, elements
         )
 


### PR DESCRIPTION
### Description

Separate the pipeline description from the actual command invocation, so that the `"gst-launch-1.0 -q"` prefix is only added at the point of execution, not when building pipeline descriptions.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

