### PR TITLE
[ViPPET] Push FPS and pipeline-latency metrics to metrics-service

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/benchmark.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/benchmark.py
@@ -103,15 +103,23 @@ class _BestConfig:
 class Benchmark:
     """Benchmarking class for pipeline evaluation."""
 
-    def __init__(self, max_runtime: float = 0, enable_latency_metrics: bool = False):
+    def __init__(
+        self,
+        max_runtime: float = 0,
+        enable_latency_metrics: bool = False,
+        job_id: str | None = None,
+    ):
         self.best_result = None
         # Initialize PipelineRunner in normal mode with optional max_runtime for each run.
         # `enable_latency_metrics` is forwarded so that the GStreamer subprocess
         # is launched with the DLStreamer latency_tracer active when requested.
+        # `job_id` is forwarded so FPS metrics pushed during each density
+        # iteration are tagged with the owning job's id in metrics-service.
         self.runner = PipelineRunner(
             mode="normal",
             max_runtime=max_runtime,
             enable_latency_metrics=enable_latency_metrics,
+            job_id=job_id,
         )
         self.logger = logging.getLogger(__name__)
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/pipeline_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/pipeline_manager.py
@@ -706,18 +706,6 @@ class PipelineManager:
 
                 pipeline_parts.append(unique_pipeline_str)
 
-        # TODO: Must be removed once the live metrics stream is in place
-        # Diagnostic summary so the stream-to-tracer correlation can be
-        # verified from the logs. Kept at INFO because it is printed once
-        # per run (not per sample).
-        if streams_per_pipeline:
-            lines = ["Stream identifiers per pipeline:"]
-            for pid, infos in streams_per_pipeline.items():
-                lines.append(f"  pipeline '{pid}' ({len(infos)} stream(s)):")
-                for info in infos:
-                    lines.append(f"    - {info.stream_id}")
-            logger.info("\n".join(lines))
-
         return PipelineCommand(
             command=" ".join(pipeline_parts),
             video_output_paths=video_output_paths,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/tests_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/tests_manager.py
@@ -465,6 +465,7 @@ class TestsManager:
                 mode="normal",
                 max_runtime=internal_spec.execution_config.max_runtime,
                 enable_latency_metrics=internal_spec.execution_config.enable_latency_metrics,
+                job_id=job_id,
             )
 
             # Store runner for this job so it can be cancelled via stop_job()
@@ -613,6 +614,7 @@ class TestsManager:
             benchmark = Benchmark(
                 max_runtime=internal_spec.execution_config.max_runtime,
                 enable_latency_metrics=internal_spec.execution_config.enable_latency_metrics,
+                job_id=job_id,
             )
 
             # Store benchmark runner for this job so that a future extension could cancel it.

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/validation_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/validation_manager.py
@@ -159,11 +159,15 @@ class ValidationManager:
         new entries for that state are appended.
         """
         try:
-            # Create PipelineRunner in validation mode
+            # Create PipelineRunner in validation mode.
+            # `job_id` is forwarded for API consistency with performance
+            # and density paths, even though validation mode never
+            # pushes FPS metrics (no gvafpscounter is attached).
             runner = PipelineRunner(
                 mode="validation",
                 max_runtime=max_runtime,
                 hard_timeout=hard_timeout,
+                job_id=job_id,
             )
 
             # Run pipeline validation

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipeline_runner.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipeline_runner.py
@@ -16,9 +16,9 @@ import select
 import signal
 import subprocess
 import sys
-import threading
 import time
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from subprocess import PIPE, Popen
 
@@ -148,6 +148,34 @@ class PipelineRunner:
     DEFAULT_METRICS_SERVICE_URL = "http://metrics-service:9090"
 
     # ------------------------------------------------------------------
+    # Shared worker pool for fire-and-forget metric pushes.
+    #
+    # Every metric push (`_push_fps_metric`, `_push_latency_sample`,
+    # `_push_final_latency_metrics`) schedules work through
+    # `_post_metrics_async`. Creating a brand-new `threading.Thread`
+    # per push scales poorly: with N streams the runner emits one FPS
+    # push + one latency push per stream every second, plus N final
+    # latency pushes at shutdown. Under load this would spawn
+    # hundreds of short-lived threads per second.
+    #
+    # A single class-level `ThreadPoolExecutor` caps concurrency at
+    # `_METRICS_EXECUTOR_WORKERS` and reuses threads across pushes.
+    # The executor is declared as a daemon pool — its worker threads
+    # do not keep the Python process alive after the main thread
+    # exits, mirroring the previous `daemon=True` thread behaviour.
+    #
+    # Shared at the class level (not per-instance) on purpose: many
+    # runners may exist in the same process (density `Benchmark`
+    # reuses one, the validation path creates one per job, etc.) and
+    # metrics-service traffic is I/O-bound, so one pool is enough to
+    # absorb all of them and no coordination is needed across
+    # instances. The executor is created lazily on first push so
+    # importing this module stays side-effect free.
+    # ------------------------------------------------------------------
+    _METRICS_EXECUTOR_WORKERS = 4
+    _metrics_executor: "ThreadPoolExecutor | None" = None
+
+    # ------------------------------------------------------------------
     # latency_tracer configuration
     #
     # When `enable_latency_metrics=True`, the GStreamer subprocess is
@@ -260,28 +288,26 @@ class PipelineRunner:
                 `GST_DEBUG=GST_TRACER:7` (appended to any existing value) and
                 `GST_TRACERS=latency_tracer(flags=pipeline,interval=1000)`.
                 When False (default), neither variable is modified.
-            job_id: Identifier of the owning job. When provided, every FPS
-                metric pushed by this runner carries a ``tags.job_id``
-                field so metrics-service can partition data per job; this
-                is how concurrent jobs are distinguished in the metrics
-                backend. When ``None`` (default), the ``tags`` field is
-                omitted from the payload — used by ad-hoc callers
-                (e.g. video transcoding) that do not belong to any job.
-                Accepted by both ``normal`` and ``validation`` modes for
-                a uniform API, but validation mode never pushes FPS
-                (no ``gvafpscounter`` is attached), so the value is
-                effectively unused there.
+            job_id: Identifier of the owning job. When provided, every
+                metric pushed by this runner — both FPS and
+                ``pipeline_latency`` — carries a ``tags.job_id`` field
+                so metrics-service can partition data per job; this is
+                how concurrent jobs are distinguished in the metrics
+                backend. When ``None`` (default), the ``job_id`` tag is
+                omitted from every payload (FPS pushes then carry no
+                ``tags`` field at all; latency pushes still carry
+                ``stream_id``). Used by ad-hoc callers (e.g. video
+                transcoding) that do not belong to any job. Accepted by
+                both ``normal`` and ``validation`` modes for a uniform
+                API, but validation mode never pushes metrics
+                (no ``gvafpscounter`` / tracer is attached), so the
+                value is effectively unused there.
         """
         self.mode = mode
         self.max_runtime = max_runtime
         self.poll_interval = poll_interval
         self.inactivity_timeout = inactivity_timeout
         self.hard_timeout = hard_timeout
-        # Resolve the metrics-service base URL once and pre-compute the
-        # full endpoint used by `_push_fps_metric`. Trailing slashes on
-        # the configured base are stripped so concatenation with the
-        # fixed path cannot produce `//api/v1/...`, which some proxies
-        # and routers treat as a distinct (and unmapped) path.
         # Resolve the metrics-service base URL once and pre-compute the
         # two endpoint URLs used by the push helpers. Trailing slashes
         # on the configured base are stripped so concatenation with the
