### PR TITLE
[ViPPET] Auto-detect single fakesink without explicit naming

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
@@ -489,6 +489,7 @@ class Graph:
         Raises:
             ValueError: If no fakesink is found in the graph
             ValueError: If multiple fakesinks exist without explicit naming
+            ValueError: If multiple fakesinks are named "default_output_sink"
 
         Note:
             This is used to mark the location where main output (for user viewing)
@@ -498,19 +499,29 @@ class Graph:
         modified_graph = copy.deepcopy(self)
         placeholder_created = False
 
-        # Try to find fakesink with explicit name="default_output_sink"
-        for node in modified_graph.nodes:
-            if (
-                node.type == "fakesink"
-                and node.data.get("name") == "default_output_sink"
-            ):
-                node.data.clear()
-                node.type = OUTPUT_PLACEHOLDER
-                placeholder_created = True
-                logger.debug(f"Converted node {node.id} to OUTPUT_PLACEHOLDER")
-                break
+        # Find all fakesinks with explicit name="default_output_sink"
+        named_default_sinks = [
+            node
+            for node in modified_graph.nodes
+            if node.type == "fakesink"
+            and node.data.get("name") == "default_output_sink"
+        ]
 
-        # If not found, check if there's exactly one fakesink in the graph
+        if len(named_default_sinks) > 1:
+            raise ValueError(
+                f"Found {len(named_default_sinks)} fakesink nodes with name='default_output_sink'. "
+                "Only one fakesink should be named 'default_output_sink'."
+            )
+
+        # If exactly one named default sink exists, use it
+        if len(named_default_sinks) == 1:
+            node = named_default_sinks[0]
+            node.data.clear()
+            node.type = OUTPUT_PLACEHOLDER
+            placeholder_created = True
+            logger.debug(f"Converted node {node.id} to OUTPUT_PLACEHOLDER")
+
+        # If no named default sink, check if there's exactly one fakesink in the graph
         if not placeholder_created:
             fakesink_nodes = [
                 node for node in modified_graph.nodes if node.type == "fakesink"

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/graph_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/graph_test.py
@@ -4318,6 +4318,32 @@ class TestPrepareMainOutputPlaceholder(unittest.TestCase):
         # Check that all properties are cleared
         self.assertEqual(result.nodes[2].data, {})
 
+    def test_single_named_non_default_fakesink_is_auto_selected(self):
+        """Test that single fakesink with non-default name is automatically selected."""
+        graph = Graph(
+            nodes=[
+                Node(id="0", type="filesrc", data={"location": "video.mp4"}),
+                Node(id="1", type="decodebin3", data={}),
+                Node(
+                    id="2",
+                    type="fakesink",
+                    data={"name": "my_custom_sink", "sync": "false"},
+                ),
+            ],
+            edges=[
+                Edge(id="0", source="0", target="1"),
+                Edge(id="1", source="1", target="2"),
+            ],
+        )
+
+        result = graph.prepare_main_output_placeholder()
+
+        # Check that the single fakesink is converted to OUTPUT_PLACEHOLDER
+        # even though it has a name different from "default_output_sink"
+        self.assertEqual(result.nodes[2].type, OUTPUT_PLACEHOLDER)
+        # Check that all properties including custom name are cleared
+        self.assertEqual(result.nodes[2].data, {})
+
     def test_named_fakesink_takes_precedence_over_others(self):
         """Test that named fakesink is preferred even when multiple fakesinks exist."""
         graph = Graph(
@@ -4370,6 +4396,38 @@ class TestPrepareMainOutputPlaceholder(unittest.TestCase):
 
         self.assertIn("Found 2 fakesink nodes", str(context.exception))
         self.assertIn("name=default_output_sink", str(context.exception))
+
+    def test_multiple_named_default_output_sinks_raises_error(self):
+        """Test that multiple fakesinks with name='default_output_sink' raises ValueError."""
+        graph = Graph(
+            nodes=[
+                Node(id="0", type="filesrc", data={"location": "video.mp4"}),
+                Node(id="1", type="decodebin3", data={}),
+                Node(id="2", type="tee", data={"name": "t"}),
+                Node(
+                    id="3",
+                    type="fakesink",
+                    data={"name": "default_output_sink", "sync": "false"},
+                ),
+                Node(
+                    id="4",
+                    type="fakesink",
+                    data={"name": "default_output_sink", "sync": "true"},
+                ),
+            ],
+            edges=[
+                Edge(id="0", source="0", target="1"),
+                Edge(id="1", source="1", target="2"),
+                Edge(id="2", source="2", target="3"),
+                Edge(id="3", source="2", target="4"),
+            ],
+        )
+
+        with self.assertRaises(ValueError) as context:
+            graph.prepare_main_output_placeholder()
+
+        self.assertIn("Found 2 fakesink nodes", str(context.exception))
+        self.assertIn("name='default_output_sink'", str(context.exception))
 
     def test_no_fakesink_raises_error(self):
         """Test that graph without any fakesink raises ValueError."""


### PR DESCRIPTION
### Description

This PR simplifies pipeline output configuration by automatically using a single fakesink node when present, eliminating the need for explicit `name=default_output_sink` in simple cases.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

