### PR TITLE
[ViPPET] Bump dependencies

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
 RUN cargo install --locked qmassa@1.2.1
 
 # Final image for the collector
-FROM docker.io/library/telegraf:1.37.1 AS collector
+FROM docker.io/library/telegraf:1.37.3 AS collector
 
 # Copy qmassa binary from the build stage
 COPY --from=qmassa /usr/local/cargo/bin/qmassa /usr/local/bin/qmassa

--- a/tools/visual-pipeline-and-platform-evaluation-tool/onvif_discovery/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/onvif_discovery/Dockerfile
@@ -14,7 +14,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.14.2-slim
+FROM python:3.14.3-slim
 
 WORKDIR /app
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/requirements-dev.txt
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
 # Development dependencies
-ruff==0.15.0
+ruff==0.15.4
 pyright==1.1.408
 coverage==7.13.4

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/requirements.txt
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/requirements.txt
@@ -1,9 +1,9 @@
-fastapi[standard]==0.128.8
+fastapi[standard]==0.133.1
 opencv-python-headless==4.13.0.92
-openvino==2025.4.1
+openvino==2026.0.0
 psutil==7.2.2
 pydantic==2.12.5
 PyYAML==6.0.3
-uvicorn==0.40.0
+uvicorn==0.41.0
 onvif-zeep==0.2.12
 python-slugify==8.0.4


### PR DESCRIPTION
**Changes:**
- Bump `FastAPI` from `0.128.8` to `0.133.1`, `uvicorn` from `0.40.0` to `0.41.0`, and `OpenVINO` from `2025.4.1` to `2026.0.0` in production requirements
- Update `ruff` development dependency from `0.15.0` to `0.15.4`
- Update `Python` base image from `3.14.2-slim` to `3.14.3-slim` in `onvif_discovery` Dockerfile and `Telegraf` from `1.37.1` to `1.37.3` in `collector` Dockerfile
