### PR TITLE
[NPU monitor tool] only read npu_memory_utilization on PTL+

### DIFF
--- a/tools/npu-monitor-tool/README.md
+++ b/tools/npu-monitor-tool/README.md
@@ -13,11 +13,13 @@ to track and analyze NPU performance.
 - **Power Consumption Tracking**: Monitor power usage in watts
 - **Thermal Management**: Track NPU temperature in Celsius
 - **Utilization Metrics**: View processing unit utilization percentage
-- **Memory Monitoring**: Track memory usage in MB/GB
+- **Memory Monitoring**: Track memory usage in MB/GB (PTL and later)
 - **Frequency Information**: Display operating frequency in Hz
 - **Bandwidth Analysis**: Monitor NPU DDR average bandwidth in MB/s or GB/s
 - **Tile Configuration**: View current tile configuration
 - **CSV Export**: Export metrics to CSV format for data analysis and visualization
+
+Disclaimer: The utilization percentage is a calculated metric, based on the difference in NPU busy timestamps when the inference starts and ends on NPU. It does not represent an exact hardware-level measurement. Hence, this metric is an approximation of workload and not a precise hardware utilization figure.
 
 ### Supported Platforms
 


### PR DESCRIPTION
The tool now avoids reading npu_memory_utilization 
on older platforms.

When unsupported/unavailable:

UI shows “N/A” for Memory Usage
CSV writes -1.00 for memory_usage (MB)
Also updates README to note memory monitoring is PTL+ only.


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

