### PR TITLE
[ViPPET] Rename `validator` terminology to `gst_runner` for general pipeline execution

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/routes/pipelines.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/routes/pipelines.py
@@ -150,7 +150,7 @@ def validate_pipeline(body: schemas.PipelineValidation):
     Operation:
         * Convert the provided PipelineGraph to a GStreamer launch string.
         * Extract validation parameters (for example ``max-runtime``).
-        * Create a new validation job and run ``validator.py`` in a
+        * Create a new validation job and run ``gst_runner.py`` in a
           background thread.
         * Return the generated job id.
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/gst_runner_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/gst_runner_test.py
@@ -1,5 +1,5 @@
 """
-Unit tests for validator.py (GStreamer Pipeline Validator).
+Unit tests for gst_runner.py (GStreamer Pipeline Runner).
 
 These tests focus on the Python control flow and error handling, using
 mocking to avoid depending on real GStreamer behavior where possible.
@@ -9,7 +9,7 @@ import unittest
 from typing import Any, Tuple
 from unittest import mock
 
-import validator
+import gst_runner
 
 
 class TestParseArgs(unittest.TestCase):
@@ -17,7 +17,7 @@ class TestParseArgs(unittest.TestCase):
 
     def test_parse_args_basic(self) -> None:
         """parse_args should correctly parse max-runtime, log-level and pipeline."""
-        args = validator.parse_args(
+        args = gst_runner.parse_args(
             [
                 "--max-runtime",
                 "5",
@@ -37,17 +37,17 @@ class TestParseArgs(unittest.TestCase):
 class TestParsePipeline(unittest.TestCase):
     """Tests for the parse_pipeline helper."""
 
-    @mock.patch.object(validator, "Gst")
+    @mock.patch.object(gst_runner, "Gst")
     def test_parse_pipeline_failure(self, mock_gst: Any) -> None:
         """parse_pipeline should return (None, False) when Gst.parse_launch raises."""
         mock_gst.parse_launch.side_effect = RuntimeError("parse error")
 
-        pipeline, ok = validator.parse_pipeline("invalid pipeline ! element")
+        pipeline, ok = gst_runner.parse_pipeline("invalid pipeline ! element")
 
         self.assertIsNone(pipeline)
         self.assertFalse(ok)
 
-    @mock.patch.object(validator, "Gst")
+    @mock.patch.object(gst_runner, "Gst")
     def test_parse_pipeline_success(self, mock_gst: Any) -> None:
         """parse_pipeline should return (pipeline, True) on success when no ERROR is logged."""
         fake_pipeline = object()
@@ -56,25 +56,25 @@ class TestParsePipeline(unittest.TestCase):
         # Simulate add/remove of the temporary log handler used during parsing.
         mock_gst.debug_add_log_function.return_value = 123
 
-        pipeline, ok = validator.parse_pipeline("videotestsrc ! fakesink")
+        pipeline, ok = gst_runner.parse_pipeline("videotestsrc ! fakesink")
 
         self.assertIs(pipeline, fake_pipeline)
         self.assertTrue(ok)
         mock_gst.debug_add_log_function.assert_called_once()
         # The temporary parsing handler must be removed again afterwards.
         mock_gst.debug_remove_log_function.assert_called_with(
-            validator._parse_log_collector
+            gst_runner._parse_log_collector
         )
 
     def test_parse_pipeline_failure_on_logged_error(self) -> None:
         """_parse_log_collector should mark error_seen when an ERROR log is observed."""
         from gi.repository import Gst as RealGst  # type: ignore[import]
 
-        state = validator._ParseLogState()
+        state = gst_runner._ParseLogState()
         message = mock.Mock()
         message.get.return_value = "simulated parse error"
 
-        validator._parse_log_collector(
+        gst_runner._parse_log_collector(
             category=mock.Mock(get_name=lambda: "SIMULATED"),
             level=RealGst.DebugLevel.ERROR,
             file=None,
@@ -91,113 +91,107 @@ class TestParsePipeline(unittest.TestCase):
         )
 
 
-class TestValidatePipeline(unittest.TestCase):
-    """Tests for the validate_pipeline high-level helper."""
+class TestRunPipeline(unittest.TestCase):
+    """Tests for the run_pipeline high-level helper."""
 
-    def test_validate_pipeline_failure_on_parse(self) -> None:
-        """validate_pipeline should return False if parsing fails."""
+    def test_run_pipeline_failure_on_parse(self) -> None:
+        """run_pipeline should return False if parsing fails."""
 
         def fake_parse_pipeline(_desc: str) -> Tuple[None, bool]:
             return None, False
 
-        with mock.patch.object(validator, "parse_pipeline", fake_parse_pipeline):
+        with mock.patch.object(gst_runner, "parse_pipeline", fake_parse_pipeline):
             self.assertFalse(
-                validator.validate_pipeline("invalid pipeline", max_run_time_sec=1.0)
+                gst_runner.run_pipeline("invalid pipeline", max_run_time_sec=1.0)
             )
 
-    def test_validate_pipeline_success_on_eos(self) -> None:
-        """validate_pipeline should return True if parse and run both succeed (e.g. via EOS)."""
+    def test_run_pipeline_success_on_eos(self) -> None:
+        """run_pipeline should return True if parse and run both succeed (e.g. via EOS)."""
         fake_pipeline = object()
 
         def fake_parse_pipeline(_desc: str):
             return fake_pipeline, True
 
-        def fake_run_pipeline_for_short_validation(pipeline, max_run_time_sec):
+        def fake_run_pipeline_for_duration(pipeline, max_run_time_sec):
             self.assertIs(pipeline, fake_pipeline)
             self.assertEqual(max_run_time_sec, 2.0)
-            # True, None -> success via EOS or equivalent non-timeout completion.
+            # True, None -> success via EOS or clean completion before max-runtime.
             return True, None
 
         with (
-            mock.patch.object(validator, "parse_pipeline", fake_parse_pipeline),
+            mock.patch.object(gst_runner, "parse_pipeline", fake_parse_pipeline),
             mock.patch.object(
-                validator,
-                "run_pipeline_for_short_validation",
-                fake_run_pipeline_for_short_validation,
+                gst_runner,
+                "run_pipeline_for_duration",
+                fake_run_pipeline_for_duration,
             ),
         ):
             self.assertTrue(
-                validator.validate_pipeline(
-                    "videotestsrc ! fakesink", max_run_time_sec=2.0
-                )
+                gst_runner.run_pipeline("videotestsrc ! fakesink", max_run_time_sec=2.0)
             )
 
-    def test_validate_pipeline_success_on_timeout(self) -> None:
-        """Timeout should be treated as SUCCESS by validate_pipeline when no errors occur."""
+    def test_run_pipeline_success_on_max_runtime(self) -> None:
+        """Max-runtime should be treated as SUCCESS by run_pipeline when no errors occur."""
         fake_pipeline = object()
 
         def fake_parse_pipeline(_desc: str):
             return fake_pipeline, True
 
-        def fake_run_pipeline_for_short_validation(pipeline, max_run_time_sec):
+        def fake_run_pipeline_for_duration(pipeline, max_run_time_sec):
             self.assertIs(pipeline, fake_pipeline)
-            # True, "timeout" -> success via timeout (no error observed).
-            return True, "timeout"
+            # True, "max_runtime" -> success via max-runtime (no error observed).
+            return True, "max_runtime"
 
         with (
-            mock.patch.object(validator, "parse_pipeline", fake_parse_pipeline),
+            mock.patch.object(gst_runner, "parse_pipeline", fake_parse_pipeline),
             mock.patch.object(
-                validator,
-                "run_pipeline_for_short_validation",
-                fake_run_pipeline_for_short_validation,
+                gst_runner,
+                "run_pipeline_for_duration",
+                fake_run_pipeline_for_duration,
             ),
         ):
             self.assertTrue(
-                validator.validate_pipeline(
-                    "videotestsrc ! fakesink", max_run_time_sec=1.0
-                )
+                gst_runner.run_pipeline("videotestsrc ! fakesink", max_run_time_sec=1.0)
             )
 
-    def test_validate_pipeline_failure_on_run_error(self) -> None:
-        """validate_pipeline should return False if run_pipeline_for_short_validation fails."""
+    def test_run_pipeline_failure_on_run_error(self) -> None:
+        """run_pipeline should return False if run_pipeline_for_duration fails."""
         fake_pipeline = object()
 
         def fake_parse_pipeline(_desc: str):
             return fake_pipeline, True
 
-        def fake_run_pipeline_for_short_validation(pipeline, max_run_time_sec):
+        def fake_run_pipeline_for_duration(pipeline, max_run_time_sec):
             self.assertIs(pipeline, fake_pipeline)
             # False, "error" -> runtime error was observed.
             return False, "error"
 
         with (
-            mock.patch.object(validator, "parse_pipeline", fake_parse_pipeline),
+            mock.patch.object(gst_runner, "parse_pipeline", fake_parse_pipeline),
             mock.patch.object(
-                validator,
-                "run_pipeline_for_short_validation",
-                fake_run_pipeline_for_short_validation,
+                gst_runner,
+                "run_pipeline_for_duration",
+                fake_run_pipeline_for_duration,
             ),
         ):
             self.assertFalse(
-                validator.validate_pipeline(
-                    "videotestsrc ! fakesink", max_run_time_sec=1.0
-                )
+                gst_runner.run_pipeline("videotestsrc ! fakesink", max_run_time_sec=1.0)
             )
 
 
-class TestValidationRunner(unittest.TestCase):
-    """Tests for the internal _ValidationRunner helper."""
+class TestPipelineRunner(unittest.TestCase):
+    """Tests for the internal _PipelineRunner helper."""
 
-    def test_validation_runner_handles_bus_error(self) -> None:
-        """_ValidationRunner.run should fail when an ERROR message is seen on the bus."""
+    def test_pipeline_runner_handles_bus_error(self) -> None:
+        """_PipelineRunner.run should fail when an ERROR message is seen on the bus."""
         # Create a fake pipeline that passes isinstance(..., Gst.Pipeline).
-        fake_pipeline = mock.create_autospec(validator.Gst.Pipeline)
+        fake_pipeline = mock.create_autospec(gst_runner.Gst.Pipeline)
         fake_bus = mock.Mock()
         fake_pipeline.get_bus.return_value = fake_bus
 
         # Prepare a fake ERROR message for drain_bus_messages after the loop.
         fake_error_message = mock.Mock()
-        fake_error_message.type = validator.Gst.MessageType.ERROR
+        fake_error_message.type = gst_runner.Gst.MessageType.ERROR
 
         # parse_error() must return a (error, debug) tuple like real GStreamer.
         fake_error = mock.Mock()
@@ -209,20 +203,20 @@ class TestValidationRunner(unittest.TestCase):
 
         # get_state should eventually succeed; the exact values are not important here.
         fake_pipeline.get_state.return_value = (
-            validator.Gst.StateChangeReturn.SUCCESS,
-            validator.Gst.State.PLAYING,
-            validator.Gst.State.VOID_PENDING,
+            gst_runner.Gst.StateChangeReturn.SUCCESS,
+            gst_runner.Gst.State.PLAYING,
+            gst_runner.Gst.State.VOID_PENDING,
         )
 
         # We do not actually want to run a real GLib.MainLoop in tests; instead,
         # we patch it so that loop.run() returns immediately.
-        with mock.patch.object(validator, "GLib") as mock_glib:
+        with mock.patch.object(gst_runner, "GLib") as mock_glib:
             mock_loop = mock.Mock()
             mock_glib.MainLoop.return_value = mock_loop
 
             mock_loop.run.side_effect = lambda: None
 
-            runner = validator._ValidationRunner(fake_pipeline, max_run_time_sec=0.1)
+            runner = gst_runner._PipelineRunner(fake_pipeline, max_run_time_sec=0.1)
             ok, reason = runner.run()
 
         self.assertFalse(ok)
@@ -233,25 +227,25 @@ class TestMain(unittest.TestCase):
     """Tests for the main CLI entry point using dependency injection.
 
     We test run_application(), which lets us inject fake
