### PR TITLE
chore: update base image for video ingestion to 2026.0.0-ubuntu24-rc1

### DIFF
--- a/sample-applications/video-search-and-summarization/video-ingestion/docker/Dockerfile
+++ b/sample-applications/video-search-and-summarization/video-ingestion/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM intel/dlstreamer-pipeline-server:2026.0.0-20260210-weekly-ubuntu24
+FROM intel/dlstreamer-pipeline-server:2026.0.0-ubuntu24-rc1
 
 COPY requirements.txt . 
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION

### Description

chore: update base image for video ingestion to 2026.0.0-ubuntu24-rc1

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Tested in dev env.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

