### PR TITLE
Update VDMS image tag to v2.12.0 in values.yaml and compose.search.yaml

### DIFF
--- a/sample-applications/video-search-and-summarization/chart/subchart/vdms-vectordb/values.yaml
+++ b/sample-applications/video-search-and-summarization/chart/subchart/vdms-vectordb/values.yaml
@@ -20,7 +20,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v2.11.0"
+  tag: "v2.12.0"
 
 imagePullSecrets: []
 # This is to override the chart name.

--- a/sample-applications/video-search-and-summarization/docker/compose.search.yaml
+++ b/sample-applications/video-search-and-summarization/docker/compose.search.yaml
@@ -71,7 +71,7 @@ services:
             - vs_network
 
     vdms-vector-db:
-        image: intellabs/vdms:v2.11.0
+        image: intellabs/vdms:v2.12.0
         ipc: host
         environment:
             - OVERRIDE_db_root_path=/db


### PR DESCRIPTION
### Description

Update the VDMS vectorDB image tag to v2.12.0 in both `values.yaml` and `compose.search.yaml` to ensure the application uses the latest version.
Fixes issue in storing text embeddings in VSS unified mode helm on GPU.

### Any Newly Introduced Dependencies

No new dependencies introduced in this change.

### How Has This Been Tested?

Changes can be tested by deploying the application and verifying that the VDMS vectorDB service runs with the updated image tag.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.