### PR TITLE
[DOCS] Fixing references in Vector Retriever docs for 2025.2

### DIFF
--- a/microservices/vector-retriever/milvus/docs/user-guide/index.rst
+++ b/microservices/vector-retriever/milvus/docs/user-guide/index.rst
@@ -57,6 +57,7 @@ Learn More
 
 .. toctree::
    :hidden:
-   
+
    get-started
    api-reference
+   release-notes


### PR DESCRIPTION
### Description

Adding missing reference to Release Notes for Vector Retriever docs. Porting: https://github.com/open-edge-platform/edge-ai-libraries/pull/1365

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