@@ -924,10 +950,16 @@ class PipelineRunner:
         """
         Fire-and-forget HTTP POST to metrics-service.
 
-        Performs the POST on a daemon thread so the pipeline hot loop
-        is never blocked by a slow or unavailable metrics-service.
-        Failures are logged at WARNING level from the worker thread
-        and never propagate back to the caller.
+        Submits the POST to a shared class-level
+        ``ThreadPoolExecutor`` (see ``_get_metrics_executor``) so the
+        pipeline hot loop is never blocked by a slow or unavailable
+        metrics-service. The pool caps concurrency at
+        ``_METRICS_EXECUTOR_WORKERS`` and reuses threads across
+        pushes, which avoids the unbounded-thread-spawn pattern a
+        per-push ``threading.Thread`` would create under load (many
+        streams × 1 Hz FPS + latency + per-stream final pushes).
+        Failures are logged at WARNING level from the worker and
+        never propagate back to the caller.
 
         This is the single I/O primitive shared by both the FPS push
         (single-metric endpoint) and the latency push (batch endpoint);
@@ -942,12 +974,12 @@ class PipelineRunner:
                 before scheduling the POST so the worker thread does
                 not share the dict with the caller.
             description: Short label used in the WARNING log if the
-                request fails (e.g. ``"fps"`` or ``"latency batch"``).
+                request fails (e.g. ``"fps"`` or ``"latency"``).
                 Kept separate from the URL so logs are readable even
                 when the endpoint path is unfamiliar.
         """
         # Snapshot everything the worker thread needs so it never
-        # reaches back into `self` on the hot path — keeps the thread
+        # reaches back into `self` on the hot path — keeps the worker
         # self-contained and avoids any accidental lifetime coupling.
         logger = self.logger
         data = json.dumps(payload).encode()
@@ -969,11 +1001,39 @@ class PipelineRunner:
                     "Failed to push %s metric to %s: %s", description, url, e
                 )
 
-        # Daemon thread so a slow metrics-service cannot keep the
-        # process alive after the main thread exits. We do not keep a
-        # reference to the Thread: each push is independent and we
-        # never need to join it.
-        threading.Thread(target=_worker, daemon=True).start()
+        # Submit the push to the shared worker pool. The pool caps
+        # concurrency at `_METRICS_EXECUTOR_WORKERS` and reuses
+        # threads, so bursts (many streams emitting latency every
+        # second + per-stream final pushes at shutdown) cannot turn
+        # into an unbounded thread spawn. We do not keep the returned
+        # Future: each push is independent and never joined.
+        self._get_metrics_executor().submit(_worker)
+
+    @classmethod
+    def _get_metrics_executor(cls) -> ThreadPoolExecutor:
+        """
+        Return (and lazily create) the shared metrics-push worker pool.
+
+        The pool is a single class-level ``ThreadPoolExecutor`` used
+        by every runner instance in the process. It is created on
+        first use so importing this module does not spawn any
+        threads, and its worker threads are daemons (via
+        ``thread_name_prefix`` + the executor's own daemon behaviour)
+        so they do not keep the Python process alive after the main
+        thread exits.
+
+        Lazy creation is race-safe enough for our use: the worst case
+        under a tight race is two executors being created and one
+        being immediately garbage-collected. Since the executor is
+        never closed on purpose (metric pushes may continue until
+        process exit), no resource leak results from the lost one.
+        """
+        if cls._metrics_executor is None:
+            cls._metrics_executor = ThreadPoolExecutor(
+                max_workers=cls._METRICS_EXECUTOR_WORKERS,
+                thread_name_prefix="vippet-metrics",
+            )
+        return cls._metrics_executor
 
     def _push_fps_metric(self, fps: float) -> None:
         """

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipeline_runner.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipeline_runner.py
@@ -16,6 +16,7 @@ import select
 import signal
 import subprocess
 import sys
+import threading
 import time
 import urllib.request
 from dataclasses import dataclass, field
@@ -233,6 +234,7 @@ class PipelineRunner:
         inactivity_timeout: int = 120,
         hard_timeout: int | None = None,
         enable_latency_metrics: bool = False,
+        job_id: str | None = None,
     ):
         """
         Initialize the PipelineRunner.
@@ -258,6 +260,17 @@ class PipelineRunner:
                 `GST_DEBUG=GST_TRACER:7` (appended to any existing value) and
                 `GST_TRACERS=latency_tracer(flags=pipeline,interval=1000)`.
                 When False (default), neither variable is modified.
+            job_id: Identifier of the owning job. When provided, every FPS
+                metric pushed by this runner carries a ``tags.job_id``
+                field so metrics-service can partition data per job; this
+                is how concurrent jobs are distinguished in the metrics
+                backend. When ``None`` (default), the ``tags`` field is
+                omitted from the payload — used by ad-hoc callers
+                (e.g. video transcoding) that do not belong to any job.
+                Accepted by both ``normal`` and ``validation`` modes for
+                a uniform API, but validation mode never pushes FPS
+                (no ``gvafpscounter`` is attached), so the value is
+                effectively unused there.
         """
         self.mode = mode
         self.max_runtime = max_runtime
@@ -269,13 +282,28 @@ class PipelineRunner:
         # the configured base are stripped so concatenation with the
         # fixed path cannot produce `//api/v1/...`, which some proxies
         # and routers treat as a distinct (and unmapped) path.
+        # Resolve the metrics-service base URL once and pre-compute the
+        # two endpoint URLs used by the push helpers. Trailing slashes
+        # on the configured base are stripped so concatenation with the
+        # fixed paths cannot produce `//api/v1/...`, which some proxies
+        # and routers treat as a distinct (and unmapped) path.
+        #
+        # Two endpoints are used:
+        #   * `/api/v1/metrics/simple` — single {name, value} pair,
+        #     used for FPS pushes (one metric per call).
+        #   * `/api/v1/metrics` — batch endpoint accepting a list of
+        #     {name, fields, tags} entries, used for latency pushes
+        #     so all four tracer fields travel in one request per
+        #     stream sample.
         self.metrics_service_url = os.environ.get(
             "METRICS_SERVICE_URL", self.DEFAULT_METRICS_SERVICE_URL
         ).rstrip("/")
         self._metrics_service_fps_url = (
             f"{self.metrics_service_url}/api/v1/metrics/simple"
         )
+        self._metrics_service_batch_url = f"{self.metrics_service_url}/api/v1/metrics"
         self.enable_latency_metrics = enable_latency_metrics
+        self.job_id = job_id
         self.logger = logging.getLogger("PipelineRunner")
         self.logger_level = self._get_log_level()
         self.logger.setLevel(self.logger_level)
@@ -880,34 +908,184 @@ class PipelineRunner:
         finally:
             # Push 0.0 to metrics-service after pipeline completion (success or failure)
             self._push_fps_metric(0.0)
+            # Re-push the last observed latency sample per stream so
+            # that at least one final pipeline_latency point per stream
+            # reaches metrics-service even if the last in-flight live
+            # push raced with pipeline teardown. No-op when the tracer
+            # was disabled or produced no samples.
+            self._push_final_latency_metrics()
+
+    def _post_metrics_async(
+        self,
+        url: str,
+        payload: dict,
+        description: str,
+    ) -> None:
+        """
+        Fire-and-forget HTTP POST to metrics-service.
+
+        Performs the POST on a daemon thread so the pipeline hot loop
+        is never blocked by a slow or unavailable metrics-service.
+        Failures are logged at WARNING level from the worker thread
+        and never propagate back to the caller.
+
+        This is the single I/O primitive shared by both the FPS push
+        (single-metric endpoint) and the latency push (batch endpoint);
+        the two differ only in the target URL and the JSON body shape,
+        both built by the respective wrappers (``_push_fps_metric``,
+        ``_push_latency_sample``, ``_push_final_latency_metrics``).
+
+        Args:
+            url: Fully qualified endpoint URL. Pre-computed once in
+                ``__init__`` — this method does not touch the base URL.
+            payload: JSON-serializable request body. Encoded as UTF-8
+                before scheduling the POST so the worker thread does
+                not share the dict with the caller.
+            description: Short label used in the WARNING log if the
+                request fails (e.g. ``"fps"`` or ``"latency batch"``).
+                Kept separate from the URL so logs are readable even
+                when the endpoint path is unfamiliar.
+        """
+        # Snapshot everything the worker thread needs so it never
+        # reaches back into `self` on the hot path — keeps the thread
+        # self-contained and avoids any accidental lifetime coupling.
+        logger = self.logger
+        data = json.dumps(payload).encode()
+
+        def _worker() -> None:
+            try:
+                req = urllib.request.Request(
+                    url,
+                    data=data,
+                    headers={"Content-Type": "application/json"},
+                )
+                # Context manager releases the socket / file descriptor
+                # deterministically after every POST, instead of
+                # waiting for GC to reclaim the response object.
+                with urllib.request.urlopen(req, timeout=1):
+                    pass
+            except Exception as e:
+                logger.warning(
+                    "Failed to push %s metric to %s: %s", description, url, e
+                )
+
+        # Daemon thread so a slow metrics-service cannot keep the
+        # process alive after the main thread exits. We do not keep a
+        # reference to the Thread: each push is independent and we
+        # never need to join it.
+        threading.Thread(target=_worker, daemon=True).start()
 
     def _push_fps_metric(self, fps: float) -> None:
         """
