### PR TITLE
update robotmctask doc to fix on typo/spell error

### DIFF
--- a/libraries/edge-control-libraries/fieldbus/robotmctask/docs/introduction.md
+++ b/libraries/edge-control-libraries/fieldbus/robotmctask/docs/introduction.md
@@ -1,7 +1,7 @@
 # Robot Motion Control Task
 ## Overview
 
-**Robotmctask** is a comprehensive C++ library designed for robot motion control task development. It provides  APIs that enable robot developers to build sophisticated robot applications with integrated AI inference engines and EtherCAT protocol support.
+**Robotmctask** is a comprehensive C++ library designed for robot motion control task development. It provides APIs that enable robot developers to build sophisticated robot applications with integrated AI inference engines and EtherCAT protocol support.
 
 # Key Features:
 
@@ -24,19 +24,19 @@ Two key blocks have been introduced to support the core architecture:
 * **libectask** is a dynamic library that provides a set of public APIs for EtherCAT real-time task creation. Key capabilities include:
     - **EtherCAT Integration:** Creates motion function blocks to operate EtherCAT slaves using ENI configurations
     - **Network Topology Support:** Handles slave configurations and network topology definitions
-    -    **Flexible Memory Management:** Supports custom shared memory callbacks for data restructuring between real-time and non-real-time domains
+    - **Flexible Memory Management:** Supports custom shared memory callbacks for data restructuring between real-time and non-real-time domains
     - **AI Pipeline Integration:** Enables AI inference callback registration within real-time tasks
 
-* **libinference** is a share library offering advanced inference capabilities with:
+* **libinference** is a shared library offering advanced inference capabilities with:
     - **Modern C++ Interface:** New C++ classes for streamlined inference implementation
-    - **Reinforcement Learning Support：** Integrated RL classes optimized for robotic applications. To facilitate quick demonstrations of code functionality, provide a stable-standing ONNX model base on real robot. This model maintains whole-body balance by controlling the lwoer limbs while the upper body performs hand movements. Such a model enables humanoid robots to remain stable through reinforcement learning when the upper limbs are engaged in VLA tasks.
+    - **Reinforcement Learning Support：** Integrated RL classes optimized for robotic applications. To facilitate quick demonstrations of code functionality, provide a stable-standing ONNX model based on real robot. This model maintains whole-body balance by controlling the lower limbs while the upper body performs hand movements. Such a model enables humanoid robots to remain stable through reinforcement learning when the upper limbs are engaged in VLA tasks.
     - **Performance Analytics:** Built-in statistical collection for performance monitoring
     - **Intel OpenVINO integration:** Default inference engine with extensible architecture
     - **Extensible Design:** Bases classes enabling custom AI model development
 
 ## Network Topology
 
-The following diagram illustrates a typical fieldbus topology for humanoid robot applications:： 
+The following diagram illustrates a typical fieldbus topology for humanoid robot applications: 
 
 <p>
     <img src="images/Humanoid_Robot_Topology.png" alt="Humanoid Robot Network Topology" title="Humanoid Robot Network Topology">
@@ -55,7 +55,7 @@ Please check [README](./../README.md) file for details.
 
 ### Examples
 
-One examples using Robot Motion Control Task are provided.
+One example using Robot Motion Control Task is provided.
 
 * [mc_rl_sample](./../examples/mc_rl_sample.cpp):
 A comprehensive demonstration showcasing:
@@ -65,7 +65,7 @@ A comprehensive demonstration showcasing:
         - Left/Right Arm Control
         - Leg control systems
     - **Dual Arm Integration:** Joint state publishing via shared memory for VLA(Vision-Language-Action) models or simulator integration
-    - **Custom Motion Algorithms:** Leg control with registred callbacks for customized motion algorithms and inference pipelines
+    - **Custom Motion Algorithms:** Leg control with registered callbacks for customized motion algorithms and inference pipelines
 
 ## License
 


### PR DESCRIPTION
### Description

This PR corrects multiple spelling and grammatical errors in the Robot Motion Control Task documentation, improving clarity and professionalism.

Key changes:

Fixed spelling errors including "share" → "shared", "lwoer" → "lower", "base" → "based", and "registred" → "registered"
Corrected grammatical issues such as "One examples" → "One example"
Removed extraneous punctuation marks


Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

