### PR TITLE
[ViPPET] Force qmassa 1.0.1 install

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN cargo install --locked qmassa
+RUN cargo install --locked --git https://github.com/ulissesf/qmassa.git --tag v1.0.1
 
 FROM docker.io/library/telegraf:1.36.1 AS collector
 


### PR DESCRIPTION
### Description

Force qmassa 1.0.1 install. Version 1.0.1 has been yanked from registry. Update to recent version will be done in a separate PR.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

