### PR TITLE
[Video-Ingestion] Peace of mind: adding default values for converted model path

### DIFF
--- a/sample-applications/video-search-and-summarization/chart/subchart/video-ingestion/templates/video-ingestion-configmap.yaml
+++ b/sample-applications/video-search-and-summarization/chart/subchart/video-ingestion/templates/video-ingestion-configmap.yaml
@@ -53,7 +53,7 @@ data:
                             help="Name of the model (without extension, e.g., 'yolov8l-worldv2')")
         parser.add_argument("--model-type", type=str, 
                             help="Type of model (e.g., 'yolo_v8', 'YOLOv8-SEG')")
-        parser.add_argument("--output-dir", type=str, default='ov_models/yoloworld', 
+        parser.add_argument("--output-dir", type=str, default='/models/yoloworld/v2', 
                             help="Directory to save the converted models")
         
         args = parser.parse_args()
@@ -70,7 +70,7 @@ data:
     # Default model settings (can be overridden by environment variables)
     export OD_MODEL_NAME=${OD_MODEL_NAME}
     export OD_MODEL_TYPE=${OD_MODEL_TYPE}
-    export OD_MODEL_OUTPUT_DIR=${OD_MODEL_OUTPUT_DIR:-"/home/pipeline-server/models/yoloworld"}
+    export OD_MODEL_OUTPUT_DIR=${OD_MODEL_OUTPUT_DIR:-"/models/yoloworld/v2"}
 
     # Function to convert object detection models
     convert_object_detection_models() {

--- a/sample-applications/video-search-and-summarization/video-ingestion/resources/scripts/converter.py
+++ b/sample-applications/video-search-and-summarization/video-ingestion/resources/scripts/converter.py
@@ -48,7 +48,7 @@ def main():
                         help="Name of the model (without extension, e.g., 'yolov8l-worldv2')")
     parser.add_argument("--model-type", type=str, default='yolo_v8', 
                         help="Type of model (e.g., 'yolo_v8', 'YOLOv8-SEG')")
-    parser.add_argument("--output-dir", type=str, default='ov_models/yoloworld', 
+    parser.add_argument("--output-dir", type=str, default='ov_models/yoloworld/v2', 
                         help="Directory to save the converted models")
     
     args = parser.parse_args()


### PR DESCRIPTION
### Description

**Adding default values for model path in Video Ingestion's model converter script and relevant helm templates.**

- In case, a output-dir option is not provided to script, it should fallback properly.
- Similar changes made for script mount in helm template for configmap.


Fixes # (issue)

NA

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

NA

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