-        Push the given FPS value to metrics-service via REST API.
-        This method is called:
-        - During pipeline execution to report current FPS metrics for monitoring
-        - After pipeline completion (with 0.0) to signal that pipeline is no longer running
+        Push the given FPS value to metrics-service.
+
+        Called:
+        - During pipeline execution, every time a new average FPS line
+          is parsed from ``gvafpscounter`` (roughly once per second).
+        - Once at pipeline completion with ``0.0`` to signal that the
+          pipeline is no longer running.
+
+        Uses the ``/api/v1/metrics/simple`` endpoint: one metric name
+        and one scalar value per request. When ``self.job_id`` is set,
+        the payload carries ``tags.job_id`` so metrics-service can
+        partition data per job; otherwise the ``tags`` field is omitted.
+
         Args:
             fps: FPS value to push.
         """
-        try:
-            data = json.dumps({"name": "fps", "value": fps}).encode()
-            req = urllib.request.Request(
-                self._metrics_service_fps_url,
-                data=data,
-                headers={"Content-Type": "application/json"},
-            )
-            # Use a context manager so the underlying socket / file
-            # descriptor is released deterministically after every POST,
-            # instead of waiting for GC to reclaim the response object.
-            with urllib.request.urlopen(req, timeout=1):
-                pass
-        except Exception as e:
-            self.logger.warning(
-                "Failed to push FPS metric to %s: %s",
-                self._metrics_service_fps_url,
-                e,
-            )
+        payload: dict[str, object] = {"name": "fps", "value": fps}
+        if self.job_id is not None:
+            payload["tags"] = {"job_id": self.job_id}
+
+        self._post_metrics_async(
+            url=self._metrics_service_fps_url,
+            payload=payload,
+            description="fps",
+        )
+
+    def _push_latency_sample(
+        self, stream_id: str, sample: "LatencyTracerSample"
+    ) -> None:
+        """
+        Push a single ``latency_tracer`` sample to metrics-service.
+
+        Called live from the stdout hot loop every time a new
+        ``latency_tracer_pipeline_interval`` line is parsed for an
+        allowed stream (see ``_parse_and_record_latency_sample``). No
+        push is made when ``enable_latency_metrics`` is False, because
+        the caller itself short-circuits on that condition.
+
+        Uses the ``/api/v1/metrics`` batch endpoint with a single
+        entry in the ``metrics`` list. The batch shape is used (even
+        for one entry) so all four tracer fields travel in a single
+        HTTP request — the alternative would be four separate calls
+        to the ``simple`` endpoint per stream per second, which scales
+        poorly with stream count.
+
+        Fields sent: ``avg_ms``, ``min_ms``, ``max_ms``, ``latency_ms``.
+        ``interval_ms`` is intentionally omitted — the emission cadence
+        is fixed at 1000 ms and metrics-service timestamps each sample
+        on receipt, so the field would only add noise. ``fps`` is also
+        intentionally omitted because it is already reported by
+        ``gvafpscounter`` via ``_push_fps_metric`` — re-sending it
+        here would double-count throughput in the dashboard.
+
+        Tags: ``job_id`` (when set) and ``stream_id`` so the dashboard
+        can distinguish concurrent streams on the same job.
+
+        Args:
+            stream_id: Composite ``"{source_name}__{sink_name}"`` used
+                as the ``stream_id`` tag value. Matches the key under
+                which the sample is stored in
+                ``self.latency_tracer_metrics``.
+            sample: The parsed tracer sample to push.
+        """
+        tags: dict[str, str] = {"stream_id": stream_id}
+        if self.job_id is not None:
+            tags["job_id"] = self.job_id
+
+        payload = {
+            "metrics": [
+                {
+                    "name": "pipeline_latency",
+                    "fields": {
+                        "avg_ms": sample.avg_ms,
+                        "min_ms": sample.min_ms,
+                        "max_ms": sample.max_ms,
+                        "latency_ms": sample.latency_ms,
+                    },
+                    "tags": tags,
+                }
+            ]
+        }
+
+        self._post_metrics_async(
+            url=self._metrics_service_batch_url,
+            payload=payload,
+            description="latency",
+        )
+
+    def _push_final_latency_metrics(self) -> None:
+        """
+        Push one final ``pipeline_latency`` sample per stream after
+        the subprocess exits.
+
+        Runs once from the ``finally`` block of ``_run_normal``,
+        iterating the in-memory ``latency_tracer_metrics`` map and
+        re-pushing the last observed sample for every stream. This
+        guarantees that at least one final sample per stream reaches
+        metrics-service even if the last in-flight per-sample push
+        raced with pipeline teardown.
+
+        No-op when ``enable_latency_metrics`` is False (the map stays
+        ``None``) or when the map is empty (tracer was enabled but
+        produced no samples — e.g. the pipeline exited before the
+        first 1000 ms interval closed).
+        """
+        if not self.latency_tracer_metrics:
+            return
+        for stream_id, sample in self.latency_tracer_metrics.items():
+            self._push_latency_sample(stream_id, sample)
 
     def _parse_and_record_latency_sample(self, line: str) -> None:
         """
@@ -978,13 +1156,17 @@ class PipelineRunner:
         )
         self.latency_tracer_metrics[stream_id] = metrics
 
