### PR TITLE
[ViPPET] Add the qmmd command to the collector Docker image

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
@@ -28,12 +28,14 @@ RUN apt-get update && \
 
 # Install qmassa
 RUN cargo install --locked qmassa@1.2.1
+RUN cargo install --locked qmmd@0.1.1
 
 # Final image for the collector
 FROM docker.io/library/telegraf:1.38.2 AS collector
 
 # Copy qmassa binary from the build stage
 COPY --from=qmassa /usr/local/cargo/bin/qmassa /usr/local/bin/qmassa
+COPY --from=qmassa /usr/local/cargo/bin/qmmd /usr/local/bin/qmmd
 
 # Set environment variable to non-interactive mode (avoids some prompts)
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Description

This update includes the installation of the qmmd command in the collector Docker image. Other services that need to collect GPU and CPU metrics can now utilize this container for seamless data collection using the services like Prometheus and Grafana.

### How Has This Been Tested?

Tested the installed qmmd command by running it through supervisord.conf and collecting GPU metrics via Prometheus and Grafana.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

