### PR TITLE
[ViPPET] Fix choosing options from dropdown 

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/components/ui/combobox.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/components/ui/combobox.tsx
@@ -96,21 +96,28 @@ function ComboboxContent({
   align = "start",
   alignOffset = 0,
   anchor,
+  portalContainer,
   ...props
 }: ComboboxPrimitive.Popup.Props &
   Pick<
     ComboboxPrimitive.Positioner.Props,
     "side" | "align" | "sideOffset" | "alignOffset" | "anchor"
-  >) {
+  > & {
+    portalContainer?:
+      | HTMLElement
+      | ShadowRoot
+      | null
+      | React.RefObject<HTMLElement | ShadowRoot | null>;
+  }) {
   return (
-    <ComboboxPrimitive.Portal>
+    <ComboboxPrimitive.Portal container={portalContainer}>
       <ComboboxPrimitive.Positioner
         side={side}
         sideOffset={sideOffset}
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="isolate z-50"
+        className="isolate z-[70]"
       >
         <ComboboxPrimitive.Popup
           data-slot="combobox-content"

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/components/ui/dialog.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/components/ui/dialog.tsx
@@ -44,18 +44,20 @@ function DialogOverlay({
   );
 }
 
-function DialogContent({
-  className,
-  children,
-  showCloseButton = true,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean;
-}) {
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentProps<typeof DialogPrimitive.Content> & {
+    showCloseButton?: boolean;
+  }
+>(function DialogContent(
+  { className, children, showCloseButton = true, ...props },
+  ref,
+) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
+        ref={ref}
         data-slot="dialog-content"
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:max-w-lg",
@@ -76,7 +78,7 @@ function DialogContent({
       </DialogPrimitive.Content>
     </DialogPortal>
   );
-}
+});
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipelines/CreatePipelineDialog.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipelines/CreatePipelineDialog.tsx
@@ -85,6 +85,7 @@ export const CreatePipelineDialog = ({
   const [selectedTemplate, setSelectedTemplate] = useState<Pipeline | null>(
     null,
   );
+  const dialogContentRef = useRef<HTMLElement | null>(null);
   const stepperRef = useRef<HTMLDivElement & IStepperMethods>(null);
 
   const { data: templates, isLoading: isLoadingTemplates } =
@@ -304,7 +305,19 @@ export const CreatePipelineDialog = ({
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
         className="max-w-6xl!"
-        onInteractOutside={(e) => e.preventDefault()}
+        ref={(node) => {
+          dialogContentRef.current = node;
+        }}
+        onInteractOutside={(e) => {
+          const target = e.target;
+          if (!(target instanceof HTMLElement)) {
+            return;
+          }
+
+          if (target.closest('[data-slot="combobox-content"]')) {
+            e.preventDefault();
+          }
+        }}
       >
         <DialogHeader>
           <DialogTitle>Create Pipeline</DialogTitle>
@@ -347,6 +360,7 @@ export const CreatePipelineDialog = ({
             <Field>
               <FieldLabel htmlFor="tags">Tags</FieldLabel>
               <PipelineTagsCombobox
+                portalContainer={dialogContentRef}
                 value={tags}
                 onChange={(newTags) => {
                   setValue("tags", newTags);
@@ -468,6 +482,7 @@ export const CreatePipelineDialog = ({
                 <Field>
                   <FieldLabel htmlFor="template-tags">Tags</FieldLabel>
                   <PipelineTagsCombobox
+                    portalContainer={dialogContentRef}
                     value={tags}
                     onChange={(newTags) => {
                       setValue("tags", newTags);

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipelines/PipelineTagsCombobox.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipelines/PipelineTagsCombobox.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "next-themes";
+import type { RefObject } from "react";
 import { useAppSelector } from "@/store/hooks";
 import { selectPipelines } from "@/store/reducers/pipelines";
 import {
@@ -16,11 +17,13 @@ import { usePipelineTagColors } from "@/hooks/usePipelineTagColors";
 type PipelineTagsComboboxProps = {
   value: string[];
   onChange: (tags: string[]) => void;
+  portalContainer?: RefObject<HTMLElement | ShadowRoot | null>;
 };
 
 export const PipelineTagsCombobox = ({
   value,
   onChange,
+  portalContainer,
 }: PipelineTagsComboboxProps) => {
   const { theme } = useTheme();
   const pipelines = useAppSelector(selectPipelines);
@@ -64,7 +67,7 @@ export const PipelineTagsCombobox = ({
           }}
         />
       </ComboboxChips>
-      <ComboboxContent>
+      <ComboboxContent portalContainer={portalContainer}>
         <ComboboxList>
           {availableTags.length > 0 ? (
             availableTags.map((tag) => (


### PR DESCRIPTION
Fixing choosing tags from dropdowns in creating pipeline from description and template window.

**Implementation Worth Mentioning**

The core issue was an interaction conflict between Radix Dialog and Base UI Combobox rendered through a portal: the dropdown was visible, keyboard navigation worked, but mouse hover/click did not select tags.

- disabling portal rendering for the combobox popup caused a runtime crash: Combox.Portal is missing.

- removing outside-interaction blocking in the dialog did not restore mouse selection.

- adding conditional onInteractOutside logic for combobox content only still did not fully fix pointer behavior.

**The final solution was to increase combobox popup z-index, keep Base UI portal behavior and explicitly portal the combobox popup into the active dialog content container (same interaction layer), plus forward ref on dialog content.**