### PR TITLE
[ViPPET] websocket reconnect mechanism

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/hooks/useWebSocketConnection.ts
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/hooks/useWebSocketConnection.ts
@@ -56,7 +56,7 @@ export const useWebSocketConnection = () => {
     clearReconnectTimeout();
 
     const delay = getReconnectDelay();
-    console.log(
+    console.debug(
       `Scheduling reconnection attempt ${reconnectAttemptRef.current + 1} in ${delay}ms`,
     );
 
@@ -85,7 +85,7 @@ export const useWebSocketConnection = () => {
       webSocketRef.current = ws;
 
       ws.onopen = () => {
-        console.log("WebSocket connected");
+        console.debug("WebSocket connected");
         reconnectAttemptRef.current = 0;
         dispatch(wsConnected());
       };
@@ -100,7 +100,7 @@ export const useWebSocketConnection = () => {
       };
 
       ws.onclose = (event) => {
-        console.log("WebSocket disconnected", event.code, event.reason);
+        console.debug("WebSocket disconnected", event.code, event.reason);
         dispatch(wsDisconnected());
         webSocketRef.current = null;
 


### PR DESCRIPTION
### Description

Added reconnect after unintentional socket closure. Attempts delays extends with number of unsuccessful reconnect to not exhaust browser (keeps 30s reconnect attempt at last stage).

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

