### PR TITLE
[ViPPET] Graceful GStreamer pipeline shutdown and logging fixes

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/gst_runner.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/gst_runner.py
@@ -24,7 +24,8 @@ The runner:
 5. Stops the pipeline when:
    - an ERROR is observed on the bus (run FAIL), OR
    - EOS is observed on the bus, OR
-   - the max-runtime elapses (if configured).
+   - the max-runtime elapses (if configured), OR
+   - SIGINT (Ctrl+C) is received.
 
 Running semantics:
 
@@ -37,17 +38,14 @@ Running semantics:
   * invalid combination of mode and max-runtime arguments.
 - Success (exit code 0):
   * the pipeline is parsed successfully AND
-  * no GStreamer ERROR appears during parsing, run, or shutdown.
-
-The script is designed to:
-
-- Be callable as a subprocess by another application.
-- Provide clear logging for diagnosing pipeline issues.
-- Be testable via dependency injection.
+  * no GStreamer ERROR appears during parsing, run, or shutdown AND
+  * the pipeline finishes via EOS, max-runtime, or SIGINT.
 """
 
 import argparse
+import gc
 import logging
+import signal
 import sys
 import threading
 import time
@@ -160,11 +158,13 @@ def gst_log_bridge(
     text = text.replace("\r", " ").replace("\n", " ")
 
     # Log only the message body, without any extra category/prefix.
-    if level >= Gst.DebugLevel.ERROR:
+    # Note: GStreamer debug levels use lower values for higher severity:
+    # ERROR=1, WARNING=2, FIXME=3, INFO=4, DEBUG=5, LOG=6, TRACE=7
+    if level <= Gst.DebugLevel.ERROR:
         logger.error("%s", text)
-    elif level >= Gst.DebugLevel.WARNING:
+    elif level <= Gst.DebugLevel.WARNING:
         logger.warning("%s", text)
-    elif level >= Gst.DebugLevel.INFO:
+    elif level <= Gst.DebugLevel.INFO:
         logger.info("%s", text)
     else:
         logger.debug("%s", text)
@@ -300,7 +300,7 @@ def _parse_log_collector(
         state: A _ParseLogState instance used to record whether an ERROR
                was observed.
     """
-    if level >= Gst.DebugLevel.ERROR:
+    if level <= Gst.DebugLevel.ERROR:
         state.error_seen = True
 
 
@@ -476,97 +476,72 @@ class _PipelineRunner:
 
         return True
 
+    def _initiate_shutdown(self, reason: str, loop: GLib.MainLoop) -> None:
+        """Initiate a graceful pipeline shutdown.
+
+        This method is safe to call from any context (thread, signal handler,
+        GLib callback). It sets the shutdown flags and quits the main loop.
+        The actual pipeline teardown (set_state(NULL)) is handled by the
+        ``run()`` method's ``finally`` block.
+
+        If shutdown has already been initiated (by max-runtime, SIGINT, or
+        a previous call), this method is a no-op.
+
+        Args:
+            reason: Human-readable reason for the shutdown (e.g. "max_runtime",
+                    "sigint").
+            loop: The GLib.MainLoop to quit.
+        """
+        if self._state.shutdown_in_progress:
+            return
+        if self._state.error_seen or self._state.eos_seen:
+            return
+
+        self._logger.info("Stopping pipeline (reason: %s).", reason)
+        self._state.shutdown_in_progress = True
+        self._state.reason = self._state.reason or reason
+
+        if reason == "max_runtime":
+            self._state.max_runtime_triggered = True
+
+        loop.quit()
+
     def _max_runtime_enforcement_thread(self, loop: GLib.MainLoop):
         """Thread that enforces the maximum pipeline runtime.
 
         After `max_run_time_sec` seconds, this thread initiates a graceful
-        shutdown by:
+        shutdown by calling _initiate_shutdown(), which quits the GLib main
+        loop. The actual pipeline teardown (set_state(NULL)) is handled by
+        the ``run()`` method's ``finally`` block.
 
-        1. Pausing the pipeline to stop source elements from producing
-           new data.
-        2. Flushing the entire pipeline (FLUSH_START + FLUSH_STOP) to
-           discard all internally buffered data in every element — not
-           just queue elements, but also decoders, inference elements,
-           and trackers.
-        3. Resuming the pipeline (PLAYING) and sending an EOS event.
-           Since all internal buffers have been flushed, the EOS
-           propagates through the pipeline almost instantly.
+        The shutdown approach mimics what gst-launch-1.0 does when it
+        receives SIGINT (Ctrl+C): transition directly to NULL without
+        sending EOS. Sending EOS is deliberately avoided because with
+        looping sources (e.g. multifilesrc loop=true), EOS must propagate
+        through all inference elements (gvadetect, gvaclassify, gvatrack)
+        which continue processing buffered frames, causing unacceptable
+        delays.
 
-        This ensures that elements like gvafpscounter still receive
-        the EOS event and can emit their final summary, while avoiding
-        the delay caused by processing hundreds of buffered frames.
-
-        If the pipeline does not reach EOS within the grace period,
-        it is forcefully stopped.
+        Elements like gvafpscounter emit their "FpsCounter(overall ...)"
+        summary during GObject element finalization (C destructor), which
+        happens when the pipeline object's reference count drops to zero.
+        This is triggered by ``del pipeline`` + ``gc.collect()`` in
+        ``run_pipeline()``.
         """