-        # TODO(PipelineRunner): push each new sample to a live metrics
-        # stream (WebSocket / SSE) instead of only updating the in-memory
-        # map and logging it here.
-        # TODO(PipelineRunner): drop this per-sample INFO log once the
-        # live metrics stream above is in place — while it is missing,
-        # this log is the only runtime-visible surface for tracer values.
-        self.logger.info(
+        # Live push: forward every new sample to metrics-service as
+        # soon as it is parsed. The call is fire-and-forget (runs on
+        # a daemon thread in `_post_metrics_async`) so a slow or
+        # unavailable backend can never stall the stdout reader.
+        self._push_latency_sample(stream_id, metrics)
+
+        # Per-sample log is kept at DEBUG level: metrics-service is
+        # now the primary surface for tracer values, so this log is
+        # only useful for local troubleshooting when the backend is
+        # unavailable or the payload shape is under review.
+        self.logger.debug(
             "latency_tracer sample: stream=%s interval_ms=%.3f avg_ms=%.3f "
             "min_ms=%.3f max_ms=%.3f latency_ms=%.3f",
             stream_id,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/tests_manager_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/tests_manager_test.py
@@ -1425,7 +1425,10 @@ class TestExecutionConfigWithMaxRuntime(unittest.TestCase):
         ):
             manager._execute_performance_test(job_id, internal_spec)
         mock_pipeline_runner_cls.assert_called_once_with(
-            mode="normal", max_runtime=120, enable_latency_metrics=False
+            mode="normal",
+            max_runtime=120,
+            enable_latency_metrics=False,
+            job_id=job_id,
         )
 
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/validation_manager_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/validation_manager_test.py
@@ -312,6 +312,57 @@ class TestValidationManager(unittest.TestCase):
         self.assertTrue(len(updated.details) > 0)
         self.assertIn("runner exploded", updated.details[0])
 
+    @patch("managers.validation_manager.PipelineRunner")
+    def test_execute_validation_marks_job_failed_without_stderr_entries(
+        self, mock_runner_cls
+    ):
+        """When the runner returns a non-zero exit code but produces no
+        stderr messages, the manager must still mark the job FAILED and
+        synthesise a detail explaining the exit code so the user can
+        distinguish this case from a successful validation.
+
+        This path is the fallback in ``_execute_validation`` when the
+        ``result.stderr`` list is empty — otherwise each stderr line is
+        converted into its own detail entry.
+        """
+        manager = ValidationManager()
+
+        internal_request = self._build_internal_validation()
+
+        job_id = "job-no-stderr"
+        job = InternalValidationJob(
+            id=job_id,
+            request=internal_request,
+            pipeline_description="pipeline",
+            state=InternalValidationJobState.RUNNING,
+            start_time=int(time.time() * 1000),
+        )
+        manager.jobs[job_id] = job
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = PipelineResult(
+            exit_code=42,
+            stderr=[],
+            stdout=[],
+        )
+        mock_runner_cls.return_value = mock_runner
+
+        manager._execute_validation(
+            job_id,
+            pipeline_description=job.pipeline_description,
+            max_runtime=10,
+            hard_timeout=70,
+        )
+
+        updated = manager.jobs[job_id]
+        self.assertEqual(updated.state, InternalValidationJobState.FAILED)
+        self.assertFalse(updated.is_valid)
+        assert updated.details is not None
+        self.assertEqual(len(updated.details), 1)
+        # The synthesised message must surface the exit code.
+        self.assertIn("42", updated.details[0])
+        self.assertIn("exit_code", updated.details[0])
+
     # ------------------------------------------------------------------
     # Status and summary retrieval
     # ------------------------------------------------------------------

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/pipeline_runner_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/pipeline_runner_test.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import signal
+import subprocess
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
@@ -8,23 +9,76 @@ from unittest.mock import MagicMock, patch
 from pipeline_runner import (
     PipelineRunner,
     PipelineResult,
+    LatencyTracerSample,
 )
 
 
-def _extract_pushed_fps_values(mock_urlopen: MagicMock) -> list[float]:
-    """Extract the `value` field from every JSON payload sent via urlopen.
+class _InlineThread:
+    """Test double for `threading.Thread` that runs `target` inline.
 
-    Used by tests that verify FPS metrics are pushed to metrics-service
-    through `PipelineRunner._push_fps_metric` (which calls
-    `urllib.request.urlopen` with a JSON body of the form
-    `{"name": "fps", "value": <float>}`).
+    Production code schedules every metrics push (`_post_metrics_async`)
+    on a daemon thread so the pipeline hot loop is never blocked by
+    HTTP I/O. That makes assertions like
+    ``mock_urlopen.assert_called_once()`` racy in unit tests — by the
+    time the assertion runs, the worker thread may not have executed
+    yet.
+
+    Replacing ``pipeline_runner.threading.Thread`` with this class
+    makes every push synchronous and deterministic: `start()` simply
+    invokes `target(*args, **kwargs)` in the calling thread. The
+    worker's own try/except still swallows exceptions, so test
+    behaviour mirrors production apart from timing.
+    """
+
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
+
+    def join(self, timeout=None):
+        # No-op: `start` already ran `target` to completion.
+        return
+
+
+def _extract_pushed_fps_values(mock_urlopen: MagicMock) -> list[float]:
+    """Extract the `value` field from every FPS-simple push.
+
+    Filters urlopen calls to those targeting the
+    ``/api/v1/metrics/simple`` endpoint (used by `_push_fps_metric`),
+    so tests that also trigger latency batch pushes on the same mock
+    still see a clean list of FPS values.
     """
     values: list[float] = []
     for call in mock_urlopen.call_args_list:
         req = call[0][0]
+        if not req.full_url.endswith("/api/v1/metrics/simple"):
+            continue
         payload = json.loads(req.data.decode())
         values.append(payload["value"])
     return values
+
+
+def _extract_latency_payloads(mock_urlopen: MagicMock) -> list[dict]:
+    """Extract every batch-endpoint payload sent to metrics-service.
+
+    Returns each JSON body as a dict, filtered to calls targeting the
+    ``/api/v1/metrics`` batch endpoint used by `_push_latency_sample`
+    and `_push_final_latency_metrics`.
+    """
+    payloads: list[dict] = []
+    for call in mock_urlopen.call_args_list:
+        req = call[0][0]
+        # Batch endpoint path ends with `/api/v1/metrics` (no trailing `/simple`).
+        if req.full_url.endswith("/api/v1/metrics/simple"):
+            continue
+        if not req.full_url.endswith("/api/v1/metrics"):
+            continue
+        payloads.append(json.loads(req.data.decode()))
+    return payloads
 
 
 def _make_process_mock(stdout_lines: list[str], exit_code: int = 0) -> MagicMock:
@@ -60,8 +114,15 @@ def _make_process_mock(stdout_lines: list[str], exit_code: int = 0) -> MagicMock
     return process_mock
 
 
+@patch("pipeline_runner.threading.Thread", _InlineThread)
 class TestPipelineRunnerNormalMode(unittest.TestCase):
-    """Tests for PipelineRunner in normal mode (production pipeline execution)."""
+    """Tests for PipelineRunner in normal mode (production pipeline execution).
+
+    `threading.Thread` is replaced with `_InlineThread` at the class
+    level so metrics pushes (`_post_metrics_async`) run synchronously
+    in the calling thread. That keeps urlopen assertions
+    deterministic without changing any production code path.
+    """
 
     def setUp(self):
         self.test_pipeline_command = (
@@ -342,10 +403,12 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
             runner._push_fps_metric(1.0)
 
         self.assertTrue(
-            any("Failed to push FPS metric" in line for line in captured.output)
+            any("Failed to push fps metric" in line for line in captured.output)
         )
 
 
+@patch("pipeline_runner.urllib.request.urlopen", new=MagicMock())
+@patch("pipeline_runner.threading.Thread", _InlineThread)
 class TestFpsMetricSelection(unittest.TestCase):
     """Tests for the FPS metric selection fallback chain in _run_normal.
 
@@ -675,6 +738,8 @@ class TestPipelineRunnerModeValidation(unittest.TestCase):
         self.assertIn("Invalid mode", str(ctx.exception))
 
 
+@patch("pipeline_runner.urllib.request.urlopen", new=MagicMock())
+@patch("pipeline_runner.threading.Thread", _InlineThread)
 class TestPipelineRunnerLatencyMetrics(unittest.TestCase):
     """Tests for the `enable_latency_metrics` subprocess-env configuration.
 
@@ -915,6 +980,8 @@ class TestPipelineRunnerLatencyMetrics(unittest.TestCase):
         self.assertIn("latency_tracer_pipeline_interval", joined)
 
 
+@patch("pipeline_runner.urllib.request.urlopen", new=MagicMock())
+@patch("pipeline_runner.threading.Thread", _InlineThread)
 class TestLatencyTracerIntervalParser(unittest.TestCase):
     """Unit tests for the `latency_tracer_pipeline_interval` line parser.
 
@@ -1112,6 +1179,525 @@ class TestLatencyTracerIntervalParser(unittest.TestCase):
             set(runner.latency_tracer_metrics.keys()),
             {"src_p0_s0_0_0__sink_p0_s0_0_0"},
         )
