### PR TITLE
[DOCS] Vector Retriever - add missing link block

### DIFF
--- a/microservices/vector-retriever/milvus/docs/user-guide/index.md
+++ b/microservices/vector-retriever/milvus/docs/user-guide/index.md
@@ -1,5 +1,13 @@
 # Retriever Microservice
 
+<!--hide_directive
+<div class="component_card_widget">
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-libraries/tree/main/microservices/vector-retriever/milvus">
+     GitHub project
+  </a>
+</div>
+hide_directive-->
+
 Retrieves embeddings based on vector similarity. Usually it is used along with a
 `dataprep` microservice.
 


### PR DESCRIPTION
### Description

Adding missing link block to Vector Retriever - milvus, leading to the GH folder.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

