### PR TITLE
[DLStreamer] Disable Architecture 2.0 elements by default on Windows

### DIFF
--- a/libraries/dl-streamer/CMakeLists.txt
+++ b/libraries/dl-streamer/CMakeLists.txt
@@ -103,6 +103,7 @@ cmake_dependent_option(ENABLE_PAHO_INSTALLATION "Enables paho-mqtt3c installatio
 cmake_dependent_option(ENABLE_TESTS "Parameter to enable tests building" ON "UNIX" OFF)
 cmake_dependent_option(ENABLE_FUZZING "Parameter to enable fuzzy tests building" OFF "UNIX" OFF)
 cmake_dependent_option(ENABLE_RDKAFKA_INSTALLATION "Enables rdkafka installation" OFF "UNIX" OFF)
+cmake_dependent_option(ENABLE_ARCHITECTURE_2_0 "Enables Architecture 2.0" ON "UNIX" OFF)
 option(ENABLE_AUDIO_INFERENCE_ELEMENTS "Enables audio inference elements" ON)
 option(ENABLE_REALSENSE "Parameter to enable RelaseSense plugin compilation" OFF)
 option(ENABLE_GENAI "Enables GenAI elements" OFF)

--- a/libraries/dl-streamer/src/CMakeLists.txt
+++ b/libraries/dl-streamer/src/CMakeLists.txt
@@ -4,13 +4,24 @@
 # SPDX-License-Identifier: MIT
 # ==============================================================================
 
-add_subdirectory(base)
-add_subdirectory(cpu)
 #add_subdirectory(ffmpeg)
-add_subdirectory(gst)
-add_subdirectory(opencl)
-add_subdirectory(opencv)
-add_subdirectory(openvino)
-add_subdirectory(sycl)
 add_subdirectory(utils)
-add_subdirectory(vaapi)
+
+if(ENABLE_ARCHITECTURE_2_0)
+    # Full set of components
+    add_subdirectory(base)
+    add_subdirectory(cpu)
+    add_subdirectory(gst)
+    add_subdirectory(opencl)
+    add_subdirectory(opencv)
+    add_subdirectory(openvino)
+    add_subdirectory(sycl)
+    add_subdirectory(vaapi)
+else()
+    # Subset of components
+    add_subdirectory(base/dlstreamer_logger)
+    add_subdirectory(gst/bins/model_proc)
+    add_subdirectory(gst/metadata)
+    add_subdirectory(gst/tracers/buffer_tracer)
+    add_subdirectory(gst/tracers/latency_tracer)
+endif()

--- a/libraries/dl-streamer/src/gst/bins/model_proc/CMakeLists.txt
+++ b/libraries/dl-streamer/src/gst/bins/model_proc/CMakeLists.txt
@@ -21,11 +21,11 @@ set_compile_flags(${TARGET_NAME})
 target_include_directories(${TARGET_NAME}
 PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${GSTREAMER_INCLUDE_DIRS}
 )
 
 target_link_libraries(${TARGET_NAME}
 PUBLIC
-    dlstreamer_gst
     json-hpp
     json-schema-validator
 )

--- a/libraries/dl-streamer/src/monolithic/gst/elements/gvamotiondetect/CMakeLists.txt
+++ b/libraries/dl-streamer/src/monolithic/gst/elements/gvamotiondetect/CMakeLists.txt
@@ -52,7 +52,7 @@ target_include_directories(gstgvamotiondetect PRIVATE
   ${CMAKE_SOURCE_DIR}/thirdparty/itt/include  # restore ITT header path for ENABLE_ITT builds
 )
 
-target_link_libraries(gstgvamotiondetect PRIVATE PkgConfig::GST dlstreamer_gst dlstreamer_gst_meta gstvideoanalyticsmeta)
+target_link_libraries(gstgvamotiondetect PRIVATE PkgConfig::GST dlstreamer_gst_meta gstvideoanalyticsmeta)
 
 if(NOT MSVC)
   # VAAPI / GstVA only for non-Windows builds

--- a/libraries/dl-streamer/src/monolithic/gst/registrator/CMakeLists.txt
+++ b/libraries/dl-streamer/src/monolithic/gst/registrator/CMakeLists.txt
@@ -44,7 +44,6 @@ PRIVATE
     inference_elements
     audio_inference_elements
     gvatrack
-    gstdlstreamer_bins
     gvametapublish
 )
 


### PR DESCRIPTION
### Description
Disable deprecated Architecture 2.0 elements by default on Windows. Only build useful elements.

Result:

```
Contents of source directory (C:\dlstreamer_tmp\build\intel64\Release\bin\Release):

Mode                 LastWriteTime         Length Name                                                                 
----                 -------------         ------ ----                                                                 
-a----        17/12/2025     08:18          41472 buffer_tracer.dll                                                    
-a----        17/12/2025     08:02          16896 dl.dll                                                               
-a----        17/12/2025     08:18          18432 dlstreamer_gst_meta.dll                                              
-a----        17/12/2025     08:18         130048 draw_face_attributes.exe                                             
-a----        17/12/2025     08:18          58368 gstgvamotiondetect.dll                                               
-a----        17/12/2025     08:21        2391552 gstvideoanalytics.dll                                                
-a----        17/12/2025     08:19         231424 gvaattachroi.dll                                                     
-a----        17/12/2025     08:19         188416 gvadeskew.dll                                                        
-a----        17/12/2025     08:19         294912 gvagenai.dll                                                         
-a----        17/12/2025     08:18          35328 gvametapublish.dll                                                   
-a----        17/12/2025     08:18         182784 gvapython.dll                                                        
-a----        17/12/2025     08:19         164352 gvawatermark3d.dll                                                   
-a----        17/12/2025     08:18          27136 latency_tracer.dll                                                   
-a----        17/12/2025     08:02        2432512 opencv_calib3d4.dll                                                  
-a----        17/12/2025     08:02        3013632 opencv_core4.dll                                                     
-a----        17/12/2025     08:02         732672 opencv_features2d4.dll                                               
-a----        17/12/2025     08:02         427008 opencv_flann4.dll                                                    
-a----        17/12/2025     08:02        4549120 opencv_imgproc4.dll                                                  
-a----        17/12/2025     08:02          90112 zlib1.dll        
```

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

