### PR TITLE
Bugfix on ecatmotor and update document for robotmctask

### DIFF
--- a/libraries/edge-control-libraries/fieldbus/ecat-enablekit/examples/ecatmotor/single_motor_vel.c
+++ b/libraries/edge-control-libraries/fieldbus/ecat-enablekit/examples/ecatmotor/single_motor_vel.c
@@ -32,8 +32,6 @@
 #include <time.h>
 #include <getopt.h>
 
-#define ECAT_MULTIPLE_DOMAIN_MODE
-
 #define CYCLE_US				(1000)
 #define PERIOD_NS				(CYCLE_US*1000)
 #define NSEC_PER_SEC			(1000000000L)

--- a/libraries/edge-control-libraries/fieldbus/robotmctask/README.md
+++ b/libraries/edge-control-libraries/fieldbus/robotmctask/README.md
@@ -29,13 +29,13 @@ sudo apt-get install cmake git build-essential libyaml-cpp-dev libeigen3-dev
 3. Install plcopen-motion library:
 
 ```shell
-sudo apt-get install plcopen-motion-dev plcopen-servo-dev plcopen-ruckig-dev plcopen-databus-dev plcopen-benchmark-dev
+sudo apt-get install plcopen-motion-dev plcopen-servo-dev plcopen-ruckig-dev plcopen-databus-dev plcopen-benchmark-dev libshmringbuf-dev
 ```
 
 4. Install EtherCAT stack and ECAT-Enablekit. Note: You also can follow [Userspace EtherCAT Master Stack](../ethercat-masterstack/docs/igh_userspace.md) and [EtherCAT Enable Kit](../ecat-enablekit/README.md) to build/deploy these packages.
 
 ```shell
-sudo apt-get install ighethercat-dpdk ecat-enablekit-dpdk
+sudo apt-get install ighethercat-dpdk ecat-enablekit-dpdk libethercatd-dev
 ```
 
 5. Follow with below command to install ruckig:
@@ -47,6 +47,18 @@ mkdir -p build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make
 make install
+```
+
+6. Install OpenVINO Toolkit using APT repository. For details, visit the [OpenVINO Toolkit Overview Website](https://www.intel.com/content/www/us/en/developer/tools/openvino-toolkit/overview.html) 
+
+```shell
+sudo apt install openvino-2025.3.0
+```
+
+7. Install robot_rviz
+
+```shell
+sudo apt install ros-<ROS2 codename>-ti5-rviz
 ```
 
 # Build


### PR DESCRIPTION
### Description
ecat-enablekit:
- update ecatmotor example without multiple domain

robotmctask:
- Added libshmringbuf-dev to the plcopen library installation command
- Added libethercatd-dev to the EtherCAT stack installation command
- Added new installation steps for OpenVINO Toolkit (version 2025.3.0) and robot_rviz (ROS Humble package)

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