+
+
+@patch("pipeline_runner.threading.Thread", _InlineThread)
+class TestLatencyMetricsPush(unittest.TestCase):
+    """Tests for the live + final latency push to metrics-service.
+
+    Covers the runner behaviour introduced by ITEP-89980:
+    ``_push_latency_sample`` fires on every parsed interval line, and
+    ``_push_final_latency_metrics`` re-pushes the last sample per
+    stream once the subprocess exits. ``threading.Thread`` is
+    replaced with ``_InlineThread`` so every push runs synchronously
+    in the calling thread, which keeps urlopen assertions
+    deterministic.
+    """
+
+    # Sample from the DLStreamer tracer documentation — identical to
+    # the fixture used in `TestLatencyTracerIntervalParser`, repeated
+    # here so the push tests are self-contained.
+    SAMPLE_INTERVAL_LINE = (
+        "latency_tracer_pipeline_interval, "
+        "source_name=(string)src_p0_s0_0_0, "
+        "sink_name=(string)sink_p0_s0_0_0, "
+        "interval=(double)1000.25, "
+        "avg=(double)364.31, "
+        "min=(double)0.004, "
+        "max=(double)529.26, "
+        "latency=(double)21.28, "
+        "fps=(double)46.99;"
+    )
+
+    def _sample(self, seed: float = 1.0) -> LatencyTracerSample:
+        """Build a deterministic sample where every field derives from a single seed."""
+        return LatencyTracerSample(
+            interval_ms=1000.0 * seed,
+            avg_ms=10.0 * seed,
+            min_ms=1.0 * seed,
+            max_ms=100.0 * seed,
+            latency_ms=5.0 * seed,
+        )
+
+    # ------------------------------------------------------------------
+    # _push_latency_sample: payload shape, URL, tags
+    # ------------------------------------------------------------------
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_push_latency_sample_uses_batch_endpoint(self, mock_urlopen):
+        """Latency pushes target the batch `/api/v1/metrics` endpoint (NOT `/simple`)."""
+        with patch.dict(
+            "os.environ",
+            {"METRICS_SERVICE_URL": "http://example:1234"},
+            clear=False,
+        ):
+            runner = PipelineRunner(
+                mode="normal", enable_latency_metrics=True, job_id="job-42"
+            )
+
+        runner._push_latency_sample("stream-a", self._sample())
+
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        self.assertEqual(req.full_url, "http://example:1234/api/v1/metrics")
+        self.assertEqual(req.headers.get("Content-type"), "application/json")
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_push_latency_sample_payload_shape(self, mock_urlopen):
+        """Payload is a single-entry batch with the four timing fields and both tags."""
+        runner = PipelineRunner(
+            mode="normal", enable_latency_metrics=True, job_id="job-42"
+        )
+        sample = self._sample(seed=2.0)
+
+        runner._push_latency_sample("stream-a", sample)
+
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data.decode())
+        self.assertEqual(
+            body,
+            {
+                "metrics": [
+                    {
+                        "name": "pipeline_latency",
+                        "fields": {
+                            "avg_ms": sample.avg_ms,
+                            "min_ms": sample.min_ms,
+                            "max_ms": sample.max_ms,
+                            "latency_ms": sample.latency_ms,
+                        },
+                        "tags": {"job_id": "job-42", "stream_id": "stream-a"},
+                    }
+                ]
+            },
+        )
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_push_latency_sample_omits_interval_and_fps(self, mock_urlopen):
+        """`interval_ms` and `fps` must never leak into the payload fields."""
+        runner = PipelineRunner(
+            mode="normal", enable_latency_metrics=True, job_id="job-42"
+        )
+
+        runner._push_latency_sample("stream-a", self._sample())
+
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        fields = body["metrics"][0]["fields"]
+        self.assertNotIn("interval_ms", fields)
+        self.assertNotIn("fps", fields)
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_push_latency_sample_without_job_id_still_tags_stream_id(
+        self, mock_urlopen
+    ):
+        """When `job_id=None`, `stream_id` is still present as a tag."""
+        runner = PipelineRunner(mode="normal", enable_latency_metrics=True)
+
+        runner._push_latency_sample("stream-a", self._sample())
+
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        self.assertEqual(body["metrics"][0]["tags"], {"stream_id": "stream-a"})
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_push_latency_sample_swallows_network_errors(self, mock_urlopen):
+        """Network errors while pushing latency must be logged at WARNING, never raised."""
+        mock_urlopen.side_effect = OSError("boom")
+        runner = PipelineRunner(
+            mode="normal", enable_latency_metrics=True, job_id="job-42"
+        )
+
+        with self.assertLogs("PipelineRunner", level="WARNING") as captured:
+            runner._push_latency_sample("stream-a", self._sample())
+
+        self.assertTrue(
+            any("Failed to push latency metric" in line for line in captured.output)
+        )
+
+    # ------------------------------------------------------------------
+    # Live push: every parsed sample is forwarded
+    # ------------------------------------------------------------------
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_parser_triggers_live_push_for_each_sample(self, mock_urlopen):
+        """Each parsed interval line produces exactly one batch POST."""
+        runner = PipelineRunner(mode="normal", enable_latency_metrics=True)
+
+        runner._parse_and_record_latency_sample(self.SAMPLE_INTERVAL_LINE)
+        runner._parse_and_record_latency_sample(self.SAMPLE_INTERVAL_LINE)
+
+        self.assertEqual(mock_urlopen.call_count, 2)
+        for call in mock_urlopen.call_args_list:
+            req = call[0][0]
+            self.assertTrue(req.full_url.endswith("/api/v1/metrics"))
+            body = json.loads(req.data.decode())
+            self.assertEqual(body["metrics"][0]["name"], "pipeline_latency")
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_parser_live_push_uses_parsed_stream_id_as_tag(self, mock_urlopen):
+        """The `stream_id` tag matches the composite `source__sink` key in the map."""
+        runner = PipelineRunner(mode="normal", enable_latency_metrics=True)
+
+        runner._parse_and_record_latency_sample(self.SAMPLE_INTERVAL_LINE)
+
+        body = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        self.assertEqual(
+            body["metrics"][0]["tags"]["stream_id"],
+            "src_p0_s0_0_0__sink_p0_s0_0_0",
+        )
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_parser_does_not_push_when_latency_metrics_disabled(self, mock_urlopen):
+        """When `enable_latency_metrics=False`, no HTTP request is ever made."""
+        runner = PipelineRunner(mode="normal", enable_latency_metrics=False)
+
+        runner._parse_and_record_latency_sample(self.SAMPLE_INTERVAL_LINE)
+
+        mock_urlopen.assert_not_called()
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_parser_does_not_push_for_filtered_stream_id(self, mock_urlopen):
+        """Samples dropped by `_allowed_stream_ids` must not produce a push."""
+        runner = PipelineRunner(mode="normal", enable_latency_metrics=True)
+        # Allow only a different stream_id than the one in the sample line.
+        runner._allowed_stream_ids = {"some_other_stream"}
+
+        runner._parse_and_record_latency_sample(self.SAMPLE_INTERVAL_LINE)
+
+        mock_urlopen.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Final push: every stream in the map is re-pushed on exit
+    # ------------------------------------------------------------------
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_push_final_latency_metrics_emits_one_per_stream(self, mock_urlopen):
+        """One batch POST per stream present in `latency_tracer_metrics`."""
+        runner = PipelineRunner(
+            mode="normal", enable_latency_metrics=True, job_id="job-42"
+        )
+        runner.latency_tracer_metrics = {
+            "stream-a": self._sample(seed=1.0),
+            "stream-b": self._sample(seed=2.0),
+        }
+
+        runner._push_final_latency_metrics()
+
+        self.assertEqual(mock_urlopen.call_count, 2)
+        pushed_stream_ids = set()
+        for call in mock_urlopen.call_args_list:
+            body = json.loads(call[0][0].data.decode())
+            pushed_stream_ids.add(body["metrics"][0]["tags"]["stream_id"])
+        self.assertEqual(pushed_stream_ids, {"stream-a", "stream-b"})
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_push_final_latency_metrics_noop_when_disabled(self, mock_urlopen):
+        """No-op when the tracer is disabled (map is `None`)."""
+        runner = PipelineRunner(mode="normal", enable_latency_metrics=False)
+
+        runner._push_final_latency_metrics()
+
+        mock_urlopen.assert_not_called()
+
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_push_final_latency_metrics_noop_when_map_empty(self, mock_urlopen):
+        """No-op when the tracer was enabled but produced no samples."""
+        runner = PipelineRunner(mode="normal", enable_latency_metrics=True)
+        # Map already starts empty when enabled; assert explicitly for clarity.
+        self.assertEqual(runner.latency_tracer_metrics, {})
+
+        runner._push_final_latency_metrics()
+
+        mock_urlopen.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # End-to-end: final push is invoked from `_run_normal`'s `finally`
+    # ------------------------------------------------------------------
+
+    @patch("pipeline_runner.Popen")
+    @patch("pipeline_runner.ps")
+    @patch("pipeline_runner.select.select")
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_run_normal_triggers_final_latency_push_in_finally(
+        self, mock_urlopen, mock_select, mock_ps, mock_popen
+    ):
+        """A full `_run_normal` emits both a live push and a final push per stream."""
+        # One interval line on stdout: the live push fires once, then the
+        # `finally` block re-pushes the same stream → 2 batch POSTs total.
+        process_mock = _make_process_mock([self.SAMPLE_INTERVAL_LINE])
+        mock_select.return_value = ([process_mock.stdout], [], [])
+        mock_popen.return_value = process_mock
+        mock_ps.Process.return_value.status.return_value = "zombie"
+
+        runner = PipelineRunner(
+            mode="normal", enable_latency_metrics=True, job_id="job-42"
+        )
+        runner.run(pipeline_command="videotestsrc ! fakesink", total_streams=1)
+
+        batch_bodies = _extract_latency_payloads(mock_urlopen)
+        self.assertEqual(
+            len(batch_bodies),
+            2,
+            "Expected one live push + one final push for the single stream",
+        )
+        for body in batch_bodies:
+            self.assertEqual(body["metrics"][0]["name"], "pipeline_latency")
+            self.assertEqual(body["metrics"][0]["tags"]["job_id"], "job-42")
+            self.assertEqual(
+                body["metrics"][0]["tags"]["stream_id"],
+                "src_p0_s0_0_0__sink_p0_s0_0_0",
+            )
+
+    @patch("pipeline_runner.Popen")
+    @patch("pipeline_runner.ps")
+    @patch("pipeline_runner.select.select")
+    @patch("pipeline_runner.urllib.request.urlopen")
+    def test_run_normal_does_not_push_latency_when_disabled(
+        self, mock_urlopen, mock_select, mock_ps, mock_popen
+    ):
+        """With `enable_latency_metrics=False`, no batch-endpoint call is ever made."""
+        process_mock = _make_process_mock([self.SAMPLE_INTERVAL_LINE])
+        mock_select.return_value = ([process_mock.stdout], [], [])
+        mock_popen.return_value = process_mock
+        mock_ps.Process.return_value.status.return_value = "zombie"
+
+        runner = PipelineRunner(
+            mode="normal", enable_latency_metrics=False, job_id="job-42"
+        )
+        runner.run(pipeline_command="videotestsrc ! fakesink", total_streams=1)
+
+        batch_bodies = _extract_latency_payloads(mock_urlopen)
+        self.assertEqual(batch_bodies, [])
+
+
+class TestPipelineResultRepr(unittest.TestCase):
+    """Coverage for the custom ``PipelineResult.__repr__``.
+
+    The implementation formats ``latency_tracer_metrics`` by its
+    cardinality so the repr stays compact when many streams are
+    running; both branches (``None`` and non-empty dict) must be
+    covered.
+    """
+
+    def test_repr_with_latency_metrics_none(self):
+        """When tracer is disabled the repr uses the literal ``None`` marker."""
+        result = PipelineResult(total_fps=10.0, per_stream_fps=5.0, num_streams=2)
+        text = repr(result)
+        self.assertIn("PipelineResult(", text)
+        self.assertIn("latency_tracer_metrics=None", text)
+
+    def test_repr_with_latency_metrics_streams(self):
+        """When tracer produced samples the repr summarises their count."""
+        sample = LatencyTracerSample(
+            interval_ms=1000.0,
+            avg_ms=10.0,
+            min_ms=1.0,
+            max_ms=100.0,
+            latency_ms=5.0,
+        )
+        result = PipelineResult(
+            total_fps=10.0,
+            per_stream_fps=5.0,
+            num_streams=2,
+            latency_tracer_metrics={"a": sample, "b": sample},
+        )
+        text = repr(result)
+        self.assertIn("latency_tracer_metrics=<2 stream(s)>", text)
+
+
+class TestGetLogLevel(unittest.TestCase):
+    """Coverage for the ``RUNNER_LOG_LEVEL`` env-var parsing."""
+
+    @patch.dict("os.environ", {"RUNNER_LOG_LEVEL": "DEBUG"}, clear=False)
+    def test_valid_level_is_returned_as_is(self):
+        self.assertEqual(PipelineRunner._get_log_level(), "DEBUG")
+
+    @patch.dict("os.environ", {"RUNNER_LOG_LEVEL": "not-a-level"}, clear=False)
+    def test_invalid_level_falls_back_to_info(self):
+        """Unknown values must map to the documented default ``INFO``."""
+        self.assertEqual(PipelineRunner._get_log_level(), "INFO")
+
+
+class TestGracefulTerminate(unittest.TestCase):
+    """Coverage for ``PipelineRunner._graceful_terminate``.
+
+    The method is a defensive helper used in three distinct
+    scenarios, each represented here by one test:
+
+    1. The subprocess has already exited — ``poll()`` returns an
+       exit code and the method short-circuits with no signal.
+    2. The subprocess ignores SIGINT and ``wait(timeout=...)`` raises
+       ``TimeoutExpired`` — the method must escalate to SIGKILL.
+    3. ``send_signal`` raises ``OSError`` (process reaped between the
+       ``poll()`` check and the signal) — the exception is swallowed.
+    """
+
+    def test_returns_immediately_when_process_already_exited(self):
+        proc = MagicMock()
+        proc.poll.return_value = 0  # already exited
+
+        PipelineRunner._graceful_terminate(proc)
+
+        proc.send_signal.assert_not_called()
+        proc.kill.assert_not_called()
+
+    def test_escalates_to_sigkill_on_sigint_timeout(self):
+        """SIGINT timing out triggers SIGKILL + a final ``wait``."""
+        proc = MagicMock()
+        proc.poll.return_value = None  # still running
+        proc.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="gst_runner.py", timeout=0.1),
+            0,  # second wait() after kill() succeeds
+        ]
+
+        PipelineRunner._graceful_terminate(proc, timeout=0.1)
+
+        proc.send_signal.assert_called_once_with(signal.SIGINT)
+        proc.kill.assert_called_once()
+        self.assertEqual(proc.wait.call_count, 2)
+
+    def test_swallows_oserror_from_send_signal(self):
+        """``OSError`` (e.g. ``ESRCH`` after reap) must not propagate."""
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.send_signal.side_effect = OSError("no such process")
+
+        # Must not raise.
+        PipelineRunner._graceful_terminate(proc)
+
+        proc.send_signal.assert_called_once_with(signal.SIGINT)
+
+
+@patch("pipeline_runner.threading.Thread", _InlineThread)
+class TestRunNormalEdgeCases(unittest.TestCase):
+    """End-to-end coverage for rarely exercised ``_run_normal`` paths.
+
+    These paths are hard to reach through the main happy-path tests
+    because they rely on specific ``select`` / ``psutil`` orderings,
+    but they are the runner's safety net in production and deserve
+    explicit assertions.
+    """
+
+    PIPELINE_CMD = "videotestsrc ! gvafpscounter ! fakesink"
+
+    @patch("pipeline_runner.Popen")
+    @patch("pipeline_runner.ps")
+    @patch("pipeline_runner.select.select")
+    @patch("pipeline_runner.urllib.request.urlopen", new=MagicMock())
+    def test_stderr_lines_are_captured_and_returned(
+        self, mock_select, mock_ps, mock_popen
+    ):
+        """An stderr line must land in ``PipelineResult.stderr``.
+
+        The main test suite always wires ``select`` to return stdout
+        only; this one returns stderr so the ``elif r == process.stderr``
+        branch in the stdout reader loop is executed.
+        """
+        process_mock = MagicMock()
+        process_mock.pid = 1234
+        process_mock.stdout = MagicMock()
+        process_mock.stderr = MagicMock()
+        process_mock.stdout.fileno.return_value = 10
+        process_mock.stderr.fileno.return_value = 11
+        # First iteration: stderr has one line. Subsequent iterations:
+        # nothing; poll then returns 0 to end the main loop.
+        process_mock.stderr.readline.side_effect = itertools.chain(
+            [b"boom on stderr\n"], itertools.repeat(b"")
+        )
+        process_mock.stdout.readline.return_value = b""
+        process_mock.poll.side_effect = itertools.chain([None], itertools.repeat(0))
+        process_mock.wait.return_value = 0
+        process_mock.returncode = 0
+        process_mock.communicate.return_value = (b"", b"")
+        mock_popen.return_value = process_mock
+
+        mock_select.side_effect = itertools.chain(
+            [([process_mock.stderr], [], [])], itertools.repeat(([], [], []))
+        )
+        # ps.Process must stay "running" until the main loop exits.
+        mock_ps.Process.return_value.status.return_value = "running"
+
+        runner = PipelineRunner(mode="normal", max_runtime=0)
+        result = runner.run(pipeline_command=self.PIPELINE_CMD, total_streams=1)
+
+        self.assertIn("boom on stderr", "\n".join(result.stderr))
+
+    @patch("pipeline_runner.Popen")
+    @patch("pipeline_runner.ps")
+    @patch("pipeline_runner.select.select")
+    @patch("pipeline_runner.urllib.request.urlopen", new=MagicMock())
+    def test_zombie_detection_ends_loop(self, mock_select, mock_ps, mock_popen):
+        """When ``ps`` reports the child as a zombie the runner breaks out
+        and calls ``wait()`` to reap it, regardless of ``poll()``.
+        """
+        process_mock = MagicMock()
+        process_mock.pid = 1234
+        process_mock.stdout = MagicMock()
+        process_mock.stderr = MagicMock()
+        process_mock.stdout.fileno.return_value = 10
+        process_mock.stderr.fileno.return_value = 11
+        process_mock.stdout.readline.side_effect = itertools.chain(
+            [b"some stdout line\n"], itertools.repeat(b"")
+        )
+        process_mock.stderr.readline.return_value = b""
+        # First poll: still running (enters the loop). After the zombie
+        # branch calls wait(), subsequent polls return the exit code so
+        # the outer ``while`` terminates.
+        process_mock.poll.side_effect = itertools.chain([None], itertools.repeat(0))
+        process_mock.wait.return_value = 0
+        process_mock.returncode = 0
+        process_mock.communicate.return_value = (b"", b"")
+        mock_popen.return_value = process_mock
+
+        mock_select.return_value = ([process_mock.stdout], [], [])
+        mock_ps.Process.return_value.status.return_value = "zombie"
+
+        runner = PipelineRunner(mode="normal", max_runtime=0)
+        result = runner.run(pipeline_command=self.PIPELINE_CMD, total_streams=1)
+
+        self.assertIsInstance(result, PipelineResult)
+        # wait() must have been called to reap the zombie.
+        process_mock.wait.assert_called()
+
+    @patch("pipeline_runner.Popen")
+    @patch("pipeline_runner.ps")
+    @patch("pipeline_runner.select.select")
+    @patch("pipeline_runner.urllib.request.urlopen", new=MagicMock())
+    def test_no_such_process_ends_loop(self, mock_select, mock_ps, mock_popen):
+        """When ``psutil.Process`` raises ``NoSuchProcess`` the runner
+        treats it as end-of-life: breaks out and calls ``wait()``.
+        """
+        process_mock = MagicMock()
+        process_mock.pid = 1234
+        process_mock.stdout = MagicMock()
+        process_mock.stderr = MagicMock()
+        process_mock.stdout.fileno.return_value = 10
+        process_mock.stderr.fileno.return_value = 11
+        process_mock.stdout.readline.side_effect = itertools.chain(
+            [b"some stdout line\n"], itertools.repeat(b"")
+        )
+        process_mock.stderr.readline.return_value = b""
+        # Same trick as the zombie test: first poll lets the runner
+        # enter the loop, subsequent polls exit it.
+        process_mock.poll.side_effect = itertools.chain([None], itertools.repeat(0))
+        process_mock.wait.return_value = 0
+        process_mock.returncode = 0
+        process_mock.communicate.return_value = (b"", b"")
+        mock_popen.return_value = process_mock
+
+        mock_select.return_value = ([process_mock.stdout], [], [])
+        # psutil raises NoSuchProcess(pid) — the runner must handle it.
+        import psutil
+
+        mock_ps.NoSuchProcess = psutil.NoSuchProcess
+        mock_ps.Process.return_value.status.side_effect = psutil.NoSuchProcess(
+            process_mock.pid
+        )
+
+        runner = PipelineRunner(mode="normal", max_runtime=0)
+        result = runner.run(pipeline_command=self.PIPELINE_CMD, total_streams=1)
+
+        self.assertIsInstance(result, PipelineResult)
+        process_mock.wait.assert_called()
 
 
 if __name__ == "__main__":

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/pipeline_runner_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/pipeline_runner_test.py
@@ -13,35 +13,51 @@ from pipeline_runner import (
 )
 
 
