### PR TITLE
[ViPPET] Fix GPU device name check to support multiple GPU identifiers

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/video_encoder.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/video_encoder.py
@@ -153,7 +153,7 @@ class VideoEncoder:
             Selected encoder element string with properties, or None if not found
         """
         key = OTHER
-        if encoder_device.device_name == "GPU":
+        if encoder_device.device_name.startswith("GPU"):
             if encoder_device.gpu_id == 0:
                 key = GPU_0
             elif encoder_device.gpu_id is not None and encoder_device.gpu_id > 0:


### PR DESCRIPTION
### Description

This PR fixes a device name comparison issue in the ViPPET video encoder to support multiple GPU identifier formats. The change replaces an exact string match with a prefix match, allowing device names like "GPU.0", "GPU.1", etc., to be correctly identified as GPU devices.

**Key Changes:**
- Modified GPU device detection logic to use `startswith()` instead of exact equality check

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

