### PR TITLE
[ViPPET] Upgrade DLStreamer base image to `2026.1.0-20260414-weekly-ubuntu24`

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/models/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/models/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.0.0-ubuntu24
+FROM intel/dlstreamer:2026.1.0-20260414-weekly-ubuntu24
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.0.0-ubuntu24
+FROM intel/dlstreamer:2026.1.0-20260414-weekly-ubuntu24
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.0.0-ubuntu24 AS prod
+FROM intel/dlstreamer:2026.1.0-20260414-weekly-ubuntu24 AS prod
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/optimization_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/optimization_manager.py
@@ -104,10 +104,11 @@ class OptimizationRunner:
         import optimizer  # pyright: ignore[reportMissingImports]
 
         opt = optimizer.DLSOptimizer()
-        opt.set_search_duration(search_duration)
         opt.set_sample_duration(sample_duration)
 
-        optimized_pipeline, total_fps = opt.optimize_for_fps(pipeline_description)
+        optimized_pipeline, total_fps = opt.optimize_for_fps(
+            pipeline_description, search_duration=search_duration
+        )
 
         return PipelineOptimizationResult(
             optimized_pipeline_description=optimized_pipeline, total_fps=total_fps

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/optimization_manager_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/optimization_manager_test.py
@@ -799,13 +799,10 @@ class TestOptimizationRunner(unittest.TestCase):
         self.fake_optimizer.preprocess_pipeline = lambda pipeline: pipeline.upper()
 
         class FakeDLSOptimizer:
-            def set_search_duration(self, duration: int) -> None:
-                pass
-
             def set_sample_duration(self, duration: int) -> None:
                 pass
 
-            def optimize_for_fps(self, pipeline: str):
+            def optimize_for_fps(self, pipeline: str, search_duration: int = 300):
                 return (pipeline + " ! OPTIMIZED", 99.9)
 
         self.fake_optimizer.DLSOptimizer = FakeDLSOptimizer


### PR DESCRIPTION
## Summary

Upgrade DLStreamer base image to `2026.1.0-20260414-weekly-ubuntu24` and adapt to upstream API changes.

## Changes

- **DLStreamer base image**: Update all Dockerfiles (`vippet`, `video_generator`, `models`) to use `intel/dlstreamer:2026.1.0-20260414-weekly-ubuntu24`.
- **DLSOptimizer API update**: Adapt to upstream change from [dlstreamer#748](https://github.com/open-edge-platform/dlstreamer/pull/748) - remove deprecated `set_search_duration()` call and pass `search_duration` directly to `optimize_for_fps()`.
- **Tests**: Update `FakeDLSOptimizer` stub to match the new `optimize_for_fps(pipeline, search_duration=300)` signature.

## Motivation

Keep up with the latest DLStreamer release for bug fixes, performance improvements, and updated optimizer API.

## Testing

Existing unit tests updated and passing.