-    initialize_gst_fn and validate_fn implementations. This way we can
+    initialize_gst_fn and run_fn implementations. This way we can
     fully exercise main's control flow without requiring a real GStreamer
     installation in the unit test environment.
     """
 
     def test_main_success(self) -> None:
-        """run_application should return 0 when validation succeeds."""
+        """run_application should return 0 when pipeline run succeeds."""
 
         def fake_initialize_gst() -> None:
             # No-op: pretend GStreamer initialized successfully.
             return None
 
-        def fake_validate(pipeline_description: str, max_run_time_sec: float) -> bool:
+        def fake_run(pipeline_description: str, max_run_time_sec: float) -> bool:
             # We can assert that arguments are passed correctly if we want.
             self.assertIn("videotestsrc", pipeline_description)
             self.assertEqual(max_run_time_sec, 3.0)
             return True
 
-        exit_code = validator.run_application(
+        exit_code = gst_runner.run_application(
             argv=[
                 "--max-runtime",
                 "3",
@@ -262,21 +256,21 @@ class TestMain(unittest.TestCase):
                 "fakesink",
             ],
             initialize_gst_fn=fake_initialize_gst,
-            validate_fn=fake_validate,
+            run_fn=fake_run,
         )
 
         self.assertEqual(exit_code, 0)
 
     def test_main_failure(self) -> None:
-        """run_application should return 1 when validation fails."""
+        """run_application should return 1 when pipeline run fails."""
 
         def fake_initialize_gst() -> None:
             return None
 
-        def fake_validate(_desc: str, _max_run_time_sec: float) -> bool:
+        def fake_run(_desc: str, _max_run_time_sec: float) -> bool:
             return False
 
-        exit_code = validator.run_application(
+        exit_code = gst_runner.run_application(
             argv=[
                 "--max-runtime",
                 "3",
@@ -287,21 +281,21 @@ class TestMain(unittest.TestCase):
                 "fakesink",
             ],
             initialize_gst_fn=fake_initialize_gst,
-            validate_fn=fake_validate,
+            run_fn=fake_run,
         )
 
         self.assertEqual(exit_code, 1)
 
     def test_main_internal_error(self) -> None:
-        """run_application should return 1 when validate_fn raises."""
+        """run_application should return 1 when run_fn raises."""
 
         def fake_initialize_gst() -> None:
             return None
 
-        def fake_validate(_desc: str, _max_run_time_sec: float) -> bool:
+        def fake_run(_desc: str, _max_run_time_sec: float) -> bool:
             raise RuntimeError("unexpected")
 
-        exit_code = validator.run_application(
+        exit_code = gst_runner.run_application(
             argv=[
                 "--max-runtime",
                 "3",
@@ -312,7 +306,7 @@ class TestMain(unittest.TestCase):
                 "fakesink",
             ],
             initialize_gst_fn=fake_initialize_gst,
-            validate_fn=fake_validate,
+            run_fn=fake_run,
         )
 
         self.assertEqual(exit_code, 1)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/managers_tests/validation_manager_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/managers_tests/validation_manager_test.py
@@ -90,7 +90,7 @@ class TestValidationManager(unittest.TestCase):
 
         request = self._build_validation_request(parameters=None)
 
-        # Patch _execute_validation so we do not actually spawn validator.py
+        # Patch _execute_validation so we do not actually spawn gst_runner.py
         with patch.object(manager, "_execute_validation") as mock_execute:
             job_id = manager.run_validation(request)
 
@@ -436,16 +436,16 @@ class TestValidatorRunner(unittest.TestCase):
     def test_parse_stderr_collects_only_validator_error_lines(self):
         """
         _parse_stderr should:
