### PR TITLE
[ViPPET] Fix max_runtime propagation in density tests

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/benchmark.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/benchmark.py
@@ -54,10 +54,10 @@ class BenchmarkResult:
 class Benchmark:
     """Benchmarking class for pipeline evaluation."""
 
-    def __init__(self):
+    def __init__(self, max_runtime: float = 0):
         self.best_result = None
-        # Initialize PipelineRunner in normal mode with max_runtime=0 (run until EOS)
-        self.runner = PipelineRunner(mode="normal", max_runtime=0)
+        # Initialize PipelineRunner in normal mode with optional max_runtime for each run
+        self.runner = PipelineRunner(mode="normal", max_runtime=max_runtime)
         self.logger = logging.getLogger(__name__)
 
     @staticmethod

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/tests_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/tests_manager.py
@@ -454,7 +454,9 @@ class TestsManager:
             )
 
             # Initialize Benchmark
-            benchmark = Benchmark()
+            benchmark = Benchmark(
+                max_runtime=internal_spec.execution_config.max_runtime
+            )
 
             # Store benchmark runner for this job so that a future extension could cancel it.
             with self._jobs_lock:


### PR DESCRIPTION
### Description

This PR fixes an issue in ViPPET where density tests ignored the configured runtime limits and ran until the end of the stream (EOS). 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

