### PR TITLE
[DOCS] add overlay=false note for custom gvawatermark config

### DIFF
--- a/microservices/dlstreamer-pipeline-server/README.md
+++ b/microservices/dlstreamer-pipeline-server/README.md
@@ -94,6 +94,15 @@ Open another terminal and send the following curl request
 }'
 ```
 
+> **Note:** When using a custom `gvawatermark` configuration (e.g., `displ-cfg=show-roi=...` or `displ-cfg=hide-roi=...`) in your pipeline, set `"overlay": false` in the frame destination to prevent the RTSP stream from adding a second `gvawatermark` with default settings that overrides your filtering configuration:
+> ```json
+> "frame": {
+>     "type": "rtsp",
+>     "path": "pallet-defect-detection",
+>     "overlay": false
+> }
+> ```
+
 The REST request will return a pipeline instance ID, which can be used as an identifier to query later the pipeline status or stop the pipeline instance. For example, a6d67224eacc11ec9f360242c0a86003.
 
 - To view the metadata, open another terminal and run the following command,


### PR DESCRIPTION
### Description

When a pipeline includes `gvawatermark` with custom **displ-cfg** (e.g., `show-roi` or `hide-roi`), the RTSP destination adds a second `gvawatermark` with default settings, causing all ROIs to be drawn regardless of filtering. Document the "overlay": false option in the frame destination to prevent this behavior.

this update is needed to explicitly explain the use case such reported in this [bug ](https://github.com/open-edge-platform/dlstreamer/issues/692)

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