-class _InlineThread:
-    """Test double for `threading.Thread` that runs `target` inline.
+class _SyncExecutor:
+    """Test double for the metrics-push ``ThreadPoolExecutor``.
 
-    Production code schedules every metrics push (`_post_metrics_async`)
-    on a daemon thread so the pipeline hot loop is never blocked by
-    HTTP I/O. That makes assertions like
-    ``mock_urlopen.assert_called_once()`` racy in unit tests — by the
-    time the assertion runs, the worker thread may not have executed
+    Production code submits every metrics push
+    (``_post_metrics_async``) to a shared class-level
+    ``ThreadPoolExecutor`` so the pipeline hot loop is never blocked
+    by HTTP I/O. That makes assertions like
+    ``mock_urlopen.assert_called_once()`` racy in unit tests — by
+    the time the assertion runs, the worker may not have executed
     yet.
 
-    Replacing ``pipeline_runner.threading.Thread`` with this class
-    makes every push synchronous and deterministic: `start()` simply
-    invokes `target(*args, **kwargs)` in the calling thread. The
-    worker's own try/except still swallows exceptions, so test
-    behaviour mirrors production apart from timing.
+    Patching ``PipelineRunner._get_metrics_executor`` to return this
+    stub makes every push synchronous and deterministic:
+    ``submit(fn, *args, **kwargs)`` simply invokes ``fn`` in the
+    calling thread. The worker's own try/except still swallows
+    exceptions, so test behaviour mirrors production apart from
+    timing.
     """
 
-    def __init__(self, target=None, args=(), kwargs=None, daemon=None):
-        self._target = target
-        self._args = args
-        self._kwargs = kwargs or {}
+    def submit(self, fn, *args, **kwargs):
+        fn(*args, **kwargs)
+        # Return a real-looking sentinel so callers that store the
+        # future do not trip over ``None``. No test inspects it.
+        return MagicMock(name="sync-future")
 
-    def start(self):
-        if self._target is not None:
-            self._target(*self._args, **self._kwargs)
 
-    def join(self, timeout=None):
-        # No-op: `start` already ran `target` to completion.
-        return
+def _patch_sync_metrics_executor(target):
+    """Decorator that swaps the shared metrics executor for a sync stub.
+
+    Uses ``patch.object(..., new=...)`` so no extra mock argument is
+    injected into the decorated methods — keeping test signatures
+    unchanged when the decorator is applied at class level.
+
+    The replacement is wrapped in ``classmethod`` so that the
+    descriptor binding of the original ``_get_metrics_executor`` is
+    preserved (otherwise the auto-passed ``cls`` would arrive as a
+    spurious positional argument). A fresh ``_SyncExecutor`` is
+    returned on every call; it is stateless so the cost is
+    negligible.
+    """
+    return patch.object(
+        PipelineRunner,
+        "_get_metrics_executor",
+        new=classmethod(lambda cls: _SyncExecutor()),
+    )(target)
 
 
 def _extract_pushed_fps_values(mock_urlopen: MagicMock) -> list[float]:
@@ -114,14 +130,15 @@ def _make_process_mock(stdout_lines: list[str], exit_code: int = 0) -> MagicMock
     return process_mock
 
 
-@patch("pipeline_runner.threading.Thread", _InlineThread)
+@_patch_sync_metrics_executor
 class TestPipelineRunnerNormalMode(unittest.TestCase):
     """Tests for PipelineRunner in normal mode (production pipeline execution).
 
