### PR TITLE
[ViPPET] Bump DLStreamer/model-download to 20260428-weekly and hide thumbnail in repr

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -119,7 +119,7 @@ services:
       - no_proxy=${no_proxy}
     command: './model_manager.sh'
   model-download:
-    image: docker.io/intel/model-download:2026.1.0-20260331-weekly
+    image: docker.io/intel/model-download:2026.1.0-20260428-weekly
     container_name: model-download
     command: --plugins ${MODEL_DOWNLOAD_PLUGINS:-openvino,huggingface,ultralytics,geti}
     healthcheck:

--- a/tools/visual-pipeline-and-platform-evaluation-tool/models/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/models/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.1.0-20260414-weekly-ubuntu24
+FROM intel/dlstreamer:2026.1.0-20260428-weekly-ubuntu24
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.1.0-20260414-weekly-ubuntu24
+FROM intel/dlstreamer:2026.1.0-20260428-weekly-ubuntu24
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.1.0-20260414-weekly-ubuntu24 AS prod
+FROM intel/dlstreamer:2026.1.0-20260428-weekly-ubuntu24 AS prod
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/internal_types.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/internal_types.py
@@ -325,6 +325,8 @@ class InternalPipeline:
         tags: List of tags for categorizing the pipeline.
         variants: List of InternalVariant objects.
         thumbnail: Base64-encoded image for pipeline preview (PREDEFINED only).
+            Excluded from ``repr()`` (and therefore from log output) because
+            the base64 payload can be very large.
         created_at: Creation timestamp as UTC datetime.
         modified_at: Last modification timestamp as UTC datetime.
     """
@@ -335,9 +337,9 @@ class InternalPipeline:
     source: InternalPipelineSource
     tags: List[str]
     variants: List[InternalVariant]
-    thumbnail: Optional[str]
-    created_at: datetime
-    modified_at: datetime
+    thumbnail: Optional[str] = field(repr=False)
+    created_at: datetime = field(repr=True)
+    modified_at: datetime = field(repr=True)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Routine weekly image bump plus a small logging quality-of-life fix.

## Changes

- **Bump DLStreamer base image** to `intel/dlstreamer:2026.1.0-20260428-weekly-ubuntu24`  in `vippet/Dockerfile`, `models/Dockerfile` and `video_generator/Dockerfile` (was `20260414-weekly`).
- **Bump model-download image** to `intel/model-download:2026.1.0-20260428-weekly` in `compose.yml` (was `20260331-weekly`).
- **Hide `thumbnail` from `InternalPipeline` repr.** The field stores a base64-encoded preview image and made log lines huge. It is now marked `field(repr=False)`; the value is still stored and returned via the API as before.

## Why

- Keep the runtime aligned with the latest weekly DLStreamer / model-download builds.
- Make backend logs readable when `InternalPipeline` instances are logged.