-        eos_grace_period_sec = 2.0
-
         time.sleep(self._max_run_time_sec)
+        self._initiate_shutdown("max_runtime", loop)
 
-        # If an ERROR or EOS already terminated the run, do nothing.
-        if self._state.error_seen or self._state.eos_seen:
-            return
+    def _on_sigint(self, loop: GLib.MainLoop) -> bool:
+        """GLib idle callback scheduled by the SIGINT signal handler.
 
-        self._logger.info(
-            "Max runtime (%.1f s) elapsed; initiating graceful shutdown.",
-            self._max_run_time_sec,
-        )
-        self._state.max_runtime_triggered = True
-        self._state.shutdown_in_progress = True
-        self._state.reason = self._state.reason or "max_runtime"
+        This runs inside the GLib main loop context (via GLib.idle_add),
+        which is safe for calling loop.quit().
 
-        # Step 1: Pause the pipeline to stop sources from producing
-        # new buffers.
-        self._logger.debug("Pausing pipeline to stop data production.")
-        self._pipeline.set_state(Gst.State.PAUSED)
-        self._pipeline.get_state(2 * Gst.SECOND)
-
-        # Step 2: Flush the entire pipeline. FLUSH_START discards all
-        # data buffered internally in every element (decoders, inference
-        # elements, queues, trackers, etc.). FLUSH_STOP resets the
-        # pipeline's streaming state so it can accept the subsequent
-        # EOS event normally.
-        self._logger.debug("Flushing pipeline to discard all internally buffered data.")
-        self._pipeline.send_event(Gst.Event.new_flush_start())
-        self._pipeline.send_event(Gst.Event.new_flush_stop(True))
-
-        # Step 3: Resume the pipeline and send EOS. The pipeline is now
-        # empty — no queued frames to process — so EOS will propagate
-        # through to the sink almost immediately, triggering summary
-        # output from elements like gvafpscounter along the way.
-        self._logger.debug("Resuming pipeline and sending EOS.")
-        self._pipeline.set_state(Gst.State.PLAYING)
-
-        eos_sent = self._pipeline.send_event(Gst.Event.new_eos())
-        if not eos_sent:
-            self._logger.warning(
-                "Failed to send EOS event to pipeline; forcing shutdown."
-            )
-            try:
-                self._pipeline.set_state(Gst.State.NULL)
-            except Exception as exc:  # noqa: BLE001
-                self._logger.warning("Error while force-stopping pipeline: %r", exc)
-            loop.quit()
-            return
-
-        # Step 4: Wait briefly for EOS to arrive on the bus. With a
-        # fully flushed pipeline this should take well under a second.
-        time.sleep(eos_grace_period_sec)
-
-        if not self._state.eos_seen and not self._state.error_seen:
-            self._logger.warning(
-                "Pipeline did not reach EOS within %.1f s grace period; "
-                "forcing shutdown.",
-                eos_grace_period_sec,
-            )
-            try:
-                self._pipeline.set_state(Gst.State.NULL)
-            except Exception as exc:  # noqa: BLE001
-                self._logger.warning(
-                    "Error while force-stopping pipeline after grace period: %r",
-                    exc,
-                )
-            loop.quit()
+        Returns:
+            GLib.SOURCE_REMOVE so the idle source is not called again.
+        """
+        self._initiate_shutdown("sigint", loop)
+        return GLib.SOURCE_REMOVE
 
     def run(self) -> Tuple[bool, Optional[str]]:
         """Run the pipeline and return (ok, reason).
@@ -580,18 +555,26 @@ class _PipelineRunner:
            to log the initial state-change outcome.
         5. If max-runtime > 0, start a background thread that will trigger when
            max_run_time_sec elapses.
-        6. Run the GLib.MainLoop until:
+        6. Install a Python-level SIGINT handler that schedules a graceful
+           shutdown via GLib.idle_add().
+        7. Run the GLib.MainLoop until:
              - ERROR on the bus, OR
              - EOS on the bus, OR
-             - the max-runtime enforcement thread calls loop.quit().
-        7. After the loop exits, stop the pipeline, remove the bus watch,
-           drain any remaining bus messages for logging, and derive the
-           final result from _RunState.
+             - the max-runtime enforcement thread calls loop.quit(), OR
+             - SIGINT (Ctrl+C) triggers a graceful shutdown.
+        8. After the loop exits:
+             a. Restore the original SIGINT handler.
+             b. Disconnect the bus signal handler and remove the signal
+                watch to break reference cycles (needed for GObject
+                element finalization by Python's GC).
+             c. Transition the pipeline to NULL.
+             d. Drain any remaining bus messages for logging.
+        9. Derive the final result from _RunState.
 
         Returns:
             (True, None)
-                if the pipeline ran successfully (EOS or clean run before
-                max-runtime, and no errors on the bus).
+                if the pipeline ran successfully (EOS, SIGINT, or clean run
+                before max-runtime, and no errors on the bus).
             (True, "max_runtime")
                 if the pipeline was stopped at max-runtime with no errors
                 observed during run or shutdown.
@@ -603,15 +586,13 @@ class _PipelineRunner:
 
         # Attach bus watch and connect handler.
         bus.add_signal_watch()
-        bus.connect("message", self._on_bus_message, loop)
+        handler_id = bus.connect("message", self._on_bus_message, loop)
 
         # Request PLAYING state.
         ret = self._pipeline.set_state(Gst.State.PLAYING)
         self._logger.debug("Requested pipeline state PLAYING, result: %s", ret)
 
         # Wait for initial state change (for logging only).
-        # This does not control the run outcome directly; runtime errors
-        # are still detected via bus messages and the max-runtime enforcement thread.
         state_change_ret, current_state, pending = self._pipeline.get_state(
             5 * Gst.SECOND,
         )
@@ -632,24 +613,54 @@ class _PipelineRunner:
             )
             max_runtime_thread.start()
 
+        # Install a Python-level SIGINT handler that schedules a graceful
+        # shutdown on the GLib main loop via GLib.idle_add().
+        #
+        # We use Python's signal.signal() instead of GLib.unix_signal_add()
+        # because the latter does not work reliably when Python's signal
+        # handling infrastructure is active — Python intercepts the signal
+        # at the C level before GLib's pipe/eventfd mechanism can see it.
+        #
+        # GLib.idle_add() is thread-safe and main-loop-safe, so calling it
+        # from a Python signal handler (which runs in the main thread
+        # between bytecode instructions) is correct.
+        original_sigint_handler = signal.getsignal(signal.SIGINT)
+
+        def _sigint_handler(signum, frame):
+            GLib.idle_add(self._on_sigint, loop)
+
+        signal.signal(signal.SIGINT, _sigint_handler)
+
         # Run main loop until:
         #   - ERROR (bus handler quits loop),
         #   - EOS (bus handler quits loop),
-        #   - max-runtime enforcement thread quits loop (if configured).
+        #   - max-runtime enforcement thread quits loop (if configured),
+        #   - SIGINT (Ctrl+C) handler quits loop.
         try:
             loop.run()
         finally:
-            # Ensure we always stop the pipeline and clean up the bus watch.
+            # Restore the original SIGINT handler.
+            signal.signal(signal.SIGINT, original_sigint_handler)
+
+            # Disconnect the bus signal handler and remove the signal watch
+            # BEFORE setting state to NULL. This breaks the reference cycle
+            # between the bus, the signal handler closure, and the pipeline,
+            # which is essential for Python's GC to later destroy the
+            # pipeline object and trigger C-level element finalizers.
+            try:
+                bus.disconnect(handler_id)
+            except Exception:  # noqa: BLE001
+                pass
+            bus.remove_signal_watch()
+
+            # Transition to NULL. This stops all elements.
             try:
                 self._pipeline.set_state(Gst.State.NULL)
             except Exception as exc:  # noqa: BLE001
                 self._logger.warning("Error while stopping pipeline after run: %r", exc)
-            bus.remove_signal_watch()
 
         # Drain any remaining messages for logging purposes.
         if drain_bus_messages(bus, self._logger):
-            # If we see an ERROR here and no reason was recorded yet,
-            # treat it as an error.
             if not self._state.error_seen:
                 self._state.error_seen = True
                 self._state.reason = self._state.reason or "error"
@@ -659,7 +670,7 @@ class _PipelineRunner:
             return False, "error"
         if self._state.max_runtime_triggered and not self._state.error_seen:
             return True, "max_runtime"
-        # EOS or normal stop without errors.
+        # EOS, SIGINT, or normal stop without errors.
         return True, None
 
 
@@ -753,6 +764,17 @@ def run_pipeline(
             pipeline.set_state(Gst.State.NULL)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Error while cleaning up pipeline: %r", exc)
+
+        # Explicitly delete the pipeline reference and force garbage
+        # collection so that GObject element finalizers run immediately.
+        # This is critical because elements like gvafpscounter emit their
+        # "FpsCounter(overall ...)" summary during GObject finalization
+        # (element disposal/destroy), NOT during EOS or state change to
+        # NULL.  In gst-launch-1.0, this happens during "Freeing pipeline".
+        # Without this, the Python GstPipeline wrapper prevents the C
+        # object from being finalized, and the summary never appears.
+        del pipeline
+        gc.collect()
 
     if not run_ok:
         logger.error(

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipeline_runner.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipeline_runner.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import select
+import signal
 import subprocess
 import sys
 import time
@@ -171,6 +172,8 @@ class PipelineRunner:
             "validation",
             "--max-runtime",
             str(self.max_runtime),
+            "--log-level",
+            self._get_log_level(),
             pipeline_command,
         ]
 
@@ -198,7 +201,7 @@ class PipelineRunner:
                 "gst_runner.py timed out after %s seconds, killing process",
                 self.hard_timeout,
             )
-            proc.kill()
+            self._graceful_terminate(proc)
             stdout, stderr = proc.communicate()
             errors = self._parse_validation_stderr(stderr)
             errors.append(
@@ -286,6 +289,8 @@ class PipelineRunner:
             "normal",
             "--max-runtime",
             str(self.max_runtime),
+            "--log-level",
+            self._get_log_level(),
             pipeline_command,
         ]
 
@@ -317,8 +322,10 @@ class PipelineRunner:
             # Poll the process to check if it is still running
             while process.poll() is None:
                 if self.cancelled:
-                    process.terminate()
-                    self.logger.info("Process cancelled, terminating")
+                    self._graceful_terminate(process)
+                    self.logger.info(
+                        "Process cancelled, sent SIGINT for graceful shutdown"
+                    )
                     break
 
                 reads, _, _ = select.select(
@@ -385,15 +392,7 @@ class PipelineRunner:
                         "terminating pipeline as potentially hung",
                         self.inactivity_timeout,
                     )
-                    process.terminate()
-                    try:
-                        process.wait(timeout=5)
-                    except Exception:
-                        self.logger.warning(
-                            "Process did not terminate gracefully after inactivity; killing it"
-                        )
-                        process.kill()
-                        process.wait()
+                    self._graceful_terminate(process, timeout=5.0)
 
                     raise RuntimeError(
                         f"Pipeline execution terminated due to inactivity timeout "
@@ -534,3 +533,31 @@ class PipelineRunner:
     def is_cancelled(self) -> bool:
         """Check if the pipeline run has been cancelled."""
         return self.cancelled
+
+    @staticmethod
+    def _get_log_level() -> str:
+        """Get the log level string from LOG_LEVEL env var, defaulting to INFO."""
+        level = os.environ.get("LOG_LEVEL", "INFO").upper()
+        valid_levels = ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG")
+        if level not in valid_levels:
+            return "INFO"
+        return level
+
+    @staticmethod
+    def _graceful_terminate(proc: subprocess.Popen, timeout: float = 10.0) -> None:
+        """Send SIGINT for graceful shutdown, fall back to SIGKILL.
+
+        Args:
+            proc: The subprocess to terminate.
+            timeout: Seconds to wait after SIGINT before sending SIGKILL.
+        """
+        if proc.poll() is not None:
+            return
+        try:
+            proc.send_signal(signal.SIGINT)
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        except OSError:
+            pass

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/pipeline_runner_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/pipeline_runner_test.py
@@ -1,4 +1,5 @@
 import itertools
+import signal
 import sys
 import unittest
 from unittest.mock import MagicMock, patch, mock_open
@@ -68,7 +69,9 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
         self.assertEqual(cmd[3], "normal")
         self.assertEqual(cmd[4], "--max-runtime")
         self.assertEqual(cmd[5], "0")
-        self.assertEqual(cmd[6], self.test_pipeline_command)
+        self.assertEqual(cmd[6], "--log-level")
+        self.assertIn(cmd[7], ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"))
+        self.assertEqual(cmd[8], self.test_pipeline_command)
 
         # Verify FPS extraction with type narrowing
         assert isinstance(result, PipelineRunResult)  # Type narrowing
@@ -85,8 +88,11 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
 
         # Mock process
         process_mock = MagicMock()
-        process_mock.poll.side_effect = [None]
-        process_mock.wait.return_value = -1
+        # First poll() returns None (main loop check: process running),
+        # second poll() returns None (_graceful_terminate check: still running,
+        # so it sends SIGINT and waits).
+        process_mock.poll.side_effect = [None, None]
+        process_mock.wait.return_value = 0
         mock_popen.return_value = process_mock
 
         runner = PipelineRunner(mode="normal", max_runtime=0)
@@ -103,6 +109,9 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
         self.assertEqual(result.per_stream_fps, expected_result.per_stream_fps)
         self.assertEqual(result.num_streams, expected_result.num_streams)
 
+        # Verify SIGINT was sent for graceful shutdown
+        process_mock.send_signal.assert_called_once_with(signal.SIGINT)
+
     @patch("pipeline_runner.Popen")
     @patch("pipeline_runner.select.select")
     def test_pipeline_hang_raises_runtime_error(self, mock_select, mock_popen):
@@ -116,8 +125,9 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
         )
 
         process_mock = MagicMock()
-        # Process keeps running (poll() always returns None).
-        process_mock.poll.return_value = None
+        # First poll() returns None (main loop: process running),
+        # second poll() returns None (_graceful_terminate: still running).
+        process_mock.poll.side_effect = [None, None]
         process_mock.stdout = MagicMock()
         process_mock.stderr = MagicMock()
         # No data available on stdout/stderr, select returns no readable fds.
@@ -244,7 +254,9 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
         )
 
         process_mock = MagicMock()
-        process_mock.poll.return_value = None
+        # First poll() returns None (main loop: process running),
+        # second poll() returns None (_graceful_terminate: still running).
+        process_mock.poll.side_effect = [None, None]
         process_mock.stdout = MagicMock()
         process_mock.stderr = MagicMock()
         mock_select.return_value = ([], [], [])
@@ -273,8 +285,10 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
     def test_stop_pipeline_writes_zero_fps(self, mock_open_file, mock_popen):
         """PipelineRunner should write 0.0 to FPS file when cancelled."""
         process_mock = MagicMock()
-        process_mock.poll.side_effect = [None]
-        process_mock.wait.return_value = -1
+        # First poll() returns None (main loop: process running),
+        # second poll() returns None (_graceful_terminate: still running).
+        process_mock.poll.side_effect = [None, None]
+        process_mock.wait.return_value = 0
         process_mock.stdout.fileno.return_value = 10
         process_mock.stderr.fileno.return_value = 11
         mock_popen.return_value = process_mock
@@ -370,25 +384,17 @@ class TestPipelineRunnerValidationMode(unittest.TestCase):
     def test_run_validation_timeout(self, mock_popen):
         """PipelineRunner in validation mode should handle timeout gracefully."""
         process_mock = MagicMock()
-        process_mock.communicate.side_effect = [
-            __import__("subprocess").TimeoutExpired("gst_runner.py", 70)
-        ]
-        process_mock.communicate.side_effect = lambda timeout: (
-            (_ for _ in ()).throw(
-                __import__("subprocess").TimeoutExpired("gst_runner.py", timeout)
-            )
-            if timeout
-            else ("", "")
-        )
 
-        # After kill, second communicate returns empty
         def communicate_with_timeout(timeout=None):
             if timeout:
                 raise __import__("subprocess").TimeoutExpired("gst_runner.py", timeout)
-            return ("", "")
+            return "", ""
 
         process_mock.communicate = communicate_with_timeout
-        process_mock.returncode = -9
+        # _graceful_terminate checks poll(), sends SIGINT, then waits.
+        process_mock.poll.return_value = None
+        process_mock.wait.return_value = 0
+        process_mock.returncode = -2
         mock_popen.return_value = process_mock
 
         runner = PipelineRunner(mode="validation", max_runtime=10)
@@ -399,6 +405,9 @@ class TestPipelineRunnerValidationMode(unittest.TestCase):
         assert isinstance(result, PipelineValidationResult)
         self.assertFalse(result.is_valid)
         self.assertTrue(any("timed out" in err for err in result.errors))
+
+        # Verify SIGINT was sent for graceful shutdown
+        process_mock.send_signal.assert_called_once_with(signal.SIGINT)
 
     def test_parse_validation_stderr(self):
         """_parse_validation_stderr should extract only gst_runner ERROR messages."""


### PR DESCRIPTION
## Description

This PR fixes several issues related to GStreamer pipeline lifecycle management in `gst_runner.py` and `pipeline_runner.py`, bringing the behavior closer to how `gst-launch-1.0` handles pipeline execution and shutdown.

### GStreamer log level mapping fix

The GStreamer debug level comparison operators in `gst_log_bridge` and `_parse_log_collector` were inverted. GStreamer uses lower numeric values for higher severity (ERROR=1, WARNING=2, INFO=4), but the code used `>=` comparisons, causing WARNING-level messages (like "unsupported memory type") to be treated as ERRORs. This was fixed by switching to `<=` comparisons, so pipelines that produce warnings no longer fail prematurely.

### Graceful shutdown on max-runtime expiry

The `_max_runtime_enforcement_thread` was redesigned to match `gst-launch-1.0`'s Ctrl+C behavior. Instead of the previous PAUSE→FLUSH→PLAY→EOS sequence (which caused issues with multi-pipeline descriptions and looping sources), the thread now simply quits the GLib main loop. The `run()` method's `finally` block then performs a single `set_state(NULL)` transition, avoiding race conditions from concurrent state changes. After `set_state(NULL)`, the pipeline object is explicitly deleted and `gc.collect()` is called to trigger GObject element finalization, which is when `gvafpscounter` emits its "FpsCounter(overall ...)" summary. Bus signal handlers are disconnected before the NULL transition to break reference cycles that would otherwise prevent Python's garbage collector from releasing the C-level pipeline object.

### Graceful shutdown on SIGINT (Ctrl+C)

A Python-level SIGINT handler was added that schedules a graceful shutdown via `GLib.idle_add()`. This approach was chosen because `GLib.unix_signal_add()` does not work reliably with Python's signal handling infrastructure. The shutdown logic is shared between SIGINT and max-runtime through a common `_initiate_shutdown()` method, ensuring consistent behavior regardless of the trigger. The original SIGINT handler is saved and restored in the `finally` block.

### Pipeline runner subprocess management

`pipeline_runner.py` was updated to pass `--log-level` (read from `LOG_LEVEL` env var, defaulting to `INFO`) to all `gst_runner.py` invocations. The cancellation and timeout termination logic was changed from `process.terminate()` (SIGTERM) to `process.send_signal(signal.SIGINT)` via a new `_graceful_terminate()` static method. This ensures that `gst_runner.py` receives SIGINT, triggering its graceful shutdown handler and producing a clean exit with code 0 in most scenarios. If the subprocess does not exit within a configurable timeout after SIGINT, it falls back to SIGKILL.

