### PR TITLE
[ViPPET] Bump DLS images to `2026.0.0-ubuntu24-rc1`

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/models/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/models/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.0.0-20260217-weekly-ubuntu24
+FROM intel/dlstreamer:2026.0.0-ubuntu24-rc1
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.0.0-20260217-weekly-ubuntu24
+FROM intel/dlstreamer:2026.0.0-ubuntu24-rc1
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.0.0-20260217-weekly-ubuntu24 AS prod
+FROM intel/dlstreamer:2026.0.0-ubuntu24-rc1 AS prod
 
 # Switch to root user to install dependencies
 USER root


### PR DESCRIPTION
[ViPPET] Bump DLS images to `2026.0.0-ubuntu24-rc1`