-    `threading.Thread` is replaced with `_InlineThread` at the class
-    level so metrics pushes (`_post_metrics_async`) run synchronously
-    in the calling thread. That keeps urlopen assertions
-    deterministic without changing any production code path.
+    The shared metrics-push ``ThreadPoolExecutor`` is replaced with a
+    synchronous stub at the class level so metrics pushes
+    (``_post_metrics_async``) run inline in the calling thread. That
+    keeps urlopen assertions deterministic without changing any
+    production code path.
     """
 
     def setUp(self):
@@ -408,7 +425,7 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
 
 
 @patch("pipeline_runner.urllib.request.urlopen", new=MagicMock())
-@patch("pipeline_runner.threading.Thread", _InlineThread)
+@_patch_sync_metrics_executor
 class TestFpsMetricSelection(unittest.TestCase):
     """Tests for the FPS metric selection fallback chain in _run_normal.
 
@@ -739,7 +756,7 @@ class TestPipelineRunnerModeValidation(unittest.TestCase):
 
 
 @patch("pipeline_runner.urllib.request.urlopen", new=MagicMock())
-@patch("pipeline_runner.threading.Thread", _InlineThread)
+@_patch_sync_metrics_executor
 class TestPipelineRunnerLatencyMetrics(unittest.TestCase):
     """Tests for the `enable_latency_metrics` subprocess-env configuration.
 
@@ -981,7 +998,7 @@ class TestPipelineRunnerLatencyMetrics(unittest.TestCase):
 
 
 @patch("pipeline_runner.urllib.request.urlopen", new=MagicMock())
-@patch("pipeline_runner.threading.Thread", _InlineThread)
+@_patch_sync_metrics_executor
 class TestLatencyTracerIntervalParser(unittest.TestCase):
     """Unit tests for the `latency_tracer_pipeline_interval` line parser.
 
