### PR TITLE
Refactor MinIO command and healthcheck configuration in audio-analyzer example

### DIFF
--- a/microservices/audio-analyzer/docker/compose-minio.yaml
+++ b/microservices/audio-analyzer/docker/compose-minio.yaml
@@ -9,9 +9,12 @@ services:
     environment:
       - MINIO_ROOT_USER=${MINIO_ACCESS_KEY}
       - MINIO_ROOT_PASSWORD=${MINIO_SECRET_KEY}
-    command: server /data --console-address ":9001"
+    command: |
+      server /data 
+      --address ":9000"
+      --console-address ":9001"
     healthcheck:
-      test: [ "CMD-SHELL", "echo > /dev/tcp/127.0.0.1/80 && exit 0 || exit 1" ]
+      test: [ "CMD-SHELL", "echo > /dev/tcp/127.0.0.1/9000 && exit 0 || exit 1" ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
### Description

Minio start command in audio analyzer uses custom port 9000, as compared to port 80 in other compose files. Therefore modified the tcp check to happen on port 9000 instead of port 80.

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Tested in dev

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

