### PR TITLE
[ViPPET][UI] Update API calls to use `execution_config` instead of `video_output`

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/api/api.generated.ts
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/api/api.generated.ts
@@ -224,7 +224,7 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: `/tests/performance`,
           method: "POST",
-          body: queryArg.performanceTestSpec,
+          body: queryArg.performanceTestSpecInput,
         }),
         invalidatesTags: ["tests"],
       }),
@@ -235,7 +235,7 @@ const injectedRtkApi = api
         query: (queryArg) => ({
           url: `/tests/density`,
           method: "POST",
-          body: queryArg.densityTestSpec,
+          body: queryArg.densityTestSpecInput,
         }),
         invalidatesTags: ["tests"],
       }),
@@ -333,9 +333,9 @@ export type CreatePipelineApiResponse =
 export type CreatePipelineApiArg = {
   pipelineDefinition: PipelineDefinition;
 };
-export type ValidatePipelineApiResponse =
-  /** status 200 Successful Response */
-  any | /** status 202 Pipeline validation started */ ValidationJobResponse;
+export type ValidatePipelineApiResponse = /** status 200 Successful Response */
+  | any
+  | /** status 202 Pipeline validation started */ ValidationJobResponse;
 export type ValidatePipelineApiArg = {
   pipelineValidationInput: PipelineValidation2;
 };
@@ -355,9 +355,9 @@ export type DeletePipelineApiResponse =
 export type DeletePipelineApiArg = {
   pipelineId: string;
 };
-export type OptimizePipelineApiResponse =
-  /** status 200 Successful Response */
-  any | /** status 202 Pipeline optimization started */ OptimizationJobResponse;
+export type OptimizePipelineApiResponse = /** status 200 Successful Response */
+  | any
+  | /** status 202 Pipeline optimization started */ OptimizationJobResponse;
 export type OptimizePipelineApiArg = {
   pipelineId: string;
   pipelineRequestOptimize: PipelineRequestOptimize;
@@ -365,12 +365,12 @@ export type OptimizePipelineApiArg = {
 export type RunPerformanceTestApiResponse =
   /** status 202 Performance test job created */ TestJobResponse;
 export type RunPerformanceTestApiArg = {
-  performanceTestSpec: PerformanceTestSpec;
+  performanceTestSpecInput: PerformanceTestSpec2;
 };
 export type RunDensityTestApiResponse =
   /** status 202 Density test job created */ TestJobResponse;
 export type RunDensityTestApiArg = {
-  densityTestSpec: DensityTestSpec;
+  densityTestSpecInput: DensityTestSpec2;
 };
 export type GetVideosApiResponse =
   /** status 200 Successful Response */ Video[];
@@ -444,16 +444,22 @@ export type PerformanceJobStatus = {
     [key: string]: string[];
   } | null;
   error_message: string | null;
+  live_stream_urls: {
+    [key: string]: string;
+  } | null;
 };
-export type VideoOutputConfig = {
-  /** Flag to enable or disable video output generation. */
-  enabled?: boolean;
+export type OutputMode = "disabled" | "file" | "live_stream";
+export type ExecutionConfig = {
+  /** Mode for pipeline output generation. */
+  output_mode?: OutputMode;
+  /** Maximum runtime in seconds (0 = run until EOS, >0 = time limit with looping for live_stream/disabled). */
+  max_runtime?: number;
 };
 export type PerformanceTestSpec = {
   /** List of pipelines with number of streams for each. */
   pipeline_performance_specs: PipelinePerformanceSpec[];
-  /** Video output configuration. */
-  video_output?: VideoOutputConfig;
+  /** Execution configuration for output and runtime. */
+  execution_config?: ExecutionConfig;
 };
 export type PerformanceJobSummary = {
   id: string;
@@ -484,8 +490,8 @@ export type DensityTestSpec = {
   fps_floor: number;
   /** List of pipelines with relative stream_rate percentages that must sum to 100. */
   pipeline_density_specs: PipelineDensitySpec[];
-  /** Video output configuration. */
-  video_output?: VideoOutputConfig;
+  /** Execution configuration for output and runtime. */
+  execution_config?: ExecutionConfig;
 };
 export type DensityJobSummary = {
   id: string;
@@ -608,6 +614,20 @@ export type OptimizationJobResponse = {
 export type TestJobResponse = {
   /** Identifier of the created test job. */
   job_id: string;
+};
+export type PerformanceTestSpec2 = {
+  /** List of pipelines with number of streams for each. */
+  pipeline_performance_specs: PipelinePerformanceSpec[];
+  /** Execution configuration for output and runtime. */
+  execution_config?: ExecutionConfig;
+};
+export type DensityTestSpec2 = {
+  /** Minimum acceptable FPS per stream. */
+  fps_floor: number;
+  /** List of pipelines with relative stream_rate percentages that must sum to 100. */
+  pipeline_density_specs: PipelineDensitySpec[];
+  /** Execution configuration for output and runtime. */
+  execution_config?: ExecutionConfig;
 };
 export type Video = {
   filename: string;

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/DensityTests.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/DensityTests.tsx
@@ -151,9 +151,10 @@ const DensityTests = () => {
     setErrorMessage(null);
     try {
       const result = await runDensityTest({
-        densityTestSpec: {
-          video_output: {
-            enabled: videoOutputEnabled,
+        densityTestSpecInput: {
+          execution_config: {
+            output_mode: videoOutputEnabled ? "file" : "disabled",
+            max_runtime: 0,
           },
           fps_floor: fpsFloor,
           pipeline_density_specs: pipelineSelections.map((selection) => ({

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/PerformanceTests.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/PerformanceTests.tsx
@@ -146,9 +146,10 @@ const PerformanceTests = () => {
     setErrorMessage(null);
     try {
       const result = await runPerformanceTest({
-        performanceTestSpec: {
-          video_output: {
-            enabled: videoOutputEnabled,
+        performanceTestSpecInput: {
+          execution_config: {
+            output_mode: videoOutputEnabled ? "file" : "disabled",
+            max_runtime: 0,
           },
           pipeline_performance_specs: pipelineSelections.map((selection) => ({
             id: selection.pipelineId,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/Pipelines.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/Pipelines.tsx
@@ -424,9 +424,10 @@ const Pipelines = () => {
       }).unwrap();
 
       const response = await runPerformanceTest({
-        performanceTestSpec: {
-          video_output: {
-            enabled: videoOutputEnabled,
+        performanceTestSpecInput: {
+          execution_config: {
+            output_mode: videoOutputEnabled ? "file" : "disabled",
+            max_runtime: 0,
           },
           pipeline_performance_specs: [
             {


### PR DESCRIPTION
1. Updated UI components (`DensityTests`, `PerformanceTests`, `Pipelines`) to use the new `execution_config` API schema with `output_mode` and `max_runtime` fields instead of the deprecated `video_output` configuration.
2. Changed mutation argument names from `performanceTestSpec`/`densityTestSpec` to `performanceTestSpecInput`/`densityTestSpecInput` to match the regenerated API types.
3. Aligned frontend requests with backend changes that introduced `ExecutionConfig` for flexible output modes (`disabled`, `file`, `live_stream`) and runtime control. Note: New features like `live_stream` output mode and `max_runtime > 0` are not implemented in this PR - only the API contract compatibility is ensured.