### PR TITLE
[ViPPET] Fix infinite loop in density search with high fps_floor

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/benchmark.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/benchmark.py
@@ -180,7 +180,7 @@ class Benchmark:
                 else:
                     exponential = False
                     higher_bound = n_streams
-                    lower_bound = n_streams // 2
+                    lower_bound = max(1, n_streams // 2)
                     n_streams = (lower_bound + higher_bound) // 2
             # use bisecting search for fine tune maximum number of streams
             else:


### PR DESCRIPTION
### Description

This PR fixes an infinite loop in the benchmark search algorithm in `vippet/benchmark.py` that occurs when the configured `fps_floor` is unrealistically high and no configuration can meet it.

The benchmark uses a two-phase approach:

1. **Exponential search**: double `n_streams` while per-stream FPS is above `fps_floor`.
2. **Binary search**: once per-stream FPS drops below `fps_floor`, bisect between the last "good" and "bad" stream counts to find the maximum `n_streams` that still meets `fps_floor`.

A corner case in this logic could cause the main loop to never terminate.

### Root cause

When `fps_floor` is so high that even the very first run (`n_streams = 1`) fails:

- The code switches from exponential to binary search with:
  - `higher_bound = n_streams` (1)
  - `lower_bound = n_streams // 2` (0 in the original code)
- It then computes:
  - `n_streams = (lower_bound + higher_bound) // 2` → 0
- At the end of the loop `n_streams` is clamped back to 1:

```python
if n_streams <= 0:
    n_streams = 1
```

Now we are in the binary search phase with:

- `lower_bound = 0`
- `higher_bound` in `{0, 1}`
- `n_streams` repeatedly reset to 1

Since per-stream FPS never reaches `fps_floor` for any `n_streams`:

- The bounds never progress to a state where `lower_bound > higher_bound`
- The break condition is never satisfied
- The algorithm keeps re-evaluating `n_streams = 1` indefinitely

The root problem is that the search assumes at least one configuration satisfies `fps_floor` and that the first failure happens after some success. When there is no successful configuration, the interval degenerates around 0/1 and the loop never terminates.

### Fix

The fix updates the search logic so that it always terminates, even when no configuration can meet `fps_floor`:

- Ensure `lower_bound` stays within the valid domain (`>= 1`) when switching from exponential to binary search:

```python
exponential = False
higher_bound = n_streams
lower_bound = max(1, n_streams // 2)
n_streams = (lower_bound + higher_bound) // 2
```

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