-          * keep only lines starting with 'validator - ERROR - ',
+          * keep only lines starting with 'gst_runner - ERROR - ',
           * strip that prefix,
           * drop empty/whitespace-only messages.
         """
         raw = "\n".join(
             [
                 "some-other-tool - INFO - hello",
-                "validator - ERROR - first error",
-                "validator - ERROR -   second error   ",
-                "validator - ERROR -    ",
+                "gst_runner - ERROR - first error",
+                "gst_runner - ERROR -   second error   ",
+                "gst_runner - ERROR -    ",
                 "completely unrelated line",
             ]
         )
@@ -461,7 +461,7 @@ class TestValidatorRunner(unittest.TestCase):
 
     def test_parse_stderr_ignores_non_prefixed_lines(self):
         """Lines without the expected prefix must be ignored."""
-        raw = "validator - INFO - not-an-error\nother - ERROR - also-ignored"
+        raw = "gst_runner - INFO - not-an-error\nother - ERROR - also-ignored"
         errors = ValidatorRunner._parse_stderr(raw)
         self.assertEqual(errors, [])
 


### PR DESCRIPTION
This PR renames functions, variables, classes, and comments throughout the codebase to reflect that `gst_runner.py` is a general-purpose GStreamer pipeline runner, not just a validation tool. The script was originally designed for pipeline validation but will be extended to support general pipeline execution in future work.

Key changes include renaming `validate_pipeline` to `run_pipeline`, `_ValidationRunner` to `_PipelineRunner`, replacing "timeout" references with "max runtime" terminology, and updating all docstrings to describe pipeline running rather than validation. The `--max-runtime` argument behavior remains unchanged and will continue to be used for both validation and general execution scenarios.

No functional changes were made - this is purely a refactoring to improve code clarity and prepare the foundation for upcoming features. All tests were updated accordingly to reflect the new terminology while maintaining the same test coverage and behavior.

