### PR TITLE
[ViPPET] Add metadata dir to env-setup target

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
@@ -68,6 +68,7 @@ generate_openapi: $(VENV_DIR) ## Generate OpenAPI schema file
 
 env-setup: ## Environment setup target: always run before build/run targets that need .env and shared dirs
 	mkdir -p shared/collector-signals && chmod o+w shared/collector-signals
+	mkdir -p shared/metadata && chmod o+w shared/metadata
 	mkdir -p shared/models/output && chmod o+w shared/models/output
 	mkdir -p shared/model-download/venv && chmod o+w shared/model-download/venv
 	mkdir -p shared/model-download/cache && chmod o+w shared/model-download/cache


### PR DESCRIPTION
### Description

This pull request makes a small update to the environment setup process in the `Makefile`. The change ensures that the `shared/metadata` directory is created with the correct permissions during environment setup.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

