### PR TITLE
time-series-analytics: Delete alerts key from config

### DIFF
--- a/microservices/time-series-analytics/src/main.py
+++ b/microservices/time-series-analytics/src/main.py
@@ -523,6 +523,8 @@ async def config_file_change(config_data: Config, background_tasks: BackgroundTa
         config["udfs"] = config_data.udfs
         if config_data.alerts:
             config["alerts"] = config_data.alerts
+        else:
+            config.pop("alerts")
         logger.info("Received configuration data: %s", config)
     except json.JSONDecodeError as error:
         logger.error("Invalid JSON format in configuration data: %s", error)


### PR DESCRIPTION
### Description

Changes:
 src/main.py- Delete the alerts key from config if not present in updated config

Fixes # (issue)

### Any Newly Introduced Dependencies

no.

### How Has This Been Tested?

yes

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

