### PR TITLE
Add secure-by-default Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,267 @@
+# Edge AI Libraries – AI Agent Instructions
+
+**Edge AI Libraries** is a monorepo of optimized libraries, microservices, tools, and sample applications for building and deploying real-time AI solutions on edge devices. Components span computer vision, multimedia analytics, generative AI, time-series analytics, and model lifecycle management.
+
+Components are **independently versioned and deployable**. Each component under `libraries/`, `microservices/`, `tools/`, `frameworks/`, and `sample-applications/` is self-contained with its own Dockerfile, Makefile, Helm chart, and tests.
+
+## Licensing Requirements (Critical – All Files)
+
+**All files must include:**
+
+- SPDX license header: `SPDX-License-Identifier: Apache-2.0`
+- Copyright line: `(C) <YEAR> Intel Corporation` (use current year for new files)
+- Example:
+  ```python
+  # SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+  # SPDX-License-Identifier: Apache-2.0
+  ```
+- **Enforcement**: REUSE/license compliance checked in CI (see `codeql.yaml`, `zizmor-scan.yaml`)
+
+## Language-Specific Skills (Load On-Demand)
+
+Consult these based on the code you're working with. Skills reside under `.github/skills/`.
+
+| Skill file | When to load |
+|---|---|
+| `.github/skills/security.md` | Dockerfile, Compose, Helm, auth/authz, input parsing, dependency changes, CVE-related work |
+
+> **Instruction Placement Policy**: Keep this file focused on high-level routing and architecture context. Detailed procedural checklists belong in skill files under `.github/skills/`. Avoid duplicating checklist content between this file and skills.
+
+## Security Defaults (Always-On)
+
+Apply secure-by-default behavior across all code generation, changes, and reviews, regardless of language or component.
+
+- Prefer least privilege across code, services, identities, file permissions, APIs, containers, and workflows; avoid insecure defaults.
+- Treat all external input as untrusted and validate format, type, range, and length at trust boundaries.
+- Never hard-code or introduce secrets, credentials, keys, tokens, or passwords in source, tests, configs, or templates; use environment variables or approved secret-management mechanisms.
+- Avoid exposing sensitive data in logs, traces, errors, metrics, or test artifacts.
+- Prevent injection vulnerabilities by avoiding unsafe string construction and using safe, context-appropriate APIs.
+- Prefer trusted, actively maintained dependencies and images; verify sources and pin versions where feasible.
+- Avoid deprecated, unmaintained, or ambiguous packages.
+- Do not suggest bypassing or weakening existing security checks or validations.
+- Keep authorization checks server-side and close to protected resources.
+- Avoid unsafe dynamic execution patterns (`eval`, `exec`, untrusted command construction).
+- Prevent time-of-check/time-of-use (TOCTOU) race conditions in state-dependent checks (e.g., certificate validation.
+- Do not assume trusted inputs, networks, or environments.
+- Be explicit about assumptions and limitations.
+- Fail safely and visibly.
+
+## AI Output Trust Model
+
+Treat AI-generated output as **untrusted draft code** until reviewed and tested.
+Reject suggestions that bypass security controls for convenience or introduce unsafe defaults.
+
+For detailed security review guidance, follow:
+`.github/skills/security.md`.
+
+## Repository Structure
+
+```
+edge-ai-libraries/
+├── libraries/          # Reusable AI/ML libraries (anomalib, datumaro, geti-sdk, model_api, …)
+├── microservices/      # Standalone deployable services (dlstreamer-pipeline-server, model-registry,
+│                       #   time-series-analytics, vlm-openvino-serving, audio-analyzer, …)
+├── sample-applications/# End-to-end reference apps (chat-qna, document-summarization, …)
+├── tools/              # Developer tooling (npu-monitor-tool, visual-pipeline-evaluation, …)
+├── frameworks/         # Edge device enablement framework
+└── .github/
+    ├── workflows/      # Per-component CI (dlsps-*, timeseries-*, GENAI-*, modelregistry-*, …)
+    └── skills/         # On-demand AI agent skill files
+```
+
+### Key Microservices
+
+| Microservice | Purpose |
+|---|---|
+| `dlstreamer-pipeline-server` | REST/gRPC-managed DL Streamer video analytics pipelines |
+| `model-registry` | Model lifecycle management, versioning, and metadata store |
+| `time-series-analytics` | Industrial time-series data processing and ML inference |
+| `vlm-openvino-serving` | Vision-Language Model serving via OpenVINO |
+| `audio-analyzer` | Audio classification and event detection |
+| `model-download` | Model artifact download and caching service |
+| `multimodal-embedding-serving` | Embedding generation for multimodal retrieval |
+| `multilevel-video-understanding` | Hierarchical video understanding and summarization |
+| `semantic-search-agent` | Vector-based semantic search agent |
+| `vector-retriever` | Retrieval layer for vector database backends |
+| `visual-data-preparation-for-retrieval` | Dataset preprocessing for visual retrieval pipelines |
+| `document-ingestion` | Document parsing and indexing for RAG pipelines |
+
+## Component Layout Convention
+
+Each component follows a consistent layout:
+
+```
+<component>/
+├── Dockerfile              # Container build definition
+├── Makefile                # Standard targets: build, lint, test, coverage
+├── README.md               # Quick start
+├── helm/ or chart/         # Helm chart for Kubernetes deployment
+├── docker/                 # Docker Compose files and supporting config
+├── src/                    # Application source code
+├── tests/                  # Unit and integration tests
+├── docs/                   # Component documentation
+├── requirements.txt         # Python runtime dependencies (or pyproject.toml / uv.lock)
+└── document-versions.yaml  # Tracks documentation versioning
+```
+
+> Some newer components use `pyproject.toml` + `uv.lock` instead of `requirements.txt`. Prefer `uv` for lock-file-based installs in those components.
+
+## Build System Patterns
+
+Each component is built independently. There is no monorepo-wide build orchestrator; use per-component Makefiles.
+
+**Standard Makefile targets** (all components):
+
+```bash
+make build        # Build container image
+make lint         # Run linters (pylint, yamllint, etc.)
+make test         # Run test suite (pytest or docker-based)
+make coverage     # Generate coverage report
+make help         # List all available targets
+```
+
+**Container builds** use Docker or Docker Compose. Build scripts are typically in `tests/build.sh` or triggered via `docker compose build`.
+
+**CI workflows** are per-component under `.github/workflows/`:
+- PR workflows: `dlsps-pr-workflow.yaml`, `timeseries-build-pull-request.yml`, `modelregistry-build-pull-request.yaml`, `genai-pre-merge.yaml`
+- Scan workflows: `codeql.yaml`, `trivy-config-mode.yaml`, `zizmor-scan.yaml`, `timeseries-scans.yaml`
+- Weekly/release: `dlsps-package-helm-weekly.yaml`, `siv-weekly-tag.yaml`
+
+## Testing Framework
+
+Tests are co-located within each component under `tests/` (unit + integration) and `tests-functional/` (end-to-end, where present).
+
+**Running tests** (component-specific, from component root):
+
+```bash
+make test                                    # Run test suite via Makefile
+pytest -vv --cov=src --cov-report term-missing   # Direct pytest (model-registry, others)
+docker run --entrypoint <test-script> <image>    # Containerized test runner (dlstreamer-pipeline-server)
+```
+
+**Coverage**: Run `make coverage` or pass `--cov` flags to pytest.
+
+**Test image freshness**: Rebuild container images before running containerized tests after source changes:
+
+```bash
+make build && make test
+```
+
+## Code Patterns & Conventions
+
+**Python packaging**:
+- Most microservices use `src/` layout with `requirements.txt` (or `pyproject.toml`)
+- Newer components (`model-download`) use `uv` with a `uv.lock` lockfile — prefer `uv sync` over `pip install` in those components
+
+**REST APIs**:
+- Services expose HTTP REST APIs; refer to each component's `docs/` or `README.md` for endpoint definitions
+- OpenAPI specs, where available, are under `docs/` or `src/rest_api/`
+
+**Helm / Kubernetes**:
+- Helm charts are under `<component>/helm/` or `<component>/chart/`
+- Values files follow `values.yaml` (defaults) with override patterns documented in component `docs/`
+
+**Configuration injection**:
+- Runtime configuration via environment variables and mounted config files
+- Secrets must use Docker Compose secrets, Kubernetes Secrets, or environment variable injection — never baked into images
+
+**Observability**:
+- OpenTelemetry instrumentation is present in some components (e.g., `dlstreamer-pipeline-server/src/opentelemetry/`)
+- Enable via environment variables; refer to component documentation
+
+**Documentation versioning**:
+- `document-versions.yaml` in each component tracks doc artifact versions
+- Update when publishing new component versions
+
+## Common Developer Workflows
+
+**Modifying a microservice** (example: `model-registry`):
+
+1. Edit source in `<component>/src/`
+2. Rebuild image: `make build`
+3. Run tests: `make test`
+4. Start service: `docker compose -f docker/docker-compose.yml up`
+5. Review logs: `docker compose -f docker/docker-compose.yml logs -f`
+
+**Adding a Python dependency**:
+- `requirements.txt`-based: add to `requirements.txt`, rebuild image
+- `pyproject.toml`/`uv`-based: `uv add <package>`, commit updated `uv.lock`
+
+**Running linters**:
+
+```bash
+make lint
+# or directly
+pylint src/
+yamllint .
+```
+
+**Partial clone** (contributing to a single component):
+
+```bash
+git clone --filter=blob:none --sparse https://github.com/open-edge-platform/edge-ai-libraries.git
+cd edge-ai-libraries
+git sparse-checkout add microservices/model-registry
+```
+
+## Integration Points & Dependencies
+
+**External runtime services** (component-specific, declared in `docker/docker-compose.yml`):
+- Vector databases: Milvus (semantic-search, vector-retriever, visual-data-preparation)
+- LLM backends: OpenAI-compatible API or local OpenVINO model server
+- Message brokers: Kafka or MQTT (where applicable in pipeline-server)
+- Object storage: MinIO or equivalent (model-download, document-ingestion)
+
+**OpenVINO**:
+- Used across inference-serving microservices for optimized edge inference
+- Model format: IR (`.xml` + `.bin`) or ONNX; see individual component docs
+
+**DLStreamer**:
+- GStreamer-based video analytics pipeline server
+- Pipeline definitions via JSON or REST API; see `dlstreamer-pipeline-server/docs/`
+
+## File Organization Essentials
+
+- **`<component>/Makefile`**: Per-component build, lint, test, and coverage targets
+- **`<component>/Dockerfile`**: Container build definition (production image)
+- **`<component>/docker/`**: Docker Compose files and supporting configs for local development
+- **`<component>/helm/`** or **`chart/`**: Helm chart for Kubernetes deployment
+- **`<component>/src/`**: Application source code
+- **`<component>/tests/`**: Unit and integration tests
+- **`<component>/docs/`**: Component user guide and API documentation
+- **`.github/workflows/`**: Per-component CI pipeline definitions
+- **`.github/skills/security.md`**: On-demand security review skill
+
+## Documentation Requirements (Always-On)
+
+### When to update documentation
+
+Update documentation immediately when making any of these changes:
+
+- Adding new features, APIs, endpoints, or configuration options
+- Modifying request/response formats or default behaviors
+- Changing build targets, Makefile commands, or deployment procedures
+- Updating dependencies or system requirements
+- Adding or removing environment variables
+- Publishing a new component version (update `document-versions.yaml`)
+
+### Key documentation locations (per component)
+
+- `<component>/README.md` — Quick start and overview
+- `<component>/docs/user-guide/` — Full user guide, API reference, build-from-source guide
+- `docs.openedgeplatform.intel.com` — Published cross-component documentation
+
+## Quick Reference: New Microservice Checklist
+
+When adding a new microservice under `microservices/`:
+
+1. Create folder with `Dockerfile`, `Makefile`, `src/`, `requirements.txt` (or `pyproject.toml`)
+2. Add standard Makefile targets: `build`, `lint`, `test`, `coverage`, `help`
+3. Add `docker/docker-compose.yml` for local development
+4. Add Helm chart under `helm/` with `Chart.yaml`, `values.yaml`, and templates
+5. Create tests in `tests/` with appropriate test runner configuration
+6. Add a CI workflow under `.github/workflows/` for PR validation and scanning
+7. Create `README.md` and `docs/` with user guide and API reference
+8. Add `document-versions.yaml` for documentation versioning
+9. Ensure SPDX license headers are present in all source files
+10. Register component in root `README.md` component table

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,47 +106,6 @@ Each component follows a consistent layout:
 
 > Some newer components use `pyproject.toml` + `uv.lock` instead of `requirements.txt`. Prefer `uv` for lock-file-based installs in those components.
 
-## Build System Patterns
-
-Each component is built independently. There is no monorepo-wide build orchestrator; use per-component Makefiles.
-
-**Standard Makefile targets** (all components):
-
-```bash
-make build        # Build container image
-make lint         # Run linters (pylint, yamllint, etc.)
-make test         # Run test suite (pytest or docker-based)
-make coverage     # Generate coverage report
-make help         # List all available targets
-```
-
-**Container builds** use Docker or Docker Compose. Build scripts are typically in `tests/build.sh` or triggered via `docker compose build`.
-
-**CI workflows** are per-component under `.github/workflows/`:
-- PR workflows: `dlsps-pr-workflow.yaml`, `timeseries-build-pull-request.yml`, `modelregistry-build-pull-request.yaml`, `genai-pre-merge.yaml`
-- Scan workflows: `codeql.yaml`, `trivy-config-mode.yaml`, `zizmor-scan.yaml`, `timeseries-scans.yaml`
-- Weekly/release: `dlsps-package-helm-weekly.yaml`, `siv-weekly-tag.yaml`
-
-## Testing Framework
-
-Tests are co-located within each component under `tests/` (unit + integration) and `tests-functional/` (end-to-end, where present).
-
-**Running tests** (component-specific, from component root):
-
-```bash
-make test                                    # Run test suite via Makefile
-pytest -vv --cov=src --cov-report term-missing   # Direct pytest (model-registry, others)
-docker run --entrypoint <test-script> <image>    # Containerized test runner (dlstreamer-pipeline-server)
-```
-
-**Coverage**: Run `make coverage` or pass `--cov` flags to pytest.
-
-**Test image freshness**: Rebuild container images before running containerized tests after source changes:
-
-```bash
-make build && make test
-```
-
 ## Code Patterns & Conventions
 
 **Python packaging**:
@@ -194,14 +153,6 @@ make lint
 # or directly
 pylint src/
 yamllint .
-```
-
-**Partial clone** (contributing to a single component):
-
-```bash
-git clone --filter=blob:none --sparse https://github.com/open-edge-platform/edge-ai-libraries.git
-cd edge-ai-libraries
-git sparse-checkout add microservices/model-registry
 ```
 
 ## Integration Points & Dependencies

--- a/.github/skills/security.md
+++ b/.github/skills/security.md
@@ -1,0 +1,149 @@
+# Security Review Skill (On-Demand)
+
+## Purpose
+
+This document defines on-demand security review guidance for code and configuration changes.
+It complements the always-on secure-by-default rules defined in `.github/copilot-instructions.md`.
+
+This skill applies only at development and authoring time.
+Runtime, host, cluster, or organizational security controls are explicitly out of scope.
+
+---
+
+## Security Review Trigger Points
+
+Load this security review skill when changes involve:
+
+- Authentication, session, or token logic
+- Authorization or resource ownership checks
+- Input parsing, validation, normalization, or canonicalization
+- File handling, deserialization, template rendering, or process execution
+- Logging, telemetry, secrets handling, or sensitive data paths
+- Dependency upgrades, lockfile changes, or CVE-related updates
+- Dockerfile or container base image changes
+- Docker Compose, Helm charts, or Kubernetes-related configuration
+- CI/CD workflow changes affecting build, test, release, or scanning
+- Privilege elevation, root execution, host mounts, or new Linux capabilities
+
+---
+
+## AI-Generated Code Guardrails
+
+When reviewing AI-generated changes:
+
+- Treat AI output as untrusted draft code until reviewed and tested
+- Verify package names, APIs, images, and tools exist and originate from trusted sources
+- Reject suggestions that bypass or disable security controls for convenience
+- Require pinned versions and lockfiles for generated dependencies; prefer integrity-verified installs when supported
+- Never accept generated code or configs that inject secrets via source files, Dockerfile `ARG`/`ENV`, or committed templates
+- Reject generated install scripts that use unchecked remote execution patterns (e.g., `curl | sh`) without checksum or signature verification
+- Reject generated build commands that disable TLS, certificate verification, or security checks to make builds pass
+- Apply RCI pattern: ask the AI to review its own output for security issues, then improve; repeat 1-2 iterations
+
+---
+
+## Secure Code Review (OSS Context)
+
+Apply when reviewing application logic, services, APIs, or libraries.
+
+### Input handling
+
+- Validate input at trust boundaries (format, type, range, length)
+- Avoid unsafe deserialization
+- Do not propagate unvalidated input across trust boundaries
+- Avoid command, query, or expression construction via string concatenation
+- Use parameterized queries for all database access
+
+### Authorization
+
+- **Keep authorization checks server-side and close to protected actions or resources**
+- Do not rely on client-side enforcement for access control
+
+### Error handling
+
+- Errors must not expose sensitive internal details
+- Avoid ignored return values or silent failures
+
+### Memory & resource safety (where applicable)
+
+- Avoid unchecked allocations and unbounded resource use
+- Ensure files, sockets, and handles are closed deterministically
+
+### Logging & telemetry
+
+- Do not log credentials, tokens, secrets, or PII
+- Logs should be actionable without exposing sensitive data
+
+### Dynamic execution
+
+- **Avoid unsafe dynamic execution patterns (`eval`, `exec`, reflection, or untrusted code execution).**
+
+### Dependency usage
+
+- Avoid shelling out when native APIs or libraries exist
+- Flag outdated, unmaintained, or suspicious dependencies
+- Prefer latest stable versions; specify exact or range-locked versions
+
+### OSS-specific review checks
+
+- Is externally observable **security-relevant behavior** documented?
+- Are assumptions and limitations stated explicitly for users?
+
+If uncertainty exists, flag it clearly rather than guessing or assuming safety.
+
+---
+
+## Container Artifact Review (Development-Time)
+
+Apply when generating or reviewing:
+
+- Dockerfiles / Containerfiles
+- docker-compose.yml
+- Helm charts (templates and values)
+
+### Dockerfile
+
+- Avoid `latest` or floating tags; pin versions or digests
+- Prefer minimal base images
+- Ensure containers do not run as root
+- Avoid setuid or setgid binaries
+- Use multi-stage builds and remove build tools, package caches, and temp files from final image
+- Prefer `COPY` over `ADD`
+- Never embed secrets in `ARG`, `ENV`, or filesystem layers
+
+### Docker Compose
+
+- Avoid `privileged: true` and host networking unless explicitly justified
+- Do not mount the Docker socket
+- Restrict host filesystem mounts
+- Limit exposed ports and networks; prefer internal networks
+
+Concerns that depend on deployment or runtime policy should be flagged as:
+**"Deployment-time responsibility."**
+
+---
+
+## Helm / Kubernetes Review (Development-Time)
+
+- Default to `runAsNonRoot: true`
+- Set `allowPrivilegeEscalation: false`
+- Prefer read-only root filesystem where feasible
+- Drop unnecessary Linux capabilities
+- Do not template secrets directly into charts
+- Document required runtime security assumptions
+
+Do not enforce cluster-wide, node-level, or runtime security controls.
+
+---
+
+## Review Output Expectations
+
+- Identify which section applies (Code / Container / Helm)
+- Classify findings as:
+  - Fix in artifact
+  - Deployment/runtime responsibility
+- Explicitly state assumptions or uncertainty
+- Use severity levels: Critical / High / Medium / Low with confidence: High / Medium / Low
+- Include specific file/function references and recommended fixes
+
+Security review is advisory; final decisions belong to maintainers.


### PR DESCRIPTION
### Description

Adds repository-level Copilot instructions to promote secure-by-default
development behavior without introducing enforcement or CI changes.

### Scope
- Additive only
- No runtime or build behavior changes
- No CI or merge policy modifications

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

