### PR TITLE
[ViPPET] Update default GPU ID in video output configurations to 0

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/api_schemas.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/api_schemas.py
@@ -162,7 +162,7 @@ class VideoOutputConfig(BaseModel):
         default=False, description="Flag to enable or disable video output generation."
     )
     encoder_device: EncoderDeviceConfig = Field(
-        default=EncoderDeviceConfig(device_name="GPU", gpu_id=None),
+        default=EncoderDeviceConfig(device_name="GPU", gpu_id=0),
         description="Encoder device configuration (only applicable when video output is enabled).",
         examples=[{"device_name": "GPU", "gpu_id": 0}],
     )
@@ -173,7 +173,7 @@ class PerformanceTestSpec(BaseModel):
     video_output: VideoOutputConfig = Field(
         default=VideoOutputConfig(
             enabled=False,
-            encoder_device=EncoderDeviceConfig(device_name="GPU", gpu_id=None),
+            encoder_device=EncoderDeviceConfig(device_name="GPU", gpu_id=0),
         ),
         description="Video output configuration.",
         examples=[
@@ -188,7 +188,7 @@ class DensityTestSpec(BaseModel):
     video_output: VideoOutputConfig = Field(
         default=VideoOutputConfig(
             enabled=False,
-            encoder_device=EncoderDeviceConfig(device_name="GPU", gpu_id=None),
+            encoder_device=EncoderDeviceConfig(device_name="GPU", gpu_id=0),
         ),
         description="Video output configuration.",
         examples=[

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/vippet.json
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/vippet.json
@@ -1471,7 +1471,8 @@
             "default": {
               "enabled": false,
               "encoder_device": {
-                "device_name": "GPU"
+                "device_name": "GPU",
+                "gpu_id": 0
               }
             },
             "examples": [
@@ -1515,7 +1516,8 @@
             "default": {
               "enabled": false,
               "encoder_device": {
-                "device_name": "GPU"
+                "device_name": "GPU",
+                "gpu_id": 0
               }
             },
             "examples": [
@@ -2030,7 +2032,8 @@
             "default": {
               "enabled": false,
               "encoder_device": {
-                "device_name": "GPU"
+                "device_name": "GPU",
+                "gpu_id": 0
               }
             },
             "examples": [
@@ -2065,7 +2068,8 @@
             "default": {
               "enabled": false,
               "encoder_device": {
-                "device_name": "GPU"
+                "device_name": "GPU",
+                "gpu_id": 0
               }
             },
             "examples": [
@@ -2592,7 +2596,8 @@
             "$ref": "#/components/schemas/EncoderDeviceConfig",
             "description": "Encoder device configuration (only applicable when video output is enabled).",
             "default": {
-              "device_name": "GPU"
+              "device_name": "GPU",
+              "gpu_id": 0
             },
             "examples": [
               {


### PR DESCRIPTION
### Description

This pull request updates the default configuration for the video encoder device in the Python API schemas. The main change is to set the default `gpu_id` for the encoder device to `0` instead of `None` wherever the device is specified as `"GPU"`.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

