### PR TITLE
[DLSPS] Switch latency tracer to DL Streamer latency functionality

### DIFF
--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/how-to-advanced/performance/processing-latency.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/how-to-advanced/performance/processing-latency.md
@@ -22,9 +22,9 @@ This guide will help you add environment variables to enable `GST TRACER` logs a
         volumes:
           - "/tmp:/tmp"
     ```
-   - `GST_DEBUG: "GST_TRACER:7"` indicates that GStreamer is set to log trace messages at level 7 during a pipeline's execution.
-   - `GST_TRACERS="latency(flags=pipeline+element)"` instructs GStreamer to enable the DL Streamer latency tracer. `flags=pipeline+element` specifies that the tracer should measure latency for both the entire pipeline and individual elements within it.
-   - `GST_DEBUG_FILE: /tmp/trace.log` specifies the file where the logs will be written.
+   - `GST_DEBUG=GST_TRACER:7` indicates that GStreamer is set to log trace messages at level 7 during a pipeline's execution.
+   - `GST_TRACERS=latency_tracer(flags=element+pipeline)` instructs GStreamer to enable the DL Streamer latency tracer. `flags=element+pipeline` specifies that the tracer should measure latency for both the entire pipeline and individual elements within it.
+   - `GST_DEBUG_FILE=/tmp/trace.log` specifies the file where the logs will be written.
 
 2. Start the Docker containers
     ```shell


### PR DESCRIPTION
Update the processing-latency guide to clarify the GST_TRACERS setting and replace verbose sample logs with a reference to the official DL Streamer Latency Tracer documentation. The GST_TRACERS example was changed to use `latency_tracer(flags=element+pipeline)` and the text now notes this is provided by DL Streamer, directing readers to the DL Streamer Latency Tracer docs for configuration and log interpretation. Removed large inline sample outputs and element-by-element explanations to avoid duplication and keep the guide concise.


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

