### PR TITLE
[ViPPET] Set /api/v1 as API root path and regenerate vippet.json

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/generate_openapi.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/generate_openapi.py
@@ -5,4 +5,4 @@ if __name__ == "__main__":
     schema = app.openapi()
     with open("api/vippet.json", "w") as f:
         json.dump(schema, f, indent=2)
-    print("OpenAPI schema written to api/vippet.json")
+    print("OpenAPI schema written to vippet/api/vippet.json")

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/main.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/main.py
@@ -33,6 +33,12 @@ app = FastAPI(
     title="Visual Pipeline and Platform Evaluation Tool API",
     description="API for Visual Pipeline and Platform Evaluation Tool",
     version="1.0.0",
+    root_path="/api/v1",
+    # without explicitly setting servers to the same value as root_path,
+    # generating openapi schema would omit whole servers section in vippet.json
+    servers=[
+        {"url": "/api/v1"},
+    ],
 )
 
 # Include routers from different modules

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/vippet.json
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/vippet.json
@@ -5,6 +5,11 @@
     "description": "API for Visual Pipeline and Platform Evaluation Tool",
     "version": "1.0.0"
   },
+  "servers": [
+    {
+      "url": "/api/v1"
+    }
+  ],
   "paths": {
     "/pipelines": {
       "get": {
@@ -621,31 +626,6 @@
         }
       }
     },
-    "/metrics": {
-      "get": {
-        "tags": [
-          "metrics"
-        ],
-        "summary": "Get Metrics",
-        "operationId": "get_metrics",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/MetricSample"
-                  },
-                  "type": "array",
-                  "title": "Response Get Metrics"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/videos": {
       "get": {
         "tags": [
@@ -742,34 +722,6 @@
         },
         "type": "object",
         "title": "HTTPValidationError"
-      },
-      "MetricSample": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "timestamp": {
-            "type": "integer",
-            "title": "Timestamp"
-          },
-          "value": {
-            "type": "number",
-            "title": "Value"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "description",
-          "timestamp",
-          "value"
-        ],
-        "title": "MetricSample"
       },
       "Model": {
         "properties": {


### PR DESCRIPTION
## Description

This PR introduces the following changes:

- **Set API root path:**  
  The FastAPI application in `vippet/api/main.py` now explicitly sets `root_path="/api/v1"` and adds a `servers` section with `{"url": "/api/v1"}`. This ensures all API endpoints are correctly namespaced under `/api/v1` and the OpenAPI schema reflects the correct base path. More details: https://fastapi.tiangolo.com/advanced/behind-a-proxy/#proxy-with-a-stripped-path-prefix

- **OpenAPI schema update:**  
  The OpenAPI schema generated in `vippet/api/vippet.json` now includes the `servers` section, matching the root path.
