### PR TITLE
time-series-analytics: Updated Thirdparty file with licenses

### DIFF
--- a/microservices/time-series-analytics/third-party-programs.txt
+++ b/microservices/time-series-analytics/third-party-programs.txt
@@ -17,77 +17,83 @@ terms are listed below.
 ia-time-series-analytics-microservice:
 ======================================
 
-1. Base docker image: kapacitor:1.7.7
+1. Base docker image: kapacitor:1.8.2
 License-Identifier: MIT License
 
 2. requirements.txt
-License-Identifier: Apache License 2.0
 
-anyio==4.9.0
-fastapi==0.115.12
-fsspec==2025.5.1
+License-Identifier: Apache License 2.0
+dpctl==0.20.2
+fastapi==0.121.0
 influxdb==5.3.2
-joblib==1.5.1
-modin==0.32.0
+pyOpenSSL==25.3.0
+joblib==1.5.2
 numpy==2.2.6
-packaging==25.0
-pandas==2.2.3
-protobuf==4.24.4
-psutil==7.0.0
-pydantic==2.11.5
-pydantic_core==2.33.2
+protobuf==6.31.1
+pydantic==2.12.4
+pydantic_core==2.41.5
 python-dateutil==2.9.0.post0
-scikit-learn==1.6.1
 scikit-learn-intelex==2025.2.0
 scipy==1.15.3
 sortedcontainers==2.4.0
-starlette==0.46.2
+starlette==0.49.3
 threadpoolctl==3.6.0
 tomlkit==0.13.2
-typing_extensions==4.14.0
-typing-inspection==0.4.1
-tzdata==2025.2
+typing-inspection==0.4.2
+typing_extensions==4.15.0
 uvicorn==0.34.0
-watchdog==6.0.0
+anyio==4.11.0
+fastapi==0.115.12
+----------------------------------------------------------------------
 
 License-Identifier: MIT License
-
-aiofiles==24.1.0
-aiosqlite==0.21.0
-annotated-types==0.7.0
-certifi==2025.4.26
-charset-normalizer==3.4.2
-click==8.2.1
+click==8.3.1
 exceptiongroup==1.3.0
 h11==0.16.0
-idna==3.10
-msgpack==1.1.0
-requests==2.32.3
+aiofiles==25.1.0
+aiosqlite==0.21.0
+annotated-types==0.7.0
+certifi==2025.11.12
+idna==3.11
+msgpack==1.1.2
+requests==2.32.5
 six==1.17.0
 sniffio==1.3.1
-wheel==0.37.1
+urllib3==2.5.0
+charset-normalizer==3.4.4
+annotated-doc==0.0.4
+cffi==2.0.0
+----------------------------------------------------------------------
 
 License-Identifier: BSD License
-
-daal==2025.2.0
-tbb==2022.1.0
-pycparser==2.22
-pandas==2.2.3
-scikit-learn==1.6.1
-scipy==1.15.3
+pycparser==2.23
 pytz==2025.2
+scikit-learn==1.6.1
+tbb==2022.3.0
+tcmlib==1.4.1
+daal==2025.7.0
+scipy==1.15.3
+----------------------------------------------------------------------
 
 License-Identifier: LGPL-3.0
-
 asyncua==1.1.5
+----------------------------------------------------------------------
 
 License-Identifier: Apache-2.0 or BSD-3-Clause
-cryptography==45.0.4
+cryptography==46.0.3
+----------------------------------------------------------------------
 
-License-Identifier: Apache-2.0
-pyOpenSSL==25.1.0
-tcmlib==1.3.0
 
+License-Identifier: Other/Proprietary 
+License (Intel End User License Agreement for Developer Tools)
+intel-cmplr-lib-rt==2025.3.1
+intel-cmplr-lib-ur==2025.3.1
+intel-cmplr-lic-rt==2025.3.1
+intel-sycl-rt==2025.3.1
+----------------------------------------------------------------------
+
+License: Apache-2.0 with LLVM exceptions
+umf==1.0.2
 
 ---------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description
This PR updates the third-party license file for the time-series-analytics microservice to reflect updated dependency versions and their associated licenses. The changes include upgrading the base Docker image from kapacitor 1.7.7 to 1.8.2 and updating numerous Python dependencies to newer versions.

- Updated base Docker image version
- Updated Python dependency versions across multiple licenses (Apache 2.0, MIT, BSD, LGPL)
- Added new Intel proprietary license dependencies and UMF library with LLVM exceptions

Fixes # (issue)

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

Yes

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

