### PR TITLE
[Chatqna EMF]  add model-download as a dependent application

### DIFF
--- a/sample-applications/chat-question-and-answer/deployment-package/application.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/application.yaml
@@ -6,12 +6,12 @@ schemaVersion: "0.1"
 $schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
 
 name: chatqna-app
-version: 2.0.1
+version: 2.1.0-rc2
 description: "Chat Q&A Sample Application"
 helmRegistry: "docker-hub"
 chartName: "intel/chat-question-and-answer"
 
-chartVersion: "2.0.1"
+chartVersion: "2.1.0-rc2"
 defaultProfile: "ovms"
 
 profiles:
@@ -80,6 +80,10 @@ profiles:
         displayName: "OTLP Endpoint Trace"
         type: string
         default: ""
+      - name: dataprepPgvector.dataprepPgvector.env.ALLOWED_HOSTS
+        displayName: "Allowed hosts for URL ingestion"
+        type: string
+        mandatory: true
       - name: global.ovmsEmbeddinggpuService.enabled
         displayName: "OVMS Embedding GPU Service"
         type: boolean
@@ -98,3 +102,13 @@ profiles:
         displayName: GPU Device
         type: string
         default: ""
+      - name: global.modelDownload.serviceName
+        displayName: "Model Download service name"
+        type: string
+        default: "model-download"
+        mandatory: false
+      - name: global.modelDownload.port
+        displayName: "Model Download service port"
+        type: string
+        default: "8000"
+        mandatory: false

--- a/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-ovms.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/chatqna-values-ovms.yaml
@@ -5,7 +5,7 @@ global:
   huggingface:
     apiToken: <HUGGINGFACEHUB_API_TOKEN>  # Set this during installation
   proxy:
-    no_proxy: ""
+    no_proxy: "localhost,127.0.0.1"
     http_proxy: ""
     https_proxy: ""
   UI_NODEPORT: <ui-nodeport>
@@ -18,6 +18,9 @@ global:
   RERANKER_MODEL: <RERANKER_MODEL>
   OTLP_ENDPOINT:
   OTLP_ENDPOINT_TRACE:
+  modelDownload:
+    serviceName: model-download
+    port: 8000
   ovmsEmbeddinggpuService:
     enabled: false
   gpu:
@@ -66,11 +69,14 @@ chatqna-ui:
   nameOverride: "ui"
 
 dataprepPgvector:
-  name: document-ingestion
-  service:
-    type: ClusterIP
-    port: 8000
-    targetPort: 8000
+  dataprepPgvector:
+    name: document-ingestion
+    service:
+      type: ClusterIP
+      port: 8000
+      targetPort: 8000
+    env:
+      ALLOWED_HOSTS: <ALLOWED_HOSTS>
 
 tgiService:
   name: text-generation-service

--- a/sample-applications/chat-question-and-answer/deployment-package/deployment-package.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/deployment-package.yaml
@@ -8,17 +8,26 @@ $schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
 name: "chatqna"
 displayName: "chatqna"
 description: "Chat Q&A Sample Application"
-version: "2.0.1"
+version: "2.1.0-rc2"
 
 applications:
   - name: chatqna-app
-    version: 2.0.1
+    version: 2.1.0-rc2
+  - name: model-download-app
+    version: 1.1.0-rc1
+
+applicationDependencies:
+  - name: chatqna-app
+    requires: model-download-app
 
 defaultNamespaces:
   chatqna-app: chatqna
+  model-download-app: chatqna
 
 deploymentProfiles:
   - name: "ovms"
     applicationProfiles:
+      - application: "model-download-app"
+        profile: "default"
       - application: "chatqna-app"
         profile: "ovms"

--- a/sample-applications/chat-question-and-answer/deployment-package/model-download-application.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/model-download-application.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: LicenseRef-Intel
+---
+specSchema: "Application"
+schemaVersion: "0.1"
+$schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
+
+name: model-download-app
+version: 1.1.0-rc1
+description: "Model Download Microservice"
+helmRegistry: "docker-hub"
+chartName: "intel/model-download-chart"
+
+chartVersion: "1.1.0-rc1"
+defaultProfile: "default"
+
+profiles:
+  - name: "default"
+    displayName: "default"
+    valuesFileName: "model-download-values.yaml"
+    parameterTemplates:
+      - name: global.proxy.http_proxy
+        displayName: "Http proxy"
+        type: string
+        default: ""
+      - name: global.proxy.https_proxy
+        displayName: "Https proxy"
+        type: string
+        default: ""
+      - name: global.proxy.no_proxy
+        displayName: "No proxy"
+        type: string
+        default: "localhost,127.0.0.1"
+      - name: modeldownload.service.port
+        displayName: "Static Service Port"
+        type: string
+        mandatory: true
+      - name: modeldownload.env.HUGGINGFACEHUB_API_TOKEN
+        displayName: "Huggingface API Token"
+        type: string
+        secret: true
+        mandatory: true
+      - name: modeldownload.env.ENABLED_PLUGINS
+        displayName: "Enabled plugins"
+        type: string
+        default: "openvino"

--- a/sample-applications/chat-question-and-answer/deployment-package/model-download-values.yaml
+++ b/sample-applications/chat-question-and-answer/deployment-package/model-download-values.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: LicenseRef-Intel
+---
+global:
+  proxy:
+    no_proxy: "localhost,127.0.0.1"
+    http_proxy: ""
+    https_proxy: ""
+
+modeldownload:
+  service:
+    port: <model-download-port>
+  env:
+    HUGGINGFACEHUB_API_TOKEN: <HUGGINGFACEHUB_API_TOKEN>
+    ENABLED_PLUGINS: openvino


### PR DESCRIPTION
### Description

This PR updates the ChatQnA application to include model-download as a dependent application in the deployment flow.

What changed

1. Added model-download as a dependency for ChatQnA deployment.
2. Updated ChatQnA configuration to support model-download connection settings (service name and port).
3. Updated ChatQnA packaging/deployment metadata to include this dependency.

Why

- ChatQnA now explicitly depends on model-download for model availability, making deployment and integration clearer and more consistent.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Tested locally deploying chatqna deployment package which deploys model-download first and then deploys chatqna

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