@@ -1181,17 +1198,17 @@ class TestLatencyTracerIntervalParser(unittest.TestCase):
         )
 
 
-@patch("pipeline_runner.threading.Thread", _InlineThread)
+@_patch_sync_metrics_executor
 class TestLatencyMetricsPush(unittest.TestCase):
     """Tests for the live + final latency push to metrics-service.
 
     Covers the runner behaviour introduced by ITEP-89980:
     ``_push_latency_sample`` fires on every parsed interval line, and
     ``_push_final_latency_metrics`` re-pushes the last sample per
-    stream once the subprocess exits. ``threading.Thread`` is
-    replaced with ``_InlineThread`` so every push runs synchronously
-    in the calling thread, which keeps urlopen assertions
-    deterministic.
+    stream once the subprocess exits. The shared metrics-push
+    ``ThreadPoolExecutor`` is replaced with a synchronous stub so
+    every push runs inline in the calling thread, which keeps
+    urlopen assertions deterministic.
     """
 
     # Sample from the DLStreamer tracer documentation — identical to
@@ -1567,7 +1584,7 @@ class TestGracefulTerminate(unittest.TestCase):
         proc.send_signal.assert_called_once_with(signal.SIGINT)
 
 
-@patch("pipeline_runner.threading.Thread", _InlineThread)
+@_patch_sync_metrics_executor
 class TestRunNormalEdgeCases(unittest.TestCase):
     """End-to-end coverage for rarely exercised ``_run_normal`` paths.
 


### PR DESCRIPTION
## Summary

Makes `PipelineRunner` publish both FPS and DLStreamer `latency_tracer` samples to `metrics-service` over HTTP, tagged per job and per stream. Replaces the previous "update an in-memory map and log each sample at INFO" stopgap with a live fire-and-forget push, and consolidates all metrics I/O behind a single shared helper.

## Motivation

Until now `PipelineRunner` was the only place where runtime pipeline signals (FPS and tracer samples) were observable, and only locally - FPS was pushed to `metrics-service` without a job tag, and every parsed `latency_tracer_pipeline_interval` line was merely stored on the runner instance and echoed to the log. With concurrent jobs and multiple streams per pipeline this is not enough: the dashboard needs per-job, per-stream data, delivered as it is produced.

## Changes

### `vippet/pipeline_runner.py`

- **`job_id` on the runner.** `PipelineRunner.__init__` now accepts an optional `job_id: str | None`. When set, every metric pushed by this runner carries a `tags.job_id` field so `metrics-service` can partition data per job. `None` is kept as a valid default for ad-hoc callers (e.g. the transcoding path in `videos.py`) that do not belong to a job. Validation mode accepts the argument for API uniformity but never pushes (no `gvafpscounter` / tracer in that mode).
- **Shared HTTP primitive.** Introduced `_post_metrics_async(url, payload, description)` as the single I/O entry point for all metric pushes:
  - Runs the POST on a daemon thread so the stdout hot loop is never blocked by a slow or unavailable `metrics-service`.
  - Snapshots everything the worker needs so it does not reach back into `self`.
  - Uses `urllib.request.urlopen` inside a context manager to deterministically release the socket / file descriptor after each request.
  - Swallows every exception with a WARNING log - network errors must never crash a pipeline run.
- **FPS push refactored.** `_push_fps_metric` is now a thin wrapper that builds the `{"name": "fps", "value": ...}` payload (optionally with `tags.job_id`) and delegates to `_post_metrics_async`. Endpoint and trigger points are unchanged: pushed on each new average line from `gvafpscounter` and once with `0.0` from the `_run_normal` `finally` block to signal pipeline stop.
- **Live latency push.** `_parse_and_record_latency_sample` now forwards every parsed sample to `metrics-service` via the new `_push_latency_sample(stream_id, sample)` helper. This removes the previous TODOs and the per-sample INFO log is demoted to DEBUG now that `metrics-service` is the primary surface for tracer values.
  - Endpoint: `/api/v1/metrics` (batch shape with a single entry) so all four timing fields of one sample travel in a single request, instead of four separate calls to `/simple` per stream per second.
  - Payload: `name="pipeline_latency"`, `fields={avg_ms, min_ms, max_ms, latency_ms}`, `tags={job_id?, stream_id}`.
  - `interval_ms` and `fps` are intentionally omitted: the emission cadence is fixed at 1000 ms, `metrics-service` timestamps on receipt, and FPS is already reported by `_push_fps_metric` - keeping it here would double-count throughput.
- **Final latency push on exit.** New `_push_final_latency_metrics` iterates the in-memory `latency_tracer_metrics` map and re-publishes the last observed sample per stream. Called once from the `_run_normal` `finally` block alongside the existing FPS `0.0` push, so at least one final `pipeline_latency` point per stream reaches the backend even if the last in-flight live push raced with pipeline teardown. No-op when the tracer is disabled or produced no samples.
- **Endpoint URLs pre-computed once.** Both `/api/v1/metrics/simple` (FPS) and `/api/v1/metrics` (latency batch) URLs are built once in `__init__` from the normalised `METRICS_SERVICE_URL` base, so the hot loop never re-concatenates them.

### `vippet/benchmark.py`

- `Benchmark.__init__` accepts and forwards `job_id` into its internal `PipelineRunner`, so FPS metrics pushed during each density iteration are tagged with the owning job's id.

### `vippet/managers/tests_manager.py`

- Both the performance (`_execute_performance_test`) and density (`_execute_density_test`) paths now pass `job_id=job_id` to `PipelineRunner` / `Benchmark`.

### `vippet/managers/validation_manager.py`

- `_execute_validation` forwards `job_id` to `PipelineRunner` for API consistency. No runtime effect - validation mode does not emit metrics.

### `vippet/managers/pipeline_manager.py`

- Removed the "Stream identifiers per pipeline" INFO dump and its TODO. With `stream_id` now published as a tag on every live `pipeline_latency` sample, the stream-to-tracer correlation is visible directly in `metrics-service` and no longer needs a start-of-run log diagnostic.

## Behaviour Impact

- FPS pushes now carry `tags.job_id` when the runner was created with one; other callers (ad-hoc runs) still produce untagged FPS, unchanged from the previous behaviour.
- When `enable_latency_metrics=True`, every `latency_tracer_pipeline_interval` line produces one live POST to `/api/v1/metrics`, plus one final POST per stream after the subprocess exits. When `enable_latency_metrics=False`, no latency-related HTTP request is ever made.
- All pushes are fire-and-forget on daemon threads; a slow or unavailable `metrics-service` logs a WARNING and does not affect pipeline timing or stability.
- Per-sample INFO log for `latency_tracer` samples is gone; equivalent output is still available at DEBUG.