### PR TITLE
[ViPPET] Use uploaded image sets as a pipeline input and harden the image upload flow

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/AGENTS.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/AGENTS.md
@@ -184,6 +184,7 @@ Hardware profiles (`COMPOSE_PROFILES`): `cpu`, `gpu`, `npu` — set automaticall
 | `UPLOAD_ALLOWED_CODECS`          | Comma-separated allow-list of upload video codecs            | `h264,h265`                                                |
 | `UPLOAD_MAX_SIZE_BYTES`          | Maximum accepted upload body size in bytes                   | `2147483648` (2 GiB)                                       |
 | `OUTPUT_VIDEO_DIR`               | Path to output videos                                        | `/videos/output`                                           |
+| `UPLOADED_IMAGES_DIR`            | Path to user-uploaded image sets                             | `/images/input/uploaded`                                   |
 | `SIMPLE_VIEW_VISIBLE_ELEMENTS`   | Glob patterns for elements shown in simplified pipeline view | `*src,urisourcebin,gva*,*sink,source`                      |
 | `SIMPLE_VIEW_INVISIBLE_ELEMENTS` | Element names hidden from simplified pipeline view           | `gvafpscounter,gvametapublish,gvametaconvert,gvawatermark` |
 | `LIVE_STREAM_SERVER_HOST`        | RTSP server hostname                                         | `mediamtx`                                                 |

--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -28,8 +28,10 @@ x-vippet: &vippet
     WEB_SERVER_LOG_LEVEL: WARNING
     MODELS_PATH: /models/output
     SUPPORTED_MODELS_FILE: /models/supported_models.yaml
-    INPUT_IMAGES_DIR: /images/input
-    OUTPUT_IMAGES_DIR: /images/output
+    # Image-set uploads. Image sets are extracted into per-set
+    # subdirectories of UPLOADED_IMAGES_DIR; no auto-downloaded image
+    # content exists today, so only the 'uploaded' tree is mounted.
+    UPLOADED_IMAGES_DIR: /images/input/uploaded
     # 'auto' holds recordings downloaded from default_recordings.yaml;
     # 'uploaded' holds user uploads. Each is created on startup if missing.
     AUTO_VIDEO_DIR: /videos/input/auto

--- a/tools/visual-pipeline-and-platform-evaluation-tool/pyrightconfig.json
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/pyrightconfig.json
@@ -13,7 +13,6 @@
     "**/node_modules",
     "**/__pycache__",
     ".git",
-    "shared/scripts",
-    "shared/model-download"
+    "shared/"
   ]
 }

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/nginx.conf
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/nginx.conf
@@ -123,9 +123,11 @@ server {
         tcp_nodelay on;
     }
 
-    # Image serving (supports nested subdirectories under input/output, restricted to image file extensions)
-    location ~* ^/assets/images/(input|output)/(.+\.(jpg|jpeg|png|bmp|webp|tif|tiff))$ {
-        alias /images/$1/$2;
+    # Image serving from the uploaded image-set tree. The regex pins the
+    # allowed extensions so only real image files leave the container,
+    # and the alias resolves under the shared /images volume mount.
+    location ~* ^/assets/images/input/uploaded/(.+\.(jpg|jpeg|png|bmp|tif|tiff))$ {
+        alias /images/input/uploaded/$1;
 
         # Security headers
         add_header X-Content-Type-Options nosniff;
@@ -136,7 +138,6 @@ server {
             image/jpeg jpg jpeg;
             image/png png;
             image/bmp bmp;
-            image/webp webp;
             image/tiff tif tiff;
         }
         default_type application/octet-stream;

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/ImagesInSet.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/ImagesInSet.tsx
@@ -128,7 +128,7 @@ export function ImagesInSet() {
                 <TableCell>{formatBytes(image.size_bytes)}</TableCell>
                 <TableCell>
                   <img
-                    src={`/assets/images/input/${imageSetName}/${image.filename}`}
+                    src={`/assets/images/input/uploaded/${imageSetName}/${image.filename}`}
                     alt={image.filename}
                     className="w-32 h-auto object-contain"
                   />

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/api_schemas.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/api_schemas.py
@@ -234,6 +234,61 @@ class VideoUploadErrorKind(str, Enum):
     FILE_EXISTS = "file_exists"
 
 
+class ImageUploadErrorKind(str, Enum):
+    """
+    **Machine-readable reason why an image archive upload was rejected.**
+
+    Returned in the `error` field of the `ImageUploadError` response body
+    together with a human-readable `detail` message. Mirrors the
+    `VideoUploadErrorKind` enum used for video uploads.
+
+    ## Values
+    - `MISSING_FILENAME` - The multipart part did not carry a filename.
+    - `UNSUPPORTED_ARCHIVE_FORMAT` - Archive extension is not in the
+      allow-list.
+    - `INVALID_ARCHIVE_NAME` - Archive filename sanitizes to an empty
+      value or carries no supported archive extension.
+    - `ARCHIVE_TOO_LARGE` - Archive request body exceeds the size cap.
+    - `ARCHIVE_CORRUPTED` - Archive could not be opened or one image
+      could not be decoded.
+    - `ARCHIVE_CONTAINS_SUBDIRECTORIES` - Archive must contain only
+      top-level files.
+    - `ARCHIVE_CONTAINS_NO_IMAGES` - Archive does not contain any
+      supported image files.
+    - `ARCHIVE_MIXED_IMAGE_EXTENSIONS` - Archive contains images of
+      more than one extension family.
+    - `ARCHIVE_DISALLOWED_IMAGE_EXTENSION` - Archive contains a file
+      with an extension outside the allow-list.
+    - `ARCHIVE_MIXED_IMAGE_RESOLUTIONS` - Archive contains images that
+      do not all share the same resolution.
+    - `ARCHIVE_UNCOMPRESSED_TOO_LARGE` - Total uncompressed size of the
+      archive exceeds the configured zip-bomb guard.
+    - `IMAGE_SET_ALREADY_EXISTS` - An image set with the derived name
+      already exists.
+    - `UNSAFE_ARCHIVE_PATH` - Archive contains a member with a
+      path-traversal attempt or a non-regular file entry.
+
+    ### Example
+    ```json
+    "archive_contains_subdirectories"
+    ```
+    """
+
+    MISSING_FILENAME = "missing_filename"
+    UNSUPPORTED_ARCHIVE_FORMAT = "unsupported_archive_format"
+    INVALID_ARCHIVE_NAME = "invalid_archive_name"
+    ARCHIVE_TOO_LARGE = "archive_too_large"
+    ARCHIVE_CORRUPTED = "archive_corrupted"
+    ARCHIVE_CONTAINS_SUBDIRECTORIES = "archive_contains_subdirectories"
+    ARCHIVE_CONTAINS_NO_IMAGES = "archive_contains_no_images"
+    ARCHIVE_MIXED_IMAGE_EXTENSIONS = "archive_mixed_image_extensions"
+    ARCHIVE_DISALLOWED_IMAGE_EXTENSION = "archive_disallowed_image_extension"
+    ARCHIVE_MIXED_IMAGE_RESOLUTIONS = "archive_mixed_image_resolutions"
+    ARCHIVE_UNCOMPRESSED_TOO_LARGE = "archive_uncompressed_too_large"
+    IMAGE_SET_ALREADY_EXISTS = "image_set_already_exists"
+    UNSAFE_ARCHIVE_PATH = "unsafe_archive_path"
+
+
 class CameraType(str, Enum):
     """
     **Type of camera device.**
@@ -1966,6 +2021,65 @@ class VideoUploadError(BaseModel):
     )
 
 
+class ImageUploadError(BaseModel):
+    """
+    **Structured error body returned when an image archive upload is rejected.**
+
+    Returned with HTTP 422 by `POST /images/upload` when the submitted
+    archive fails any validation step (extension, size, layout, content,
+    duplicate name, ...). Mirrors the shape of `VideoUploadError`: a
+    human-readable `detail` plus a machine-readable `error` /
+    `found` / `allowed` triple. The `found` and `allowed` fields are
+    typed loosely (`Any` / `list[Any]`) because some checks return
+    composite values such as a list of detected extensions or a pair of
+    resolutions.
+
+    ## Attributes
+    - `detail` - Human-readable error message suitable for direct UI
+      display.
+    - `error` - Machine-readable error kind (see `ImageUploadErrorKind`).
+    - `found` - Optional value that actually failed validation.
+    - `allowed` - Optional list of accepted values for the failed check.
+
+    ### Example (mixed image extensions)
+    ```json
+    {
+      "detail": "Archive must contain images of exactly one type. Found multiple: ['jpg', 'png'].",
+      "error": "archive_mixed_image_extensions",
+      "found": ["jpg", "png"],
+      "allowed": null
+    }
+    ```
+
+    ### Example (subdirectories not allowed)
+    ```json
+    {
+      "detail": "Archive must contain only files at the top level. Found nested entry 'subdir/foo.jpg'.",
+      "error": "archive_contains_subdirectories",
+      "found": "subdir/foo.jpg",
+      "allowed": null
+    }
+    ```
+    """
+
+    detail: str = Field(
+        ...,
+        description="Human-readable error message suitable for UI display.",
+    )
+    error: ImageUploadErrorKind = Field(
+        ...,
+        description="Machine-readable error kind.",
+    )
+    found: Optional[Any] = Field(
+        default=None,
+        description="Value that actually failed validation, or null.",
+    )
+    allowed: Optional[List[Any]] = Field(
+        default=None,
+        description="List of accepted values for the failed check, or null.",
+    )
+
+
 class VideoExistsResponse(BaseModel):
     """
     **Response indicating whether a video file exists.**
@@ -1999,20 +2113,55 @@ class ImageSet(BaseModel):
     **Metadata for a single image set (directory of images).**
 
     ## Attributes
-    - `name` - Name of the image set (directory name under INPUT_IMAGES_DIR)
-    - `image_count` - Number of image files in the directory
+    - `name` - Name of the image set (directory name under
+      `UPLOADED_IMAGES_DIR`; identical to the sanitized archive trunk).
+    - `source_archive` - Original uploaded archive filename.
+    - `image_count` - Number of image files in the set.
+    - `extension` - Lowercase canonical extension shared by every image
+      (`jpg`, `png`, `bmp` or `tif`).
+    - `width` - Common image width in pixels.
+    - `height` - Common image height in pixels.
+    - `uploaded_at` - ISO-8601 UTC timestamp of when the set was created.
 
     ### Example
     ```json
     {
       "name": "traffic_dataset",
-      "image_count": 120
+      "source_archive": "traffic_dataset.zip",
+      "image_count": 120,
+      "extension": "png",
+      "width": 1920,
+      "height": 1080,
+      "uploaded_at": "2026-04-27T10:00:00Z"
     }
     ```
     """
 
     name: str = Field(..., description="Name of the image set directory.")
-    image_count: int = Field(..., description="Number of image files in the directory.")
+    source_archive: str = Field(
+        default="",
+        description="Original uploaded archive filename.",
+    )
+    image_count: int = Field(
+        ...,
+        description="Number of image files in the set.",
+    )
+    extension: str = Field(
+        default="",
+        description="Lowercase canonical image extension shared by every image.",
+    )
+    width: int = Field(
+        default=0,
+        description="Common image width in pixels.",
+    )
+    height: int = Field(
+        default=0,
+        description="Common image height in pixels.",
+    )
+    uploaded_at: str = Field(
+        default="",
+        description="ISO-8601 UTC timestamp of when the set was created.",
+    )
 
 
 class ImageSetExistsResponse(BaseModel):

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/main.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/main.py
@@ -10,6 +10,7 @@ from fastapi.responses import HTMLResponse
 
 from api.middleware import InitializationMiddleware
 from api.routes import health
+from images import ImagesManager
 from internal_types import InternalAppStatus
 from managers.app_state_manager import AppStateManager
 from managers.pipeline_manager import PipelineManager
@@ -56,6 +57,11 @@ def _initialize_in_background(app: FastAPI) -> None:
         # Initialize VideosManager - downloads videos, scans files,
         # extracts metadata, and converts to TS format
         VideosManager()
+
+        # Initialize ImagesManager - ensures the uploaded image-set
+        # root directory exists with the right permissions before any
+        # request hits POST /images/upload.
+        ImagesManager()
 
         # Initialize PipelineManager - loads predefined pipelines
         PipelineManager()

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/routes/images.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/routes/images.py
@@ -1,40 +1,185 @@
+"""
+HTTP routes for the image-set feature.
+Mirrors the patterns used by the videos router:
+- Streaming upload with a per-chunk size cap (no Content-Length header
+  in the public schema; size is enforced mid-stream).
+- Hybrid 422 error envelope with both a human-readable ``detail`` and a
+  machine-readable ``error`` / ``found`` / ``allowed`` triple.
+- All filesystem mutations are delegated to ``ImagesManager`` so the
+  router stays thin.
+"""
+
 import logging
 import os
 import tempfile
-from typing import List
-
-from fastapi import APIRouter, File, UploadFile, HTTPException, Query, Path
+from fastapi import APIRouter, File, Path, Query, UploadFile
 from fastapi.responses import JSONResponse
-
 import api.api_schemas as schemas
-from images import ARCHIVE_EXTENSIONS, ImagesManager
+from images import (
+    ARCHIVE_EXTENSIONS,
+    UPLOADED_IMAGES_DIR,
+    ImageSet as DomainImageSet,
+    ImageUploadError,
+    ImageUploadErrorKind,
+    ImagesManager,
+)
 
 router = APIRouter()
 logger = logging.getLogger("api.routes.images")
 
 
+# --------------------------------------------------------------------------- #
+# Configuration (resolved at import time so the router stays stateless).
+# --------------------------------------------------------------------------- #
+def _parse_int_env(name: str, default: int) -> int:
+    """
+    Parse an integer environment variable; fall back to ``default`` on
+    any parsing error and log a warning.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid integer for env var %s=%r, falling back to %d",
+            name,
+            raw,
+            default,
+        )
+        return default
+
+
+# Default 2 GiB; matches the videos endpoint and nginx
+# ``client_max_body_size 2G;`` in ui/nginx.conf.
+_DEFAULT_UPLOAD_MAX_SIZE_BYTES = 2 * 1024 * 1024 * 1024
+UPLOAD_MAX_SIZE_BYTES: int = _parse_int_env(
+    "UPLOAD_MAX_SIZE_BYTES",
+    _DEFAULT_UPLOAD_MAX_SIZE_BYTES,
+)
+# --------------------------------------------------------------------------- #
+# Helpers.
+# --------------------------------------------------------------------------- #
+# Mapping from the manager's literal error-kind strings to the API enum
+# values. Centralised so the manager (which has no FastAPI dependency)
+# stays decoupled from the schema layer.
+_ERROR_KIND_MAP: dict[str, schemas.ImageUploadErrorKind] = {
+    "missing_filename": schemas.ImageUploadErrorKind.MISSING_FILENAME,
+    "unsupported_archive_format": (
+        schemas.ImageUploadErrorKind.UNSUPPORTED_ARCHIVE_FORMAT
+    ),
+    "invalid_archive_name": schemas.ImageUploadErrorKind.INVALID_ARCHIVE_NAME,
+    "archive_too_large": schemas.ImageUploadErrorKind.ARCHIVE_TOO_LARGE,
+    "archive_corrupted": schemas.ImageUploadErrorKind.ARCHIVE_CORRUPTED,
+    "archive_contains_subdirectories": (
+        schemas.ImageUploadErrorKind.ARCHIVE_CONTAINS_SUBDIRECTORIES
+    ),
+    "archive_contains_no_images": (
+        schemas.ImageUploadErrorKind.ARCHIVE_CONTAINS_NO_IMAGES
+    ),
+    "archive_mixed_image_extensions": (
+        schemas.ImageUploadErrorKind.ARCHIVE_MIXED_IMAGE_EXTENSIONS
+    ),
+    "archive_disallowed_image_extension": (
+        schemas.ImageUploadErrorKind.ARCHIVE_DISALLOWED_IMAGE_EXTENSION
+    ),
+    "archive_mixed_image_resolutions": (
+        schemas.ImageUploadErrorKind.ARCHIVE_MIXED_IMAGE_RESOLUTIONS
+    ),
+    "archive_uncompressed_too_large": (
+        schemas.ImageUploadErrorKind.ARCHIVE_UNCOMPRESSED_TOO_LARGE
+    ),
+    "image_set_already_exists": schemas.ImageUploadErrorKind.IMAGE_SET_ALREADY_EXISTS,
+    "unsafe_archive_path": schemas.ImageUploadErrorKind.UNSAFE_ARCHIVE_PATH,
+}
+
+
+def _upload_error_response(
+    kind: ImageUploadErrorKind,
+    detail: str,
+    *,
+    found: object | None = None,
+    allowed: list[object] | None = None,
+) -> JSONResponse:
+    """
+    Build a uniform HTTP 422 response body for upload rejections.
+    Using a single helper guarantees every rejection path returns the
+    same shape and the same status code.
+    """
+    schema_kind = _ERROR_KIND_MAP.get(kind)
+    if schema_kind is None:
+        # Should never happen - guards against future drift between the
+        # manager's literal strings and the API enum.
+        logger.error("Unknown image upload error kind: %r", kind)
+        schema_kind = schemas.ImageUploadErrorKind.ARCHIVE_CORRUPTED
+    payload = schemas.ImageUploadError(
+        detail=detail,
+        error=schema_kind,
+        found=found,
+        allowed=allowed,
+    )
+    return JSONResponse(status_code=422, content=payload.model_dump())
+
+
+def _to_schema(image_set: DomainImageSet) -> schemas.ImageSet:
+    """
+    Convert an internal ``images.ImageSet`` into the public schema
+    response shape. Centralised so the conversion lives in one place.
+    """
+    return schemas.ImageSet(
+        name=image_set.name,
+        source_archive=image_set.source_archive,
+        image_count=image_set.image_count,
+        extension=image_set.extension,
+        width=image_set.width,
+        height=image_set.height,
+        uploaded_at=image_set.uploaded_at,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Routes.
+# --------------------------------------------------------------------------- #
 @router.get(
     "",
     operation_id="get_image_sets",
     summary="List all available image sets",
-    response_model=List[schemas.ImageSet],
+    response_model=list[schemas.ImageSet],
 )
-def get_image_sets():
+async def get_image_sets() -> list[schemas.ImageSet] | JSONResponse:
     """
-    **List all discovered image sets (directories) in INPUT_IMAGES_DIR.**
+    **List all discovered image sets with their canonical metadata.**
 
     ## Operation
 
-    1. ImagesManager scans INPUT_IMAGES_DIR for subdirectories
-    2. Counts image files in each subdirectory
-    3. Returns array of ImageSet objects
+    1. `ImagesManager` scans `UPLOADED_IMAGES_DIR` for subdirectories.
+    2. For each directory, the canonical metadata is loaded from the
+       sidecar `set.json`. Directories without a readable `set.json`
+       are skipped (with a warning) so the endpoint never fails because
+       of a partially populated shared volume.
+    3. Returns an array of `ImageSet` objects.
+
+    ## Parameters
+
+    None
 
     ## Response Format
 
     | Code | Description |
     |------|-------------|
-    | 200  | JSON array of ImageSet objects (empty if none found) |
+    | 200  | JSON array of `ImageSet` objects (empty if none found) |
     | 500  | Runtime error while listing image sets |
+
+    ## Conditions
+
+    ### ✅ Success
+    - `ImagesManager` successfully initialized at startup
+    - `UPLOADED_IMAGES_DIR` exists and is readable
+
+    ### ❌ Failure
+    - `ImagesManager` initialization fails → application exits at startup
+    - Runtime errors → 500
 
     ## Example Response
 
@@ -42,7 +187,12 @@ def get_image_sets():
     [
       {
         "name": "traffic_dataset",
-        "image_count": 120
+        "source_archive": "traffic_dataset.zip",
+        "image_count": 120,
+        "extension": "png",
+        "width": 1920,
+        "height": 1080,
+        "uploaded_at": "2026-04-27T10:00:00Z"
       }
     ]
     ```
@@ -50,18 +200,15 @@ def get_image_sets():
     logger.debug("Received request for all image sets.")
     try:
         sets = ImagesManager().get_all_image_sets()
-        logger.debug(f"Found {len(sets)} image sets.")
-        return [
-            schemas.ImageSet(name=s.name, image_count=s.image_count)
-            for s in sets.values()
-        ]
+        logger.debug("Found %d image sets.", len(sets))
+        return [_to_schema(s) for s in sets.values()]
     except Exception:
         logger.error("Failed to list image sets", exc_info=True)
         return JSONResponse(
+            status_code=500,
             content=schemas.MessageResponse(
                 message="Unexpected error while listing image sets"
             ).model_dump(),
-            status_code=500,
         )
 
 
@@ -71,20 +218,32 @@ def get_image_sets():
     summary="Check if an image set directory already exists",
     response_model=schemas.ImageSetExistsResponse,
 )
-def check_image_set_exists(
+async def check_image_set_exists(
     name: str = Query(..., description="Image set (directory) name to check"),
-):
+) -> schemas.ImageSetExistsResponse:
     """
-    **Check if an image set directory with the given name exists in INPUT_IMAGES_DIR.**
+    **Check if an image set directory with the given name already exists.**
+
+    Used by the UI to skip uploading a duplicate archive and to warn the
+    user early. Always succeeds with a boolean response.
 
     ## Parameters
-    - `name` (query) - Name of the image set directory to check
+
+    - `name` (query) - Name of the image set directory to check.
 
     ## Response Format
 
     | Code | Description |
     |------|-------------|
-    | 200  | Returns ImageSetExistsResponse with exists boolean |
+    | 200  | Returns `ImageSetExistsResponse` with `exists` boolean |
+
+    ## Conditions
+
+    ### ✅ Success
+    - Always succeeds with a boolean response
+
+    ### ❌ Failure
+    - None (this endpoint has no failure modes)
 
     ## Example Response
 
@@ -95,9 +254,9 @@ def check_image_set_exists(
     }
     ```
     """
-    logger.debug(f"Checking existence of image set directory: {name}")
+    logger.debug("Checking existence of image set directory: %s", name)
     exists = ImagesManager().image_set_exists(name)
-    logger.debug(f"Image set '{name}' exists: {exists}")
+    logger.debug("Image set '%s' exists: %s", name, exists)
     return schemas.ImageSetExistsResponse(exists=exists, name=name)
 
 
@@ -107,153 +266,352 @@ def check_image_set_exists(
     summary="Upload a new image set as an archive",
     response_model=schemas.ImageSet,
     status_code=201,
+    responses={
+        422: {
+            "model": schemas.ImageUploadError,
+            "description": "Upload rejected by server-side validation.",
+        },
+        500: {
+            "model": schemas.MessageResponse,
+            "description": "Unexpected server error during upload or processing.",
+        },
+    },
 )
-async def upload_image_archive(file: UploadFile = File(...)):
+async def upload_image_archive(
+    file: UploadFile = File(...),
+) -> JSONResponse | schemas.ImageSet:
     """
-    **Upload an archive of images. The archive is extracted into its own directory under INPUT_IMAGES_DIR.**
+    **Upload an archive of images and commit it as a new image set
+    under `UPLOADED_IMAGES_DIR`.**
 
     ## Operation
 
-    1. Validate archive extension against supported formats
-    2. Derive image set directory name from archive filename (without extension)
-    3. Reject if a directory with that name already exists
-    4. Save archive to a temp location, then extract safely into the target directory
-    5. Return ImageSet object with the discovered image count
+    1. **Pre-write validation** (before any bytes touch disk):
+       - Filename is present.
+       - The filename carries a supported archive extension and the
+         sanitized trunk is not empty.
+       - No image set with the derived name already exists.
+    2. **Stream upload to a temporary file** under `UPLOADED_IMAGES_DIR`,
+       enforcing `UPLOAD_MAX_SIZE_BYTES` per chunk. Aborts and deletes
+       the temp file the moment the accumulated byte count exceeds the
+       limit.
+    3. **Validate + commit via `ImagesManager.register_uploaded_archive`**:
+       - Safe extraction (zip-slip guard, sub-directories rejected,
+         non-regular tar entries rejected).
+       - Uncompressed-size cap to defuse zip-bombs
+         (`UPLOAD_MAX_SIZE_BYTES × 10`).
+       - All extracted files must be of one allowed image extension
+         family and share the same resolution.
+       - Every image is renamed to `<trunk>_<NNNN>.<ext>`.
+       - `set.json` is written with the canonical metadata.
+       - The staging directory is atomically renamed into its final
+         location under a per-target lock so two concurrent uploads
+         cannot both win the same name.
+
+    Every validation rejection returns HTTP 422 with an
+    `ImageUploadError` body containing both a human-readable `detail`
+    field and a structured `error` / `found` / `allowed` triple.
 
     ## Parameters
-    - `file` (multipart/form-data) - Archive file to upload (zip, tar, tar.gz, tgz)
+
+    - `file` (multipart/form-data) - Archive file to upload (zip, tar,
+      tar.gz, tgz).
 
     ## Response Format
 
     | Code | Description |
     |------|-------------|
-    | 201  | Archive uploaded and extracted, returns ImageSet object |
-    | 400  | Invalid archive (unsupported extension, duplicate name, unsafe paths, no images) |
-    | 500  | Error during upload or extraction |
+    | 201  | Archive accepted; returns the new `ImageSet` metadata |
+    | 422  | Upload rejected (`ImageUploadError` body with `error`, `found`, `allowed`, `detail`) |
+    | 500  | Unexpected server error (for example disk full during the commit) |
 
-    ## Example Response
+    ## Conditions
+
+    ### ✅ Success
+    - Filename is present and carries a supported archive extension
+    - Sanitised trunk is non-empty
+    - Archive size is within `UPLOAD_MAX_SIZE_BYTES`
+    - Total uncompressed size is within
+      `UPLOAD_MAX_SIZE_BYTES × 10` (zip-bomb guard)
+    - Archive is a flat collection of images, all of the same extension
+      family and the same resolution
+    - No image set with the derived name already exists
+    - `set.json` is written successfully and the staging directory is
+      moved into its final location
+
+    ### ❌ Failure
+    - Missing filename → 422 (`missing_filename`)
+    - Unsupported archive extension → 422 (`unsupported_archive_format`)
+    - Filename sanitizes to an empty trunk → 422 (`invalid_archive_name`)
+    - Image set with the derived name already exists → 422 (`image_set_already_exists`)
+    - Archive too large → 422 (`archive_too_large`)
+    - Archive corrupted or contains an undecodable image → 422 (`archive_corrupted`)
+    - Archive contains sub-directories → 422 (`archive_contains_subdirectories`)
+    - Archive contains no supported images → 422 (`archive_contains_no_images`)
+    - Archive mixes image extensions → 422 (`archive_mixed_image_extensions`)
+    - Archive contains a disallowed file extension → 422 (`archive_disallowed_image_extension`)
+    - Archive contains images of different resolutions → 422 (`archive_mixed_image_resolutions`)
+    - Total uncompressed size exceeds the zip-bomb guard → 422 (`archive_uncompressed_too_large`)
+    - Archive contains an unsafe path or non-regular entry → 422 (`unsafe_archive_path`)
+    - Disk move or other I/O failure during commit → 500
+    - Any other unexpected runtime error → 500
+
+    ## Example success response (HTTP 201)
 
     ```json
     {
       "name": "traffic_dataset",
-      "image_count": 120
+      "source_archive": "Traffic Dataset.zip",
+      "image_count": 120,
+      "extension": "png",
+      "width": 1920,
+      "height": 1080,
+      "uploaded_at": "2026-04-27T10:00:00Z"
+    }
+    ```
+
+    ## Example error response (HTTP 422, mixed image extensions)
+
+    ```json
+    {
+      "detail": "Archive must contain images of exactly one type. Found multiple: ['jpg', 'png'].",
+      "error": "archive_mixed_image_extensions",
+      "found": ["jpg", "png"],
+      "allowed": null
+    }
+    ```
+
+    ## Example error response (HTTP 422, archive too large)
+
+    ```json
+    {
+      "detail": "Archive is too large (over 2147483648 bytes). Maximum allowed size is 2147483648 bytes.",
+      "error": "archive_too_large",
+      "found": 3221225472,
+      "allowed": [2147483648]
     }
     ```
     """
-    logger.info(f"Received image archive upload request: {file.filename}")
+    raw_filename = file.filename
+    logger.info("Received image archive upload request: %s", raw_filename)
 
-    if not file.filename:
-        logger.warning("Upload request without filename")
-        raise HTTPException(status_code=400, detail="No filename provided")
+    # ---- Stage 1: pre-write validation ----------------------------------
+
+    if not raw_filename:
+        logger.warning("Upload rejected: missing filename")
+        return _upload_error_response(
+            "missing_filename",
+            "Upload is missing a valid filename.",
+            found=raw_filename,
+        )
 
     manager = ImagesManager()
 
-    # Validate archive extension and derive set name
-    set_name = manager.derive_set_name(file.filename)
-    if not set_name:
-        logger.warning(f"Unsupported archive extension: {file.filename}")
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "Unsupported archive format. Allowed extensions: "
-                + ", ".join(ARCHIVE_EXTENSIONS)
-            ),
+    # Validate extension explicitly before touching disk so the request
+    # is rejected as cheaply as possible. The manager re-checks during
+    # ``register_uploaded_archive`` for callers that bypass the API.
+    trunk = manager.derive_trunk(raw_filename)
+    if trunk is None:
+        # Two distinct sub-cases: unsupported extension vs sanitization
+        # collapsed to empty. Surface both as ``unsupported_archive_format``
+        # if the extension is missing, otherwise as ``invalid_archive_name``.
+        lower = raw_filename.lower()
+        has_supported_ext = any(lower.endswith("." + ext) for ext in ARCHIVE_EXTENSIONS)
+        if not has_supported_ext:
+            logger.warning(
+                "Upload rejected: unsupported archive extension for %r",
+                raw_filename,
+            )
+            return _upload_error_response(
+                "unsupported_archive_format",
+                (
+                    f"Unsupported archive format for '{raw_filename}'. "
+                    f"Allowed extensions: {', '.join(ARCHIVE_EXTENSIONS)}."
+                ),
+                found=raw_filename,
+                allowed=list(ARCHIVE_EXTENSIONS),
+            )
+        logger.warning(
+            "Upload rejected: archive name %r sanitises to empty trunk",
+            raw_filename,
+        )
+        return _upload_error_response(
+            "invalid_archive_name",
+            f"Archive filename '{raw_filename}' sanitises to an empty name.",
+            found=raw_filename,
         )
 
-    # Check for duplicate set name
-    if manager.image_set_exists(set_name):
-        logger.warning(f"Image set already exists: {set_name}")
-        raise HTTPException(
-            status_code=400, detail=f"Image set '{set_name}' already exists"
+    if manager.image_set_exists(trunk):
+        logger.warning("Upload rejected: image set '%s' already exists", trunk)
+        return _upload_error_response(
+            "image_set_already_exists",
+            f"An image set named '{trunk}' already exists.",
+            found=trunk,
         )
 
-    # Save archive to a temp file, then hand off to the manager for extraction
-    tmp_fd, tmp_path = tempfile.mkstemp(
-        prefix="img_archive_", suffix="_" + file.filename
+    # ---- Stage 2: stream to temp file under the uploads root ------------
+
+    # Ensure the uploads root exists before mkstemp - the manager's
+    # constructor takes care of this on its first call, but a freshly
+    # cleaned shared volume might still need it.
+    ImagesManager.ensure_root_dir()
+
+    temp_fd, temp_path = tempfile.mkstemp(
+        prefix=".upload-",
+        suffix=os.path.splitext(raw_filename)[1] or ".bin",
+        dir=UPLOADED_IMAGES_DIR,
     )
-    os.close(tmp_fd)
+    os.close(temp_fd)
+
+    bytes_written = 0
+    chunk_size = 1024 * 1024  # 1 MiB
 
     try:
-        chunk_size = 8192
-        logger.debug(f"Saving archive to temp path {tmp_path}")
-        with open(tmp_path, "wb") as f:
+        with open(temp_path, "wb") as out:
             while True:
                 chunk = await file.read(chunk_size)
                 if not chunk:
                     break
-                f.write(chunk)
+                bytes_written += len(chunk)
+                if bytes_written > UPLOAD_MAX_SIZE_BYTES:
+                    logger.warning(
+                        "Upload rejected mid-stream: bytes_written=%d exceeds limit=%d",
+                        bytes_written,
+                        UPLOAD_MAX_SIZE_BYTES,
+                    )
+                    return _upload_error_response(
+                        "archive_too_large",
+                        (
+                            f"Archive is too large (over {UPLOAD_MAX_SIZE_BYTES} bytes). "
+                            f"Maximum allowed size is {UPLOAD_MAX_SIZE_BYTES} bytes."
+                        ),
+                        found=bytes_written,
+                        allowed=[UPLOAD_MAX_SIZE_BYTES],
+                    )
+                out.write(chunk)
 
-        archive_size = os.path.getsize(tmp_path)
-        logger.info(
-            f"Archive '{file.filename}' saved ({archive_size / (1024 * 1024):.2f} MB); extracting..."
+        logger.debug(
+            "Wrote %d bytes to temp file %s for '%s'",
+            bytes_written,
+            temp_path,
+            raw_filename,
         )
 
-        image_set = manager.extract_archive(tmp_path, set_name)
+        # ---- Stage 3: validate + commit via the manager -----------------
+
+        try:
+            image_set = manager.register_uploaded_archive(temp_path, raw_filename)
+        except ImageUploadError as exc:
+            logger.warning(
+                "Upload rejected by validator: kind=%s detail=%s",
+                exc.kind,
+                exc.detail,
+            )
+            return _upload_error_response(
+                exc.kind,
+                exc.detail,
+                found=exc.found,
+                allowed=exc.allowed,
+            )
+        except RuntimeError as exc:
+            logger.error(
+                "Failed to register uploaded archive '%s': %s",
+                raw_filename,
+                exc,
+                exc_info=True,
+            )
+            return JSONResponse(
+                status_code=500,
+                content=schemas.MessageResponse(
+                    message=f"Failed to finalise upload: {exc}"
+                ).model_dump(),
+            )
 
         logger.info(
-            f"Successfully extracted image set '{set_name}' ({image_set.image_count} images)"
+            "Uploaded image set '%s' (%.2f MB) registered successfully",
+            image_set.name,
+            bytes_written / (1024 * 1024),
         )
-        return schemas.ImageSet(name=image_set.name, image_count=image_set.image_count)
+        return _to_schema(image_set)
 
-    except FileExistsError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except ValueError as e:
-        # Unsupported archive type, corrupted archive, unsafe paths, or no images
-        logger.warning(f"Rejected archive '{file.filename}': {e}")
-        raise HTTPException(status_code=400, detail=str(e))
-    except HTTPException:
-        raise
-    except Exception as e:
+    except Exception as exc:
         logger.error(
-            f"Error uploading image archive '{file.filename}': {e}", exc_info=True
+            "Unexpected error while uploading '%s': %s",
+            raw_filename,
+            exc,
+            exc_info=True,
         )
-        raise HTTPException(
-            status_code=500, detail=f"Error uploading image archive: {str(e)}"
+        return JSONResponse(
+            status_code=500,
+            content=schemas.MessageResponse(
+                message=f"Unexpected error during upload: {exc}"
+            ).model_dump(),
         )
     finally:
-        try:
-            os.remove(tmp_path)
-        except OSError:
-            pass
+        # Always remove the temp archive once the manager has either
+        # consumed it or rejected it.
+        if os.path.isfile(temp_path):
+            try:
+                os.remove(temp_path)
+            except OSError:
+                logger.debug("Best-effort cleanup failed for temp file %s", temp_path)
 
 
 @router.get(
     "/{name}",
     operation_id="list_images_in_set",
     summary="List all images inside a given image set",
-    response_model=List[schemas.ImageInfo],
+    response_model=list[schemas.ImageInfo],
 )
-def list_images_in_set(
+async def list_images_in_set(
     name: str = Path(..., description="Name of the image set directory"),
-):
+) -> list[schemas.ImageInfo] | JSONResponse:
     """
     **List all image files in the given image set with per-file metadata.**
 
     ## Operation
 
-    1. Validate the image set name and ensure the directory exists
-    2. Recursively walk the set directory for supported image extensions
-    3. For each image, collect filename, extension, size, and dimensions
-    4. Return the list sorted by filename
+    1. Resolve the image set by name and load its canonical metadata
+       from `set.json`. If either the directory or the sidecar is
+       missing the request is treated as 404.
+    2. Iterate over the (flat) directory in alphabetical order and
+       collect every file whose extension matches the canonical
+       extension recorded in `set.json`. The sidecar itself is excluded
+       from the listing.
+    3. For each entry, stat the file for its size; width and height
+       come straight from `set.json` because every image in a set
+       shares the same resolution by construction (no per-call OpenCV
+       probing).
 
     ## Parameters
-    - `name` (path) - Name of the image set directory
+
+    - `name` (path) - Name of the image set directory.
 
     ## Response Format
 
     | Code | Description |
     |------|-------------|
-    | 200  | JSON array of ImageInfo objects (empty if the set has no images) |
-    | 404  | Image set with the given name does not exist |
+    | 200  | JSON array of `ImageInfo` objects (empty if the set has no images) |
+    | 404  | Image set with the given name does not exist or has no readable `set.json` |
     | 500  | Runtime error while listing images |
+
+    ## Conditions
+
+    ### ✅ Success
+    - Image set directory exists under `UPLOADED_IMAGES_DIR`
+    - Sidecar `set.json` is readable
+
+    ### ❌ Failure
+    - Image set name unknown or missing → 404
+    - Unhandled runtime error → 500
 
     ## Example Response
 
     ```json
     [
       {
-        "filename": "frame_0001.jpg",
-        "extension": "jpg",
+        "filename": "traffic_dataset_001.png",
+        "extension": "png",
         "size_bytes": 204812,
         "width": 1920,
         "height": 1080
@@ -261,14 +619,19 @@ def list_images_in_set(
     ]
     ```
     """
-    logger.debug(f"Received request for images in set '{name}'.")
+    logger.debug("Received request for images in set '%s'.", name)
     try:
         images = ImagesManager().get_images_in_set(name)
         if images is None:
-            logger.warning(f"Image set '{name}' not found.")
-            raise HTTPException(status_code=404, detail=f"Image set '{name}' not found")
+            logger.warning("Image set '%s' not found.", name)
+            return JSONResponse(
+                status_code=404,
+                content=schemas.MessageResponse(
+                    message=f"Image set '{name}' not found"
+                ).model_dump(),
+            )
 
-        logger.debug(f"Found {len(images)} images in set '{name}'.")
+        logger.debug("Found %d images in set '%s'.", len(images), name)
         return [
             schemas.ImageInfo(
                 filename=img.filename,
@@ -279,13 +642,12 @@ def list_images_in_set(
             )
             for img in images
         ]
-    except HTTPException:
-        raise
+
     except Exception:
-        logger.error(f"Failed to list images for set '{name}'", exc_info=True)
+        logger.error("Failed to list images for set '%s'", name, exc_info=True)
         return JSONResponse(
+            status_code=500,
             content=schemas.MessageResponse(
                 message="Unexpected error while listing images"
             ).model_dump(),
-            status_code=500,
         )

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
@@ -3106,6 +3106,27 @@ def _prepare_generic_input(nodes: list[Node]) -> None:
     for node in nodes:
         # Check for file sources
         if node.type in {"filesrc", "multifilesrc"}:
+            # Image-set multifilesrc nodes carry an internal marker
+            # placed by ``apply_simple_view_changes``. Round-trip them
+            # back to ``kind=image_set`` with the set name derived
+            # from the location pattern's parent directory, so the
+            # simple view stays stable across save/load cycles.
+            if node.type == "multifilesrc" and _IMAGE_SET_NODE_FLAG in node.data:
+                location = str(node.data.get("location", ""))
+                set_name = ""
+                if location:
+                    # ``/images/input/uploaded/<set>/<set>_%0Nd.<ext>``
+                    # -> ``<set>``.
+                    set_name = os.path.basename(os.path.dirname(location))
+                node.data.clear()
+                node.type = "source"
+                node.data["kind"] = InputKind.IMAGE_SET
+                node.data["source"] = set_name
+                logger.debug(
+                    f"Converted image-set multifilesrc to generic source: {set_name}"
+                )
+                continue
+
             source_name = node.data.get("location", "")
             node.data.clear()
             node.type = "source"

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
@@ -18,6 +18,7 @@ from resources import (
 from utils import slugify_text
 from video_decoder import VideoDecoder
 from videos import VideosManager
+from images import ImagesManager
 
 # Internal constant used as a placeholder type for the main output sink in the graph.
 OUTPUT_PLACEHOLDER: str = "{OUTPUT_PLACEHOLDER}"
@@ -100,6 +101,64 @@ class InputKind(str, Enum):
 
     FILE = "file"
     CAMERA = "camera"
+    IMAGE_SET = "image_set"
+
+
+# Default frame rate (numerator/denominator) used in the caps that follow
+# the ``multifilesrc`` element when the source is an image set. Image
+# sets do not carry a native frame rate, so a fixed cadence is required
+# to drive the downstream pipeline. Kept conservative; can be overridden
+# in the future by extending the source-node ``data`` payload.
+IMAGE_SET_DEFAULT_FRAMERATE = "30/1"
+
+# Internal flag stored in ``Node.data`` to mark a ``multifilesrc`` node
+# that originated from an image-set source. Used by the looping
+# transformation and codec detection to handle these nodes specially
+# without having to reparse the location pattern.
+_IMAGE_SET_NODE_FLAG = "__image_set"
+
+
+def _image_set_decoder_for_extension(extension: str) -> str:
+    """
+    Return the GStreamer decoder element name that pairs with the given
+    canonical image extension. Every extension accepted by the upload
+    validator is guaranteed to have a software decoder available in the
+    runtime environment.
+    """
+    table = {
+        "jpg": "jpegdec",
+        "jpeg": "jpegdec",
+        "png": "pngdec",
+        "bmp": "avdec_bmp",
+        "tif": "avdec_tiff",
+        "tiff": "avdec_tiff",
+    }
+    decoder = table.get(extension.lower())
+    if decoder is None:
+        # Should never happen - the upload validator already enforces
+        # the allow-list. Falling back to ``decodebin3`` keeps the
+        # pipeline runnable in case a directory was created out of
+        # band.
+        return "decodebin3"
+    return decoder
+
+
+def _image_set_caps_for_extension(extension: str) -> str:
+    """
+    Return the caps string that pairs with the chosen image decoder.
+    The caps mime type matches the extension (jpg/jpeg -> ``image/jpeg``)
+    and pins a fixed frame rate so the downstream chain can negotiate.
+    """
+    mime_table = {
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "png": "image/png",
+        "bmp": "image/bmp",
+        "tif": "image/tiff",
+        "tiff": "image/tiff",
+    }
+    mime = mime_table.get(extension.lower(), "image/jpeg")
+    return f"{mime},framerate={IMAGE_SET_DEFAULT_FRAMERATE}"
 
 
 @dataclass
@@ -441,6 +500,17 @@ class Graph:
                     f"Looping playback is not supported for live sources like {node.type}. "
                     f"Please disable looping, remove, or replace the {node.type} element in your pipeline."
                 )
+
+            # Image-set sources are already represented as
+            # ``multifilesrc`` and do not need a TS companion. Just
+            # toggle ``loop`` so the runner can rely on a wallclock
+            # timer to terminate the pipeline.
+            if node.type == "multifilesrc" and _IMAGE_SET_NODE_FLAG in node.data:
+                node.data["loop"] = "true"
+                logger.debug(
+                    "Enabled looping on image-set multifilesrc (node %s)", node.id
+                )
+                continue
 
             # Replace filesrc with multifilesrc loop=true
             if node.type == "filesrc":
@@ -832,7 +902,7 @@ class Graph:
         #       while an intermediate recorder sink sits on the inline
         #       branch.
         #
-        #   (c) If there is exactly one fakesink in the graph and it has
+        #   (c) If there is exactly one fakesink in the graph, and it has
         #       no explicit name, that fakesink is the main sink (mirrors
         #       the auto-pick rule of `prepare_main_output_placeholder`).
         #
@@ -855,7 +925,7 @@ class Graph:
 
         sink_node: Optional[Node] = None
 
-        # (a) OUTPUT_PLACEHOLDER has highest priority.
+        # (a) OUTPUT_PLACEHOLDER has the highest priority.
         if len(placeholder_nodes) == 1:
             sink_node = placeholder_nodes[0]
 
@@ -1445,10 +1515,105 @@ class Graph:
                             f"Unsupported camera source '{source}' for node {node_id}. "
                             f"Camera sources must start with '{RTSP_URL_PREFIX}' for network cameras or '{USB_DEVICE_PREFIX}' for USB cameras."
                         )
+
+                elif kind == InputKind.IMAGE_SET:
+                    # Image-set source: resolve the set name to a
+                    # ``multifilesrc`` location pattern and inject a
+                    # decoder + caps node right after it. The looping
+                    # transformation flips ``loop`` to ``true`` later
+                    # if the run requires it; here we always emit a
+                    # single-pass configuration with ``stop-index`` so
+                    # the pipeline terminates cleanly when the set is
+                    # exhausted.
+                    image_set = ImagesManager().get_image_set(source)
+                    if image_set is None:
+                        raise ValueError(
+                            f"Unknown image set '{source}' for node {node_id}."
+                        )
+                    location_pattern = ImagesManager().get_location_pattern(source)
+                    if location_pattern is None:
+                        raise ValueError(
+                            f"Failed to resolve location pattern for image set '{source}'."
+                        )
+
+                    if node_id not in advanced_nodes_by_id:
+                        # Should not happen - the simple-to-advanced
+                        # mapping is bijective for source nodes - but
+                        # guard against drift instead of crashing in
+                        # the rewiring loop below.
+                        raise ValueError(
+                            f"Internal error: image-set source node {node_id} missing in advanced view."
+                        )
+
+                    advanced_node = advanced_nodes_by_id[node_id]
+                    advanced_node.type = "multifilesrc"
+                    advanced_node.data.clear()
+                    advanced_node.data.update(
+                        {
+                            "location": location_pattern,
+                            "index": "1",
+                            "stop-index": str(image_set.image_count),
+                            "loop": "false",
+                            "caps": _image_set_caps_for_extension(image_set.extension),
+                            # Internal marker used by looping and codec
+                            # detection to recognize this node as part
+                            # of an image-set pipeline.
+                            _IMAGE_SET_NODE_FLAG: image_set.extension,
+                        }
+                    )
+
+                    # Allocate fresh IDs for the decoder and caps nodes.
+                    existing_ids = [
+                        int(n.id) for n in result_advanced.nodes if n.id.isdigit()
+                    ] + [int(e.id) for e in result_advanced.edges if e.id.isdigit()]
+                    next_id = (max(existing_ids) + 1) if existing_ids else 0
+
+                    decoder_id = str(next_id)
+                    next_id += 1
+                    decoder_node = Node(
+                        id=decoder_id,
+                        type=_image_set_decoder_for_extension(image_set.extension),
+                        data={},
+                    )
+
+                    edge_src_to_decoder = Edge(
+                        id=str(next_id),
+                        source=node_id,
+                        target=decoder_id,
+                    )
+                    next_id += 1
+
+                    # Insert the decoder right after the multifilesrc
+                    # node in the nodes list to preserve the visual
+                    # order in any debug dump.
+                    for i, n in enumerate(result_advanced.nodes):
+                        if n.id == node_id:
+                            result_advanced.nodes.insert(i + 1, decoder_node)
+                            break
+
+                    # Rewire: every edge that previously left the
+                    # source node now leaves the decoder, and we add
+                    # one fresh edge ``source -> decoder``.
+                    for edge in result_advanced.edges:
+                        if edge.source == node_id:
+                            edge.source = decoder_id
+                    result_advanced.edges.append(edge_src_to_decoder)
+
+                    logger.debug(
+                        f"Transformed source node {node_id} into multifilesrc + "
+                        f"{decoder_node.type} for image set '{source}' "
+                        f"({image_set.image_count} images, {image_set.extension})"
+                    )
+                    # The standard "set type/data" code path below is
+                    # bypassed for image sets because we already mutated
+                    # the advanced node above. ``continue`` to the next
+                    # source node.
+                    continue
                 else:
                     raise ValueError(
                         f"Unsupported source kind '{kind}' for node {node_id}. "
-                        f"Supported kinds: '{InputKind.FILE.value}', '{InputKind.CAMERA.value}'"
+                        f"Supported kinds: '{InputKind.FILE.value}', "
+                        f"'{InputKind.CAMERA.value}', '{InputKind.IMAGE_SET.value}'"
                     )
 
                 # Update the node in advanced view (overwriting any properties copied earlier)
@@ -1551,6 +1716,19 @@ class Graph:
         # TODO: temporary, to avoid circular import. In the near future, this file will be refactored to not depend on managers at all.
 
         for node in self.nodes:
+            # Image-set sources carry their canonical extension on the
+            # multifilesrc node. Returning that string here lets logging
+            # and downstream device-selection code treat it like any
+            # other codec value.
+            if node.type == "multifilesrc" and _IMAGE_SET_NODE_FLAG in node.data:
+                ext = str(node.data.get(_IMAGE_SET_NODE_FLAG, "")).lower()
+                if ext:
+                    logger.debug(
+                        f"Determined codec '{ext}' from image-set multifilesrc"
+                    )
+                    return ext
+                return None
+
             if node.type == "filesrc":
                 location = node.data.get("location")
                 if not location:
@@ -2874,6 +3052,14 @@ def _input_video_name_to_path(nodes: list[Node]) -> None:
         for key in ("source", "location"):
             name = node.data.get(key)
             if name is None:
+                continue
+
+            # Already-absolute paths (e.g. image-set ``multifilesrc``
+            # location patterns like ``/images/input/uploaded/.../foo_%02d.jpg``)
+            # bypass the video-name → path mapping; they are taken
+            # as-is by GStreamer.
+            if name.startswith("/"):
+                logger.debug(f"Leaving absolute {node.type} {key} unchanged: {name}")
                 continue
 
             path = VideosManager().get_video_path(name)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/images.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/images.py
@@ -1,71 +1,250 @@
+"""
+Image-set storage and validation.
+
+This module owns the lifecycle of image sets uploaded via the API:
+extracting archives into an isolated layout, validating their contents
+against a strict set of rules, renaming images to a deterministic
+sequence, and persisting a sidecar ``set.json`` with the canonical
+metadata used by the rest of the application.
+
+Public surface:
+    - ImagesManager (singleton): scan / register / resolve image sets.
+    - ImageSet (dataclass): canonical metadata for one image set.
+    - ImageInfo (dataclass): per-image metadata (filename, size, dims).
+    - ImageUploadError + ImageUploadErrorKind: structured validation
+      errors consumed by the API layer.
+
+Storage layout::
+
+    <UPLOADED_IMAGES_DIR>/<trunk>/<trunk>_0001.<ext>
+    <UPLOADED_IMAGES_DIR>/<trunk>/<trunk>_0002.<ext>
+    ...
+    <UPLOADED_IMAGES_DIR>/<trunk>/set.json
+
+Every image inside one set has the same extension and the same
+resolution; this is enforced at upload time and reflected by
+``set.json``.
+"""
+
+import json
 import logging
 import os
+import re
 import shutil
 import tarfile
+import tempfile
 import threading
 import zipfile
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from datetime import datetime, timezone
+from typing import Literal
 
 import cv2
 
 logger = logging.getLogger("images")
 
-# Default directory for input image sets
-_INPUT_IMAGES_DIR = "shared/images/input"
 
-# Read path from environment, falling back to default
-INPUT_IMAGES_DIR: str = os.path.normpath(
-    os.environ.get("INPUT_IMAGES_DIR", _INPUT_IMAGES_DIR)
+# --------------------------------------------------------------------------- #
+# Configuration (module-level for ergonomics; resolved once at import time so
+# tests and runtime share the same view of the environment).
+# --------------------------------------------------------------------------- #
+
+# Default location of the uploaded image sets on disk. Matches the shared
+# volume layout declared in compose.yml.
+_UPLOADED_IMAGES_DIR = "/images/input/uploaded"
+
+UPLOADED_IMAGES_DIR: str = os.path.normpath(
+    os.environ.get("UPLOADED_IMAGES_DIR", _UPLOADED_IMAGES_DIR)
 )
 
-# Supported archive extensions (lowercase, without leading dot).
-# Multi-part extensions (e.g. "tar.gz") are matched against full filename.
-ARCHIVE_EXTENSIONS = (
+# Supported archive extensions (lowercase, no leading dot). Multipart
+# extensions like ``tar.gz`` are matched against the full filename.
+ARCHIVE_EXTENSIONS: tuple[str, ...] = (
     "zip",
     "tar",
     "tar.gz",
     "tgz",
 )
 
-# Supported image file extensions (lowercase, without leading dot)
-IMAGE_EXTENSIONS = (
+# Image extensions accepted by the validator. Each one must have a
+# software GStreamer decoder available so that pipeline integration can
+# always produce a working ``multifilesrc -> *dec`` chain.
+IMAGE_EXTENSIONS: tuple[str, ...] = (
     "jpg",
     "jpeg",
     "png",
     "bmp",
-    "webp",
     "tif",
     "tiff",
 )
+
+# Map every accepted image extension to its canonical family member.
+# ``jpeg`` and ``jpg`` are normalized to ``jpg``; ``tiff`` is normalized
+# to ``tif``. The canonical value is what ends up on disk and inside
+# ``set.json``.
+_EXTENSION_FAMILIES: dict[str, str] = {
+    "jpg": "jpg",
+    "jpeg": "jpg",
+    "png": "png",
+    "bmp": "bmp",
+    "tif": "tif",
+    "tiff": "tif",
+}
+
+# Hardcoded multiplier guarding against zip-bombs. The total uncompressed
+# size must not exceed ``UPLOAD_MAX_SIZE_BYTES * _UNCOMPRESSED_RATIO``.
+_UNCOMPRESSED_RATIO = 10
+
+# Conservative pattern for the sanitized archive trunk that becomes the
+# directory name and the prefix of every renamed image. Matches the
+# scheme used for video uploads.
+_SAFE_TRUNK_RE = re.compile(r"[^A-Za-z0-9_-]+")
+
+
+def _resolve_max_size_bytes() -> int:
+    """
+    Resolve ``UPLOAD_MAX_SIZE_BYTES`` from the environment, falling back to
+    2 GiB. Re-read on every call so tests can monkey-patch the env.
+    """
+    raw = os.environ.get("UPLOAD_MAX_SIZE_BYTES")
+    if raw is None or raw.strip() == "":
+        return 2 * 1024 * 1024 * 1024
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid integer for UPLOAD_MAX_SIZE_BYTES=%r, falling back to 2 GiB",
+            raw,
+        )
+        return 2 * 1024 * 1024 * 1024
+
+
+# --------------------------------------------------------------------------- #
+# Validation result / exception types.
+# --------------------------------------------------------------------------- #
+
+
+# Machine-readable error kinds for image-archive uploads. Mirrors the
+# ``VideoUploadErrorKind`` enum used for video uploads and is consumed by
+# the API layer when building the structured 422 response body.
+ImageUploadErrorKind = Literal[
+    "missing_filename",
+    "unsupported_archive_format",
+    "archive_too_large",
+    "archive_corrupted",
+    "archive_contains_subdirectories",
+    "archive_contains_no_images",
+    "archive_mixed_image_extensions",
+    "archive_disallowed_image_extension",
+    "archive_mixed_image_resolutions",
+    "archive_uncompressed_too_large",
+    "image_set_already_exists",
+    "invalid_archive_name",
+    "unsafe_archive_path",
+]
+
+
+class ImageUploadError(Exception):
+    """
+    Validation error raised while preparing or extracting an image archive.
+
+    Carries the structured fields the API needs to build a uniform 422
+    response: machine-readable ``kind``, human-readable ``detail``, and
+    the optional ``found`` / ``allowed`` triple.
+    """
+
+    def __init__(
+        self,
+        kind: ImageUploadErrorKind,
+        detail: str,
+        *,
+        found: object | None = None,
+        allowed: list[object] | None = None,
+    ) -> None:
+        super().__init__(detail)
+        self.kind: ImageUploadErrorKind = kind
+        self.detail = detail
+        self.found = found
+        self.allowed = allowed
+
+
+# --------------------------------------------------------------------------- #
+# Data classes.
+# --------------------------------------------------------------------------- #
 
 
 @dataclass
 class ImageSet:
     """
-    Represents a directory of images under INPUT_IMAGES_DIR.
+    Canonical metadata for one image set, mirroring ``set.json`` on disk.
+
+    Attributes:
+        name: Sanitised trunk - matches the directory name and the
+            common prefix of every image file inside it.
+        source_archive: Original uploaded archive filename (untouched).
+        image_count: Number of images in the set.
+        extension: Canonical lowercase extension shared by every image
+            (``jpg``, ``png``, ``bmp`` or ``tif``).
+        width: Common image width in pixels.
+        height: Common image height in pixels.
+        uploaded_at: ISO-8601 UTC timestamp of when the set was created.
     """
 
     name: str
+    source_archive: str
     image_count: int
+    extension: str
+    width: int
+    height: int
+    uploaded_at: str
 
-    def to_dict(self) -> dict:
-        return {"name": self.name, "image_count": self.image_count}
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "source_archive": self.source_archive,
+            "image_count": self.image_count,
+            "extension": self.extension,
+            "width": self.width,
+            "height": self.height,
+            "uploaded_at": self.uploaded_at,
+        }
+
+    @staticmethod
+    def from_dict(data: dict) -> "ImageSet":
+        """
+        Build an ``ImageSet`` from a dictionary loaded from ``set.json``.
+
+        Missing fields fall back to safe defaults so that minor schema
+        drift between writes and reads does not break loading.
+        """
+        return ImageSet(
+            name=str(data.get("name", "")),
+            source_archive=str(data.get("source_archive", "")),
+            image_count=int(data.get("image_count") or 0),
+            extension=str(data.get("extension", "")),
+            width=int(data.get("width") or 0),
+            height=int(data.get("height") or 0),
+            uploaded_at=str(data.get("uploaded_at", "")),
+        )
 
 
 @dataclass
 class ImageInfo:
     """
-    Represents a single image file in an image set.
+    Per-image metadata returned by ``ImagesManager.get_images_in_set``.
+
+    All fields are derived from ``set.json`` (no per-call OpenCV probing)
+    except ``size_bytes``, which is stat()-ed on demand because file size
+    is not part of the canonical metadata.
     """
 
     filename: str
     extension: str
     size_bytes: int
-    width: Optional[int]
-    height: Optional[int]
+    width: int
+    height: int
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, object]:
         return {
             "filename": self.filename,
             "extension": self.extension,
@@ -75,264 +254,771 @@ class ImageInfo:
         }
 
 
+# --------------------------------------------------------------------------- #
+# Internal helpers.
+# --------------------------------------------------------------------------- #
+
+
+def _canonical_extension(ext: str) -> str | None:
+    """
+    Map a raw lowercase extension to its canonical family member, or
+    ``None`` if the extension is not in ``IMAGE_EXTENSIONS``.
+    """
+    return _EXTENSION_FAMILIES.get(ext.lower())
+
+
+def _is_within_directory(base: str, target: str) -> bool:
+    """
+    Return True when ``target`` resolves to a path inside ``base``. Used
+    to defeat zip-slip / tar-slip attacks before extraction.
+    """
+    base_abs = os.path.abspath(base)
+    target_abs = os.path.abspath(target)
+    try:
+        return os.path.commonpath([base_abs, target_abs]) == base_abs
+    except ValueError:
+        # Different drives on Windows.
+        return False
+
+
+def _strip_archive_extension(filename: str) -> str | None:
+    """
+    Return the filename with its supported archive extension removed, or
+    ``None`` if the filename does not end with one. Multipart extensions
+    are tested first (longest match wins).
+    """
+    lower = filename.lower()
+    for ext in sorted(ARCHIVE_EXTENSIONS, key=len, reverse=True):
+        if lower.endswith("." + ext):
+            return filename[: -(len(ext) + 1)]
+    return None
+
+
+def sanitise_trunk(raw: str) -> str | None:
+    """
+    Sanitize the archive trunk into a value safe for use as a directory
+    name and filename prefix.
+
+    Lower-cases the input, replaces every run of disallowed characters
+    with a single underscore, then strips leading/trailing underscores.
+    Returns ``None`` if the result is empty or made of dots only.
+    """
+    if not raw:
+        return None
+    lowered = raw.strip().lower()
+    cleaned = _SAFE_TRUNK_RE.sub("_", lowered).strip("_")
+    if not cleaned or cleaned in (".", ".."):
+        return None
+    return cleaned
+
+
+def _now_iso() -> str:
+    """Return the current UTC time formatted as an ISO-8601 string."""
+    return (
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Manager.
+# --------------------------------------------------------------------------- #
+
+
 class ImagesManager:
     """
-    Thread-safe singleton that manages image sets stored as subdirectories of INPUT_IMAGES_DIR.
+    Thread-safe singleton that owns the on-disk image sets directory.
 
-    Each image set is a directory containing image files. Archives uploaded via
-    `extract_archive` are extracted into their own subdirectory.
-
-    Create instances with ImagesManager() to get the shared singleton instance.
+    All file-system operations go through this class so cross-cutting
+    concerns - directory creation with the right permissions, atomic
+    commit of the final image-set directory, race protection between
+    concurrent uploads - live in exactly one place.
     """
 
-    _instance: Optional["ImagesManager"] = None
+    _instance: "ImagesManager | None" = None
     _lock = threading.Lock()
+    # Serializes the commit phase of ``register_uploaded_archive`` so
+    # two concurrent uploads cannot race past the "directory does not
+    # yet exist" check.
+    _upload_lock = threading.Lock()
 
     def __new__(cls) -> "ImagesManager":
         if cls._instance is None:
             with cls._lock:
+                # Double-checked locking.
                 if cls._instance is None:
                     cls._instance = super().__new__(cls)
         return cls._instance
 
     def __init__(self) -> None:
-        # Protect against multiple initialization
+        # Protect against re-initialization - the singleton constructor
+        # may be called multiple times by callers that don't realize it
+        # is shared.
         if hasattr(self, "_initialized"):
             return
         self._initialized = True
 
         logger.debug(
-            f"Initializing ImagesManager with INPUT_IMAGES_DIR={INPUT_IMAGES_DIR}"
+            "Initializing ImagesManager with UPLOADED_IMAGES_DIR=%s",
+            UPLOADED_IMAGES_DIR,
         )
-        os.makedirs(INPUT_IMAGES_DIR, exist_ok=True)
+        self.ensure_root_dir()
 
     # ------------------------------------------------------------------ #
-    # Public API
+    # Directory bootstrap.
     # ------------------------------------------------------------------ #
 
-    def get_all_image_sets(self) -> Dict[str, ImageSet]:
+    @staticmethod
+    def ensure_root_dir() -> None:
         """
-        Returns a dict mapping set name to ImageSet for all subdirectories
-        of INPUT_IMAGES_DIR.
+        Create ``UPLOADED_IMAGES_DIR`` with mode 0o755 if missing.
+
+        ``os.makedirs`` is subject to the process umask and leaves an
+        existing directory's permissions untouched, so we follow up with
+        an explicit ``os.chmod`` to guarantee the mode in every case.
         """
-        result: Dict[str, ImageSet] = {}
-        if not os.path.isdir(INPUT_IMAGES_DIR):
+        try:
+            os.makedirs(UPLOADED_IMAGES_DIR, mode=0o755, exist_ok=True)
+            os.chmod(UPLOADED_IMAGES_DIR, 0o755)
+        except OSError as exc:
+            raise RuntimeError(
+                f"Failed to create image set root '{UPLOADED_IMAGES_DIR}': {exc}"
+            ) from exc
+
+    # ------------------------------------------------------------------ #
+    # Discovery / lookup.
+    # ------------------------------------------------------------------ #
+
+    def get_all_image_sets(self) -> dict[str, ImageSet]:
+        """
+        Return all image sets currently on disk, keyed by name.
+
+        Sets without a readable ``set.json`` are skipped with a warning -
+        the sidecar is the source of truth and a missing one means the
+        directory was not produced by this manager.
+        """
+        result: dict[str, ImageSet] = {}
+        if not os.path.isdir(UPLOADED_IMAGES_DIR):
             return result
 
-        for entry in sorted(os.listdir(INPUT_IMAGES_DIR)):
-            full = os.path.join(INPUT_IMAGES_DIR, entry)
-            if os.path.isdir(full):
-                result[entry] = ImageSet(
-                    name=entry, image_count=self._count_images(full)
+        for entry in sorted(os.listdir(UPLOADED_IMAGES_DIR)):
+            full = os.path.join(UPLOADED_IMAGES_DIR, entry)
+            if not os.path.isdir(full):
+                continue
+            # Skip in-flight staging directories created by
+            # ``register_uploaded_archive``.
+            if entry.startswith(".staging-"):
+                continue
+            image_set = self._load_set_json(full)
+            if image_set is None:
+                logger.warning(
+                    "Skipping image set directory '%s' without a readable set.json",
+                    entry,
                 )
+                continue
+            # The directory name is the source of truth for the set name -
+            # override whatever was persisted in case it drifted.
+            image_set.name = entry
+            result[entry] = image_set
         return result
 
     def image_set_exists(self, name: str) -> bool:
         """
-        Returns True if an image set with the given name exists as a directory
-        under INPUT_IMAGES_DIR. Rejects names containing path separators.
+        Return True if a directory with the given name exists under
+        ``UPLOADED_IMAGES_DIR``. Names containing path separators are
+        rejected to defend against path traversal.
         """
         if not self._is_safe_set_name(name):
             return False
-        return os.path.isdir(os.path.join(INPUT_IMAGES_DIR, name))
+        return os.path.isdir(os.path.join(UPLOADED_IMAGES_DIR, name))
 
-    def get_image_set_path(self, name: str) -> Optional[str]:
+    def get_image_set(self, name: str) -> ImageSet | None:
         """
-        Returns the full path to the image set directory, or None if not found.
+        Return the canonical metadata for one image set, or ``None`` if
+        either the directory or its ``set.json`` is missing.
+        """
+        if not self._is_safe_set_name(name):
+            return None
+        full = os.path.join(UPLOADED_IMAGES_DIR, name)
+        if not os.path.isdir(full):
+            return None
+        image_set = self._load_set_json(full)
+        if image_set is None:
+            return None
+        image_set.name = name
+        return image_set
+
+    def get_image_set_path(self, name: str) -> str | None:
+        """
+        Return the absolute path to the image set directory, or ``None``
+        if the set does not exist.
         """
         if not self.image_set_exists(name):
             return None
-        return os.path.join(INPUT_IMAGES_DIR, name)
+        return os.path.join(UPLOADED_IMAGES_DIR, name)
 
-    def get_images_in_set(self, name: str) -> Optional[List[ImageInfo]]:
+    def get_images_in_set(self, name: str) -> list[ImageInfo] | None:
         """
-        Returns a list of ImageInfo objects describing every image file in the
-        given image set directory. Returns None if the set does not exist.
+        Return a sorted list of images in the given set, or ``None`` if
+        the set does not exist.
 
-        The set directory is walked recursively; only files with supported
-        IMAGE_EXTENSIONS are included. The returned list is sorted by filename
-        (as relative path from the set root).
+        Width / height come from ``set.json`` (every image in a set
+        shares the same resolution by construction); only the per-file
+        size is stat()-ed on demand. The ``set.json`` sidecar itself is
+        not included in the listing.
         """
-        set_path = self.get_image_set_path(name)
-        if set_path is None:
+        image_set = self.get_image_set(name)
+        if image_set is None:
             return None
 
-        images: List[ImageInfo] = []
-        for root, _dirs, files in os.walk(set_path):
-            for fname in files:
-                ext = fname.rsplit(".", 1)[-1].lower() if "." in fname else ""
-                if ext not in IMAGE_EXTENSIONS:
-                    continue
-
-                full_path = os.path.join(root, fname)
-                rel_path = os.path.relpath(full_path, set_path).replace(os.sep, "/")
-
-                try:
-                    size_bytes = os.path.getsize(full_path)
-                except OSError as e:
-                    logger.warning(f"Failed to stat image '{full_path}': {e}")
-                    size_bytes = 0
-
-                width, height = self._read_image_dimensions(full_path)
-
-                images.append(
-                    ImageInfo(
-                        filename=rel_path,
-                        extension=ext,
-                        size_bytes=size_bytes,
-                        width=width,
-                        height=height,
-                    )
+        set_dir = os.path.join(UPLOADED_IMAGES_DIR, name)
+        result: list[ImageInfo] = []
+        for entry in sorted(os.listdir(set_dir)):
+            full = os.path.join(set_dir, entry)
+            if not os.path.isfile(full):
+                continue
+            ext = entry.rsplit(".", 1)[-1].lower() if "." in entry else ""
+            if ext != image_set.extension:
+                # Skip set.json and any stray files of a different type.
+                continue
+            try:
+                size_bytes = os.path.getsize(full)
+            except OSError as exc:
+                logger.warning("Failed to stat image '%s': %s", full, exc)
+                size_bytes = 0
+            result.append(
+                ImageInfo(
+                    filename=entry,
+                    extension=ext,
+                    size_bytes=size_bytes,
+                    width=image_set.width,
+                    height=image_set.height,
                 )
+            )
+        return result
 
-        images.sort(key=lambda i: i.filename)
-        return images
+    def get_location_pattern(self, name: str) -> str | None:
+        """
+        Return the absolute ``multifilesrc`` location pattern for the
+        given image set, or ``None`` if the set is missing.
+
+        Example::
+
+            /images/input/uploaded/dataset/dataset_%04d.png
+
+        The ``%0Nd`` width matches the zero-padding used at upload time
+        (``len(str(image_count))``).
+        """
+        image_set = self.get_image_set(name)
+        if image_set is None:
+            return None
+        width = max(1, len(str(image_set.image_count)))
+        filename = f"{image_set.name}_%0{width}d.{image_set.extension}"
+        return os.path.join(UPLOADED_IMAGES_DIR, image_set.name, filename)
+
+    # ------------------------------------------------------------------ #
+    # Upload pipeline.
+    # ------------------------------------------------------------------ #
 
     @staticmethod
-    def derive_set_name(archive_filename: str) -> Optional[str]:
+    def derive_trunk(archive_filename: str) -> str | None:
         """
-        Derive the image-set directory name from an archive filename by
-        stripping its supported extension. Returns None for unsupported
-        extensions or empty basenames.
+        Derive the sanitized trunk from an uploaded archive filename.
+
+        Returns ``None`` if the filename does not carry a supported
+        archive extension or if sanitization collapses to an empty
+        string.
         """
         if not archive_filename:
             return None
-        lower = archive_filename.lower()
-        stripped: Optional[str] = None
-        for ext in sorted(ARCHIVE_EXTENSIONS, key=len, reverse=True):
-            if lower.endswith("." + ext):
-                stripped = archive_filename[: -(len(ext) + 1)]
-                break
+        # Defend against client-supplied path components.
+        basename = os.path.basename(archive_filename)
+        stripped = _strip_archive_extension(basename)
         if stripped is None:
             return None
+        return sanitise_trunk(stripped)
 
-        # Drop any path components the client may have sent
-        name = os.path.basename(stripped)
-        if not name or name in (".", ".."):
-            return None
-        return name
-
-    def extract_archive(self, archive_path: str, set_name: str) -> ImageSet:
+    def register_uploaded_archive(
+        self,
+        temp_archive_path: str,
+        original_filename: str,
+    ) -> ImageSet:
         """
-        Extracts the archive at `archive_path` into INPUT_IMAGES_DIR/<set_name>.
+        Validate an already-uploaded archive and commit it as a new
+        image set under ``UPLOADED_IMAGES_DIR``.
 
-        Caller is responsible for validating `set_name` (via `derive_set_name`)
-        and ensuring no existing set collides (via `image_set_exists`).
+        The caller is responsible for streaming the bytes to
+        ``temp_archive_path`` and enforcing the request-body size cap;
+        this method takes over from there:
+
+        1. Derive and validate the sanitized trunk.
+        2. Reject the upload if a set with that name already exists.
+        3. Extract the archive into a temporary staging directory and
+           run all content validations (flat layout, allowed image
+           extensions, single image extension family, single resolution,
+           uncompressed-size guard).
+        4. Rename every image to ``<trunk>_<NNNN>.<ext>`` (deterministic
+           alphabetical order, zero-padded width derived from the count).
+        5. Write ``set.json`` and atomically move the staging directory
+           into its final location.
 
         Raises:
-            FileExistsError: If the target directory already exists.
-            ValueError: If the archive type is unsupported, the archive is
-                corrupted, contains unsafe paths (zip-slip), or contains no
-                supported images. On failure the target directory is cleaned up.
+            ImageUploadError: For any user-facing validation failure.
+            RuntimeError: For unexpected I/O failures during commit.
         """
-        if not self._is_safe_set_name(set_name):
-            raise ValueError(f"Invalid image set name: {set_name!r}")
+        trunk = self.derive_trunk(original_filename)
+        if trunk is None:
+            raise ImageUploadError(
+                "invalid_archive_name",
+                (
+                    f"Archive filename '{original_filename}' is not a supported "
+                    f"archive or sanitises to an empty name. Allowed extensions: "
+                    f"{', '.join(ARCHIVE_EXTENSIONS)}."
+                ),
+                found=original_filename,
+                allowed=list(ARCHIVE_EXTENSIONS),
+            )
 
-        target_dir = os.path.join(INPUT_IMAGES_DIR, set_name)
-        if os.path.exists(target_dir):
-            raise FileExistsError(f"Image set '{set_name}' already exists")
+        # Cheap pre-check before extraction. The atomic reservation
+        # below catches the race when two uploads with the same trunk
+        # arrive concurrently.
+        if self.image_set_exists(trunk):
+            raise ImageUploadError(
+                "image_set_already_exists",
+                f"An image set named '{trunk}' already exists.",
+                found=trunk,
+            )
 
-        os.makedirs(INPUT_IMAGES_DIR, exist_ok=True)
-        os.makedirs(target_dir, exist_ok=False)
+        max_uncompressed = _resolve_max_size_bytes() * _UNCOMPRESSED_RATIO
 
+        # Stage the extraction inside a sibling temp directory so the
+        # final move is a same-filesystem rename instead of a copy.
+        self.ensure_root_dir()
+        staging_dir = tempfile.mkdtemp(
+            prefix=".staging-",
+            dir=UPLOADED_IMAGES_DIR,
+        )
         try:
-            lower = archive_path.lower()
-            if lower.endswith(".zip"):
-                self._safe_extract_zip(archive_path, target_dir)
-            else:
-                # tar, tar.gz, tgz
-                self._safe_extract_tar(archive_path, target_dir)
+            self._safe_extract(temp_archive_path, staging_dir, max_uncompressed)
+            image_files = self._validate_extracted_contents(staging_dir)
+            canonical_ext = self._enforce_single_extension(image_files)
+            width, height = self._enforce_single_resolution(staging_dir, image_files)
+            renamed = self._rename_images(
+                staging_dir, image_files, trunk, canonical_ext
+            )
 
-            image_count = self._count_images(target_dir)
-            if image_count == 0:
-                raise ValueError(
-                    "Archive contains no supported images. Allowed extensions: "
-                    + ", ".join(IMAGE_EXTENSIONS)
-                )
+            image_set = ImageSet(
+                name=trunk,
+                source_archive=os.path.basename(original_filename),
+                image_count=len(renamed),
+                extension=canonical_ext,
+                width=width,
+                height=height,
+                uploaded_at=_now_iso(),
+            )
+            self._write_set_json(staging_dir, image_set)
 
-            logger.info(f"Extracted image set '{set_name}' ({image_count} images)")
-            return ImageSet(name=set_name, image_count=image_count)
-
-        except (zipfile.BadZipFile, tarfile.TarError) as e:
-            shutil.rmtree(target_dir, ignore_errors=True)
-            raise ValueError(f"Corrupted archive: {e}") from e
+            self._commit_staging(staging_dir, trunk)
+            logger.info(
+                "Registered image set '%s' (%d images, %s, %dx%d)",
+                trunk,
+                image_set.image_count,
+                canonical_ext,
+                width,
+                height,
+            )
+            return image_set
+        except ImageUploadError:
+            shutil.rmtree(staging_dir, ignore_errors=True)
+            raise
         except Exception:
-            shutil.rmtree(target_dir, ignore_errors=True)
+            shutil.rmtree(staging_dir, ignore_errors=True)
             raise
 
     # ------------------------------------------------------------------ #
-    # Internals
+    # Extraction and validation.
+    # ------------------------------------------------------------------ #
+
+    def _safe_extract(
+        self,
+        archive_path: str,
+        dest_dir: str,
+        max_uncompressed_bytes: int,
+    ) -> None:
+        """
+        Extract ``archive_path`` into ``dest_dir`` after sanitizing every
+        member.
+
+        Performs three checks before writing any byte to disk:
+
+        - Path safety: every member must resolve inside ``dest_dir``.
+        - Flat layout: members may not contain any path separator.
+        - Uncompressed-size cap: the sum of declared member sizes must
+          not exceed ``max_uncompressed_bytes``.
+        """
+        lower = archive_path.lower()
+        try:
+            if lower.endswith(".zip"):
+                self._safe_extract_zip(archive_path, dest_dir, max_uncompressed_bytes)
+            else:
+                self._safe_extract_tar(archive_path, dest_dir, max_uncompressed_bytes)
+        except (zipfile.BadZipFile, tarfile.TarError) as exc:
+            raise ImageUploadError(
+                "archive_corrupted",
+                f"Archive could not be opened or read: {exc}",
+            ) from exc
+
+    @staticmethod
+    def _check_member_layout(name: str, dest_dir: str) -> None:
+        """
+        Reject archive members that escape ``dest_dir`` (zip-slip) or
+        live inside a subdirectory (we mandate a flat layout).
+        """
+        if "/" in name or "\\" in name:
+            raise ImageUploadError(
+                "archive_contains_subdirectories",
+                (
+                    "Archive must contain only files at the top level. "
+                    f"Found nested entry '{name}'."
+                ),
+                found=name,
+            )
+        if not _is_within_directory(dest_dir, os.path.join(dest_dir, name)):
+            raise ImageUploadError(
+                "unsafe_archive_path",
+                f"Archive contains an unsafe path: '{name}'.",
+                found=name,
+            )
+
+    @classmethod
+    def _safe_extract_zip(
+        cls,
+        archive_path: str,
+        dest_dir: str,
+        max_uncompressed_bytes: int,
+    ) -> None:
+        """
+        Validate and extract a ``.zip`` archive.
+        """
+        with zipfile.ZipFile(archive_path) as zf:
+            members = zf.infolist()
+            total = 0
+            for member in members:
+                if member.is_dir():
+                    # An explicit directory entry violates the flat-only
+                    # rule even if no file lives in it.
+                    cls._check_member_layout(member.filename, dest_dir)
+                    continue
+                cls._check_member_layout(member.filename, dest_dir)
+                total += int(member.file_size)
+                if total > max_uncompressed_bytes:
+                    raise ImageUploadError(
+                        "archive_uncompressed_too_large",
+                        (
+                            "Archive uncompressed size exceeds the allowed "
+                            f"maximum of {max_uncompressed_bytes} bytes."
+                        ),
+                        found=total,
+                        allowed=[max_uncompressed_bytes],
+                    )
+
+            for member in members:
+                if member.is_dir():
+                    continue
+                zf.extract(member, dest_dir)
+
+    @classmethod
+    def _safe_extract_tar(
+        cls,
+        archive_path: str,
+        dest_dir: str,
+        max_uncompressed_bytes: int,
+    ) -> None:
+        """
+        Validate and extract a ``.tar`` / ``.tar.gz`` / ``.tgz`` archive.
+        """
+        with tarfile.open(archive_path) as tf:
+            members = tf.getmembers()
+            total = 0
+            for member in members:
+                if member.isdir():
+                    cls._check_member_layout(member.name, dest_dir)
+                    continue
+                if not member.isfile():
+                    # Reject symlinks, devices, fifos - anything that
+                    # isn't a regular file has no business in an image
+                    # archive.
+                    raise ImageUploadError(
+                        "unsafe_archive_path",
+                        f"Archive contains a non-regular entry: '{member.name}'.",
+                        found=member.name,
+                    )
+                cls._check_member_layout(member.name, dest_dir)
+                total += int(member.size)
+                if total > max_uncompressed_bytes:
+                    raise ImageUploadError(
+                        "archive_uncompressed_too_large",
+                        (
+                            "Archive uncompressed size exceeds the allowed "
+                            f"maximum of {max_uncompressed_bytes} bytes."
+                        ),
+                        found=total,
+                        allowed=[max_uncompressed_bytes],
+                    )
+
+            # ``filter="data"`` is the Python 3.12+ default-safe filter
+            # that strips ownership and dangerous attributes.
+            tf.extractall(dest_dir, members=members, filter="data")
+
+    @staticmethod
+    def _validate_extracted_contents(staging_dir: str) -> list[str]:
+        """
+        Return the sorted list of image filenames in ``staging_dir``.
+
+        Raises an ``ImageUploadError`` if no images are found or if any
+        file uses an extension outside the allow-list.
+        """
+        all_entries = sorted(os.listdir(staging_dir))
+        image_files: list[str] = []
+        for entry in all_entries:
+            full = os.path.join(staging_dir, entry)
+            if not os.path.isfile(full):
+                # Subdirectories are already rejected during extraction;
+                # this guard catches anything else (sockets, broken
+                # symlinks).
+                continue
+            ext = entry.rsplit(".", 1)[-1].lower() if "." in entry else ""
+            if ext not in IMAGE_EXTENSIONS:
+                raise ImageUploadError(
+                    "archive_disallowed_image_extension",
+                    (
+                        f"Archive contains a file with an unsupported extension: "
+                        f"'{entry}'. Allowed image extensions: "
+                        f"{', '.join(IMAGE_EXTENSIONS)}."
+                    ),
+                    found=ext,
+                    allowed=list(IMAGE_EXTENSIONS),
+                )
+            image_files.append(entry)
+
+        if not image_files:
+            raise ImageUploadError(
+                "archive_contains_no_images",
+                "Archive does not contain any supported image files.",
+                allowed=list(IMAGE_EXTENSIONS),
+            )
+        return image_files
+
+    @staticmethod
+    def _enforce_single_extension(image_files: list[str]) -> str:
+        """
+        Verify that every image in the archive belongs to the same
+        extension family (``jpg`` and ``jpeg`` count as one) and return
+        the canonical family member.
+        """
+        families: set[str] = set()
+        for filename in image_files:
+            ext = filename.rsplit(".", 1)[-1].lower()
+            canonical = _canonical_extension(ext)
+            if canonical is None:
+                # Should not happen - already filtered upstream.
+                raise ImageUploadError(
+                    "archive_disallowed_image_extension",
+                    f"Unsupported image extension '.{ext}'.",
+                    found=ext,
+                    allowed=list(IMAGE_EXTENSIONS),
+                )
+            families.add(canonical)
+
+        if len(families) > 1:
+            raise ImageUploadError(
+                "archive_mixed_image_extensions",
+                (
+                    "Archive must contain images of exactly one type. "
+                    f"Found multiple: {sorted(families)}."
+                ),
+                found=sorted(families),
+            )
+        return next(iter(families))
+
+    @staticmethod
+    def _enforce_single_resolution(
+        staging_dir: str, image_files: list[str]
+    ) -> tuple[int, int]:
+        """
+        Open every image with OpenCV and verify they all share the same
+        resolution. Return the common ``(width, height)``. Any file that
+        cannot be decoded is treated as a corrupted archive.
+        """
+        common: tuple[int, int] | None = None
+        for filename in image_files:
+            full = os.path.join(staging_dir, filename)
+            try:
+                img = cv2.imread(full, cv2.IMREAD_UNCHANGED)
+            except Exception as exc:  # pragma: no cover - defensive
+                raise ImageUploadError(
+                    "archive_corrupted",
+                    f"Image '{filename}' could not be decoded: {exc}.",
+                    found=filename,
+                ) from exc
+            if img is None:
+                raise ImageUploadError(
+                    "archive_corrupted",
+                    f"Image '{filename}' could not be decoded.",
+                    found=filename,
+                )
+            height, width = img.shape[:2]
+            dims = (int(width), int(height))
+            if common is None:
+                common = dims
+            elif common != dims:
+                raise ImageUploadError(
+                    "archive_mixed_image_resolutions",
+                    (
+                        "Archive must contain images that all share the same "
+                        f"resolution. Found {dims} after {common}."
+                    ),
+                    found=[list(common), list(dims)],
+                )
+        # ``common`` is non-None because ``image_files`` is non-empty.
+        assert common is not None
+        return common
+
+    @staticmethod
+    def _rename_images(
+        staging_dir: str,
+        image_files: list[str],
+        trunk: str,
+        canonical_ext: str,
+    ) -> list[str]:
+        """
+        Rename every image inside ``staging_dir`` to
+        ``<trunk>_<NNNN>.<canonical_ext>`` using a width derived from
+        the number of images (``len(str(N))``). Returns the new
+        filenames in numeric order.
+
+        The rename happens via a ``.tmp`` intermediate to avoid clashes
+        when an original name already matches the target pattern.
+        """
+        count = len(image_files)
+        width = max(1, len(str(count)))
+        tmp_names: list[str] = []
+
+        # First pass: move everything to a temporary name so source and
+        # target can never collide during the second pass.
+        for index, original in enumerate(sorted(image_files), start=1):
+            tmp_name = f".rename-{index:0{width}d}.tmp"
+            os.replace(
+                os.path.join(staging_dir, original),
+                os.path.join(staging_dir, tmp_name),
+            )
+            tmp_names.append(tmp_name)
+
+        # Second pass: move the ``.tmp`` files to their final canonical
+        # names, lower-casing the extension regardless of the original.
+        final_names: list[str] = []
+        for index, tmp_name in enumerate(tmp_names, start=1):
+            final = f"{trunk}_{index:0{width}d}.{canonical_ext}"
+            os.replace(
+                os.path.join(staging_dir, tmp_name),
+                os.path.join(staging_dir, final),
+            )
+            final_names.append(final)
+        return final_names
+
+    @staticmethod
+    def _write_set_json(staging_dir: str, image_set: ImageSet) -> None:
+        """
+        Persist the canonical ``set.json`` sidecar inside ``staging_dir``.
+        Written before the staging dir is moved into its final location
+        so the commit is atomic from the consumer's point of view.
+        """
+        path = os.path.join(staging_dir, "set.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(image_set.to_dict(), fh, indent=2)
+        try:
+            os.chmod(path, 0o644)
+        except OSError as exc:
+            logger.warning("Could not chmod '%s': %s", path, exc)
+
+    def _commit_staging(self, staging_dir: str, trunk: str) -> None:
+        """
+        Atomically move the staging directory into its final location
+        ``UPLOADED_IMAGES_DIR/<trunk>``.
+
+        The lock + ``os.makedirs(..., exist_ok=False)`` reservation
+        turns the conflict check into a single critical section so two
+        concurrent uploads cannot both win.
+        """
+        target_dir = os.path.join(UPLOADED_IMAGES_DIR, trunk)
+        with self._upload_lock:
+            try:
+                # Reserve the target name atomically. ``exist_ok=False``
+                # raises if the directory already exists, which is the
+                # signal that another concurrent upload won the race.
+                os.makedirs(target_dir, exist_ok=False)
+            except FileExistsError as exc:
+                raise ImageUploadError(
+                    "image_set_already_exists",
+                    f"An image set named '{trunk}' already exists.",
+                    found=trunk,
+                ) from exc
+
+            # Replace the empty placeholder with the staging directory.
+            # ``os.rename`` succeeds over an empty target directory on
+            # POSIX, which is what we just guaranteed.
+            try:
+                os.rmdir(target_dir)
+                os.rename(staging_dir, target_dir)
+            except OSError as exc:
+                # Clean up our placeholder so a retry can succeed.
+                try:
+                    if os.path.isdir(target_dir):
+                        os.rmdir(target_dir)
+                except OSError:
+                    pass
+                raise RuntimeError(
+                    f"Failed to commit image set '{trunk}': {exc}"
+                ) from exc
+
+            try:
+                os.chmod(target_dir, 0o755)
+            except OSError as exc:
+                logger.warning("Could not chmod '%s': %s", target_dir, exc)
+
+    # ------------------------------------------------------------------ #
+    # Misc helpers.
     # ------------------------------------------------------------------ #
 
     @staticmethod
     def _is_safe_set_name(name: str) -> bool:
+        """
+        Return True when ``name`` is a single safe path component.
+        """
         if not name or name in (".", ".."):
             return False
-        if os.sep in name:
+        if "/" in name or "\\" in name:
             return False
-        if os.altsep and os.altsep in name:
+        if os.sep in name or (os.altsep and os.altsep in name):
             return False
         return True
 
     @staticmethod
-    def _count_images(directory: str) -> int:
-        count = 0
-        for _root, _dirs, files in os.walk(directory):
-            for name in files:
-                ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
-                if ext in IMAGE_EXTENSIONS:
-                    count += 1
-        return count
-
-    @staticmethod
-    def _read_image_dimensions(
-        file_path: str,
-    ) -> tuple[Optional[int], Optional[int]]:
+    def _load_set_json(set_dir: str) -> ImageSet | None:
         """
-        Reads (width, height) from an image file using OpenCV.
-        Returns (None, None) if the image cannot be read.
+        Load and parse the ``set.json`` sidecar from ``set_dir``. Returns
+        ``None`` on any error so a corrupted sidecar does not crash the
+        listing endpoint.
         """
+        path = os.path.join(set_dir, "set.json")
+        if not os.path.isfile(path):
+            return None
         try:
-            img = cv2.imread(file_path, cv2.IMREAD_UNCHANGED)
-        except Exception as e:
-            logger.warning(f"Failed to read image '{file_path}': {e}")
-            return None, None
-        if img is None:
-            return None, None
-        h, w = img.shape[:2]
-        return int(w), int(h)
-
-    @staticmethod
-    def _is_within_directory(base: str, target: str) -> bool:
-        base_abs = os.path.abspath(base)
-        target_abs = os.path.abspath(target)
-        try:
-            return os.path.commonpath([base_abs, target_abs]) == base_abs
-        except ValueError:
-            # Different drives on Windows
-            return False
-
-    @classmethod
-    def _safe_extract_zip(cls, archive_path: str, dest_dir: str) -> None:
-        with zipfile.ZipFile(archive_path) as zf:
-            members = zf.namelist()
-            for member in members:
-                member_path = os.path.join(dest_dir, member)
-                if not cls._is_within_directory(dest_dir, member_path):
-                    raise ValueError("Archive contains unsafe paths (path traversal).")
-            zf.extractall(dest_dir, members=members)
-
-    @classmethod
-    def _safe_extract_tar(cls, archive_path: str, dest_dir: str) -> None:
-        with tarfile.open(archive_path) as tf:
-            members = tf.getmembers()
-            for member in members:
-                member_path = os.path.join(dest_dir, member.name)
-                if not cls._is_within_directory(dest_dir, member_path):
-                    raise ValueError("Archive contains unsafe paths (path traversal).")
-            tf.extractall(dest_dir, members=members)
-
-
-def list_image_sets() -> List[ImageSet]:
-    """Convenience helper mirroring videos-style module-level usage."""
-    return list(ImagesManager().get_all_image_sets().values())
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Failed to read '%s': %s", path, exc)
+            return None
+        if not isinstance(data, dict):
+            logger.warning("set.json at '%s' is not an object", path)
+            return None
+        return ImageSet.from_dict(data)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/api_tests/images_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/api_tests/images_test.py
@@ -12,6 +12,8 @@ cleanup behaviour as well.
 
 import io
 import os
+import shutil
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -200,6 +202,20 @@ class TestUploadValidationRejections(_BaseImagesAPITest):
 
 
 class TestUploadStreaming(_BaseImagesAPITest):
+    def setUp(self) -> None:
+        # The route writes the incoming archive to a temp file under
+        # ``UPLOADED_IMAGES_DIR``. On CI that path (``/images/...``)
+        # does not exist, so point the route at a per-test temp dir.
+        self._tmpdir = tempfile.mkdtemp(prefix="vippet-upload-test-")
+        self._uploads_patch = patch.object(
+            images_route, "UPLOADED_IMAGES_DIR", self._tmpdir
+        )
+        self._uploads_patch.start()
+
+    def tearDown(self) -> None:
+        self._uploads_patch.stop()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
     def _post(self, filename: str, content: bytes) -> httpx.Response:
         files = {"file": (filename, io.BytesIO(content), "application/zip")}
         return self.client.post("/images/upload", files=files)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/api_tests/images_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/api_tests/images_test.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for ``vippet.api.routes.images``.
+
+The router is exercised via ``fastapi.TestClient`` and ``ImagesManager``
+is mocked end-to-end, so the tests verify the HTTP contract (status
+codes, request body parsing, response envelope) without touching the
+filesystem. The few tests that go through the real upload path provide
+a lightweight stub manager so we can assert temp-file streaming and
+cleanup behaviour as well.
+"""
+
+import io
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routes.images as images_route
+from api.routes.images import router as images_router
+
+
+def _make_set_obj(
+    name: str = "alpha",
+    image_count: int = 5,
+    extension: str = "png",
+) -> MagicMock:
+    obj = MagicMock()
+    obj.name = name
+    obj.source_archive = f"{name}.zip"
+    obj.image_count = image_count
+    obj.extension = extension
+    obj.width = 1280
+    obj.height = 720
+    obj.uploaded_at = "2026-04-28T10:00:00Z"
+    return obj
+
+
+def _make_image_info(
+    filename: str = "alpha_001.png",
+    extension: str = "png",
+    size_bytes: int = 12345,
+) -> MagicMock:
+    info = MagicMock()
+    info.filename = filename
+    info.extension = extension
+    info.size_bytes = size_bytes
+    info.width = 1280
+    info.height = 720
+    return info
+
+
+class _BaseImagesAPITest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        app = FastAPI()
+        app.include_router(images_router, prefix="/images")
+        cls.client = TestClient(app)
+
+
+# --------------------------------------------------------------------------- #
+# GET /images
+# --------------------------------------------------------------------------- #
+
+
+class TestGetImageSets(_BaseImagesAPITest):
+    def test_returns_list_of_sets(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.get_all_image_sets.return_value = {
+                "alpha": _make_set_obj("alpha", 5, "png"),
+                "beta": _make_set_obj("beta", 7, "jpg"),
+            }
+            mock_cls.return_value = instance
+
+            response = self.client.get("/images")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["name"], "alpha")
+        self.assertEqual(data[0]["image_count"], 5)
+        self.assertEqual(data[0]["extension"], "png")
+        self.assertEqual(data[0]["width"], 1280)
+        self.assertEqual(data[0]["height"], 720)
+        self.assertEqual(data[0]["source_archive"], "alpha.zip")
+        self.assertEqual(data[0]["uploaded_at"], "2026-04-28T10:00:00Z")
+
+    def test_empty_list(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.get_all_image_sets.return_value = {}
+            mock_cls.return_value = instance
+
+            response = self.client.get("/images")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_unexpected_error_returns_500(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.get_all_image_sets.side_effect = RuntimeError("boom")
+            mock_cls.return_value = instance
+
+            response = self.client.get("/images")
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("message", response.json())
+
+
+# --------------------------------------------------------------------------- #
+# GET /images/check-image-set-exists
+# --------------------------------------------------------------------------- #
+
+
+class TestCheckImageSetExists(_BaseImagesAPITest):
+    def test_exists_true(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.image_set_exists.return_value = True
+            mock_cls.return_value = instance
+            response = self.client.get(
+                "/images/check-image-set-exists", params={"name": "alpha"}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"exists": True, "name": "alpha"})
+
+    def test_exists_false(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.image_set_exists.return_value = False
+            mock_cls.return_value = instance
+            response = self.client.get(
+                "/images/check-image-set-exists", params={"name": "missing"}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"exists": False, "name": "missing"})
+
+    def test_missing_query_param_is_422(self) -> None:
+        response = self.client.get("/images/check-image-set-exists")
+        self.assertEqual(response.status_code, 422)
+
+
+# --------------------------------------------------------------------------- #
+# POST /images/upload (pre-write validation)
+# --------------------------------------------------------------------------- #
+
+
+class TestUploadValidationRejections(_BaseImagesAPITest):
+    """
+    Cases where the route returns 422 before writing to disk. The
+    manager is mocked so its filesystem side effects are never invoked.
+    """
+
+    def _post(self, filename: str, content: bytes = b"data") -> httpx.Response:
+        files = {"file": (filename, io.BytesIO(content), "application/octet-stream")}
+        return self.client.post("/images/upload", files=files)
+
+    def test_unsupported_archive_extension(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.derive_trunk.return_value = None
+            mock_cls.return_value = instance
+            response = self._post("file.7z")
+        self.assertEqual(response.status_code, 422)
+        body = response.json()
+        self.assertEqual(body["error"], "unsupported_archive_format")
+        self.assertEqual(body["found"], "file.7z")
+        self.assertIsInstance(body["allowed"], list)
+
+    def test_invalid_archive_name(self) -> None:
+        # The filename has a supported extension but sanitises to empty.
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.derive_trunk.return_value = None
+            mock_cls.return_value = instance
+            response = self._post("!!!.zip")
+        self.assertEqual(response.status_code, 422)
+        body = response.json()
+        self.assertEqual(body["error"], "invalid_archive_name")
+        self.assertEqual(body["found"], "!!!.zip")
+
+    def test_image_set_already_exists_pre_check(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.derive_trunk.return_value = "dorota"
+            instance.image_set_exists.return_value = True
+            mock_cls.return_value = instance
+            response = self._post("dorota.zip")
+        self.assertEqual(response.status_code, 422)
+        body = response.json()
+        self.assertEqual(body["error"], "image_set_already_exists")
+        self.assertEqual(body["found"], "dorota")
+
+
+# --------------------------------------------------------------------------- #
+# POST /images/upload (streaming + manager interaction)
+# --------------------------------------------------------------------------- #
+
+
+class TestUploadStreaming(_BaseImagesAPITest):
+    def _post(self, filename: str, content: bytes) -> httpx.Response:
+        files = {"file": (filename, io.BytesIO(content), "application/zip")}
+        return self.client.post("/images/upload", files=files)
+
+    def test_archive_too_large_mid_stream(self) -> None:
+        with patch.object(images_route, "UPLOAD_MAX_SIZE_BYTES", 16):
+            with patch("api.routes.images.ImagesManager") as mock_cls:
+                instance = MagicMock()
+                instance.derive_trunk.return_value = "huge"
+                instance.image_set_exists.return_value = False
+                mock_cls.return_value = instance
+
+                response = self._post("huge.zip", b"X" * 1024)
+
+        self.assertEqual(response.status_code, 422)
+        body = response.json()
+        self.assertEqual(body["error"], "archive_too_large")
+        self.assertGreater(body["found"], 16)
+        self.assertEqual(body["allowed"], [16])
+
+    def test_successful_upload_returns_201_and_set(self) -> None:
+        captured_paths: list[str] = []
+
+        def fake_register(temp_path: str, original: str):
+            # Confirm the temp file actually exists when the manager is
+            # called, so we know the route streamed bytes to disk first.
+            captured_paths.append(temp_path)
+            self.assertTrue(os.path.isfile(temp_path))
+            return _make_set_obj("dorota", 40, "jpg")
+
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.derive_trunk.return_value = "dorota"
+            instance.image_set_exists.return_value = False
+            instance.register_uploaded_archive.side_effect = fake_register
+            mock_cls.return_value = instance
+
+            response = self._post("dorota.zip", b"PK\x03\x04" + b"x" * 64)
+
+        self.assertEqual(response.status_code, 201)
+        body = response.json()
+        self.assertEqual(body["name"], "dorota")
+        self.assertEqual(body["image_count"], 40)
+        self.assertEqual(body["extension"], "jpg")
+
+        # Temp file must be cleaned up after the response is built.
+        self.assertEqual(len(captured_paths), 1)
+        self.assertFalse(os.path.isfile(captured_paths[0]))
+
+    def test_manager_validation_error_mapped_to_422(self) -> None:
+        from images import ImageUploadError
+
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.derive_trunk.return_value = "bad"
+            instance.image_set_exists.return_value = False
+            instance.register_uploaded_archive.side_effect = ImageUploadError(
+                "archive_mixed_image_extensions",
+                "Mixed extensions found.",
+                found=["jpg", "png"],
+                allowed=None,
+            )
+            mock_cls.return_value = instance
+
+            response = self._post("bad.zip", b"x" * 32)
+
+        self.assertEqual(response.status_code, 422)
+        body = response.json()
+        self.assertEqual(body["error"], "archive_mixed_image_extensions")
+        self.assertEqual(body["found"], ["jpg", "png"])
+        self.assertEqual(body["detail"], "Mixed extensions found.")
+
+    def test_manager_runtime_error_mapped_to_500(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.derive_trunk.return_value = "io"
+            instance.image_set_exists.return_value = False
+            instance.register_uploaded_archive.side_effect = RuntimeError("disk full")
+            mock_cls.return_value = instance
+
+            response = self._post("io.zip", b"x" * 32)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("disk full", response.json()["message"])
+
+    def test_unexpected_exception_mapped_to_500(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.derive_trunk.return_value = "boom"
+            instance.image_set_exists.return_value = False
+            instance.register_uploaded_archive.side_effect = ValueError("???")
+            mock_cls.return_value = instance
+
+            response = self._post("boom.zip", b"x" * 32)
+
+        self.assertEqual(response.status_code, 500)
+
+
+# --------------------------------------------------------------------------- #
+# GET /images/{name}
+# --------------------------------------------------------------------------- #
+
+
+class TestListImagesInSet(_BaseImagesAPITest):
+    def test_returns_listing(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.get_images_in_set.return_value = [
+                _make_image_info("alpha_01.png"),
+                _make_image_info("alpha_02.png"),
+            ]
+            mock_cls.return_value = instance
+            response = self.client.get("/images/alpha")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["filename"], "alpha_01.png")
+        self.assertEqual(data[0]["extension"], "png")
+        self.assertEqual(data[0]["width"], 1280)
+        self.assertEqual(data[0]["height"], 720)
+        self.assertEqual(data[0]["size_bytes"], 12345)
+
+    def test_set_not_found_returns_404(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.get_images_in_set.return_value = None
+            mock_cls.return_value = instance
+            response = self.client.get("/images/missing")
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("not found", response.json()["message"])
+
+    def test_unexpected_error_returns_500(self) -> None:
+        with patch("api.routes.images.ImagesManager") as mock_cls:
+            instance = MagicMock()
+            instance.get_images_in_set.side_effect = RuntimeError("oops")
+            mock_cls.return_value = instance
+            response = self.client.get("/images/x")
+        self.assertEqual(response.status_code, 500)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/graph_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/graph_test.py
@@ -6529,5 +6529,60 @@ class TestInputVideoNameToPathAbsoluteBypass(unittest.TestCase):
         self.assertEqual(nodes[0].data["location"], "/videos/input/uploaded/foo.mp4")
 
 
+# --------------------------------------------------------------------------- #
+# _prepare_generic_input: image-set multifilesrc round-trip back to source.
+# --------------------------------------------------------------------------- #
+
+
+class TestPrepareGenericInputImageSet(unittest.TestCase):
+    """
+    Verify that ``_prepare_generic_input`` (advanced -> simple) emits a
+    ``source`` node with ``kind=image_set`` for ``multifilesrc`` nodes
+    that were originally produced from an image-set source. Without
+    this, the simple view would lose the image-set kind on round-trip
+    and reload the pipeline as a regular file source.
+    """
+
+    def test_image_set_multifilesrc_becomes_image_set_source(self) -> None:
+        from graph import _IMAGE_SET_NODE_FLAG, InputKind, _prepare_generic_input
+
+        node = Node(
+            id="0",
+            type="multifilesrc",
+            data={
+                "location": "/images/input/uploaded/dorota/dorota_%02d.jpg",
+                "index": "1",
+                "stop-index": "40",
+                "loop": "false",
+                "caps": "image/jpeg,framerate=30/1",
+                _IMAGE_SET_NODE_FLAG: "jpg",
+            },
+        )
+
+        _prepare_generic_input([node])
+
+        self.assertEqual(node.type, "source")
+        self.assertEqual(node.data["kind"], InputKind.IMAGE_SET)
+        self.assertEqual(node.data["source"], "dorota")
+        # Internal marker must not leak into the simple view.
+        self.assertNotIn(_IMAGE_SET_NODE_FLAG, node.data)
+        self.assertNotIn("location", node.data)
+
+    def test_plain_multifilesrc_still_becomes_file_source(self) -> None:
+        from graph import InputKind, _prepare_generic_input
+
+        node = Node(
+            id="0",
+            type="multifilesrc",
+            data={"location": "loop.mp4"},
+        )
+
+        _prepare_generic_input([node])
+
+        self.assertEqual(node.type, "source")
+        self.assertEqual(node.data["kind"], InputKind.FILE)
+        self.assertEqual(node.data["source"], "loop.mp4")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/graph_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/graph_test.py
@@ -6133,5 +6133,401 @@ class TestApplyStreamIdentifiers(unittest.TestCase):
         self.assertNotIn("name", splitmux.data)
 
 
+# --------------------------------------------------------------------------- #
+# Image-set source mapping (simple -> advanced).
+# --------------------------------------------------------------------------- #
+
+
+def _make_image_set_mock(
+    name: str = "dorota",
+    extension: str = "jpg",
+    image_count: int = 40,
+    width: int = 2,
+):
+    """
+    Build a mock for ``ImagesManager().get_image_set`` / ``get_location_pattern``.
+    ``width`` is the zero-padding width that the location pattern carries
+    (``len(str(image_count))``).
+    """
+    image_set = MagicMock()
+    image_set.name = name
+    image_set.extension = extension
+    image_set.image_count = image_count
+    image_set.width = 1280
+    image_set.height = 720
+    location = f"/images/input/uploaded/{name}/{name}_%0{width}d.{extension}"
+    return image_set, location
+
+
+class TestImageSetSourceMapping(unittest.TestCase):
+    """
+    Verify that ``apply_simple_view_changes`` rewrites a generic
+    ``source`` node with ``kind=image_set`` into a concrete
+    ``multifilesrc`` + decoder pair, with the right caps, stop-index and
+    edges. The downstream ``apply_looping_modifications`` and
+    ``determine_input_codec`` behaviours that depend on the marker flag
+    are covered in their own classes below.
+    """
+
+    def _make_simple(self, kind, source: str) -> Graph:
+        return Graph(
+            nodes=[
+                Node(id="0", type="source", data={"kind": kind, "source": source}),
+                Node(id="2", type="gvadetect", data={"model": "yolo"}),
+                Node(id="12", type="fakesink", data={}),
+            ],
+            edges=[
+                Edge(id="0", source="0", target="2"),
+                Edge(id="11", source="2", target="12"),
+            ],
+        )
+
+    def _make_advanced_with_filesrc(self) -> Graph:
+        # Mirrors the kind of advanced graph that ``from_simple_view``
+        # produces for a file source (filesrc + decodebin3 + ...).
+        return Graph(
+            nodes=[
+                Node(id="0", type="filesrc", data={"location": "x.mp4"}),
+                Node(id="1", type="decodebin3", data={}),
+                Node(id="2", type="gvadetect", data={"model": "yolo"}),
+                Node(id="12", type="fakesink", data={}),
+            ],
+            edges=[
+                Edge(id="0", source="0", target="1"),
+                Edge(id="1", source="1", target="2"),
+                Edge(id="11", source="2", target="12"),
+            ],
+        )
+
+    @patch("graph.ImagesManager")
+    def test_jpg_image_set_replaces_filesrc_with_multifilesrc_and_jpegdec(
+        self, mock_cls
+    ):
+        image_set, location = _make_image_set_mock("dorota", "jpg", 40, 2)
+        instance = MagicMock()
+        instance.get_image_set.return_value = image_set
+        instance.get_location_pattern.return_value = location
+        mock_cls.return_value = instance
+
+        original_simple = self._make_simple(InputKind.FILE, "x.mp4")
+        modified_simple = self._make_simple(InputKind.IMAGE_SET, "dorota")
+        original_advanced = self._make_advanced_with_filesrc()
+
+        result = Graph.apply_simple_view_changes(
+            modified_simple=modified_simple,
+            original_simple=original_simple,
+            original_advanced=original_advanced,
+        )
+
+        # The original source node has been retyped to multifilesrc.
+        src = next(n for n in result.nodes if n.id == "0")
+        self.assertEqual(src.type, "multifilesrc")
+        self.assertEqual(src.data["location"], location)
+        self.assertEqual(src.data["index"], "1")
+        self.assertEqual(src.data["stop-index"], "40")
+        # ``loop`` starts off; ``apply_looping_modifications`` flips it.
+        self.assertEqual(src.data["loop"], "false")
+        self.assertIn("caps", src.data)
+        self.assertTrue(src.data["caps"].startswith("image/jpeg"))
+        # Internal marker is present (carries the canonical extension).
+        self.assertIn("__image_set", src.data)
+        self.assertEqual(src.data["__image_set"], "jpg")
+
+        # A jpegdec node has been inserted right after the source.
+        decoder_nodes = [n for n in result.nodes if n.type == "jpegdec"]
+        self.assertEqual(len(decoder_nodes), 1)
+        decoder = decoder_nodes[0]
+
+        # Edges are rewired so the source flows through the decoder.
+        edges_from_source = [e for e in result.edges if e.source == "0"]
+        self.assertEqual(len(edges_from_source), 1)
+        self.assertEqual(edges_from_source[0].target, decoder.id)
+
+        # The original ``0->1`` edge into decodebin3 has been retargeted
+        # to flow out of the new decoder.
+        edges_from_decoder = [e for e in result.edges if e.source == decoder.id]
+        # The decoder fans out to whatever was downstream of the original source.
+        self.assertGreaterEqual(len(edges_from_decoder), 1)
+
+    @patch("graph.ImagesManager")
+    def test_png_uses_pngdec_and_image_png_caps(self, mock_cls):
+        image_set, location = _make_image_set_mock("imgs", "png", 5, 1)
+        instance = MagicMock()
+        instance.get_image_set.return_value = image_set
+        instance.get_location_pattern.return_value = location
+        mock_cls.return_value = instance
+
+        result = Graph.apply_simple_view_changes(
+            modified_simple=self._make_simple(InputKind.IMAGE_SET, "imgs"),
+            original_simple=self._make_simple(InputKind.FILE, "x.mp4"),
+            original_advanced=self._make_advanced_with_filesrc(),
+        )
+
+        src = next(n for n in result.nodes if n.id == "0")
+        self.assertTrue(src.data["caps"].startswith("image/png"))
+        self.assertEqual(src.data["__image_set"], "png")
+        self.assertTrue(any(n.type == "pngdec" for n in result.nodes))
+
+    @patch("graph.ImagesManager")
+    def test_bmp_uses_avdec_bmp(self, mock_cls):
+        image_set, location = _make_image_set_mock("b", "bmp", 3, 1)
+        instance = MagicMock()
+        instance.get_image_set.return_value = image_set
+        instance.get_location_pattern.return_value = location
+        mock_cls.return_value = instance
+
+        result = Graph.apply_simple_view_changes(
+            modified_simple=self._make_simple(InputKind.IMAGE_SET, "b"),
+            original_simple=self._make_simple(InputKind.FILE, "x.mp4"),
+            original_advanced=self._make_advanced_with_filesrc(),
+        )
+        self.assertTrue(any(n.type == "avdec_bmp" for n in result.nodes))
+        src = next(n for n in result.nodes if n.id == "0")
+        self.assertTrue(src.data["caps"].startswith("image/bmp"))
+
+    @patch("graph.ImagesManager")
+    def test_tif_uses_avdec_tiff(self, mock_cls):
+        image_set, location = _make_image_set_mock("t", "tif", 3, 1)
+        instance = MagicMock()
+        instance.get_image_set.return_value = image_set
+        instance.get_location_pattern.return_value = location
+        mock_cls.return_value = instance
+
+        result = Graph.apply_simple_view_changes(
+            modified_simple=self._make_simple(InputKind.IMAGE_SET, "t"),
+            original_simple=self._make_simple(InputKind.FILE, "x.mp4"),
+            original_advanced=self._make_advanced_with_filesrc(),
+        )
+        self.assertTrue(any(n.type == "avdec_tiff" for n in result.nodes))
+        src = next(n for n in result.nodes if n.id == "0")
+        self.assertTrue(src.data["caps"].startswith("image/tiff"))
+
+    @patch("graph.ImagesManager")
+    def test_unknown_image_set_raises(self, mock_cls):
+        instance = MagicMock()
+        instance.get_image_set.return_value = None
+        mock_cls.return_value = instance
+
+        with self.assertRaises(ValueError) as cm:
+            Graph.apply_simple_view_changes(
+                modified_simple=self._make_simple(InputKind.IMAGE_SET, "missing"),
+                original_simple=self._make_simple(InputKind.FILE, "x.mp4"),
+                original_advanced=self._make_advanced_with_filesrc(),
+            )
+        self.assertIn("Unknown image set", str(cm.exception))
+
+    @patch("graph.ImagesManager")
+    def test_missing_location_pattern_raises(self, mock_cls):
+        image_set, _ = _make_image_set_mock("dorota", "jpg", 40, 2)
+        instance = MagicMock()
+        instance.get_image_set.return_value = image_set
+        instance.get_location_pattern.return_value = None
+        mock_cls.return_value = instance
+
+        with self.assertRaises(ValueError) as cm:
+            Graph.apply_simple_view_changes(
+                modified_simple=self._make_simple(InputKind.IMAGE_SET, "dorota"),
+                original_simple=self._make_simple(InputKind.FILE, "x.mp4"),
+                original_advanced=self._make_advanced_with_filesrc(),
+            )
+        self.assertIn("location pattern", str(cm.exception))
+
+
+# --------------------------------------------------------------------------- #
+# Looping behaviour for image-set sources.
+# --------------------------------------------------------------------------- #
+
+
+class TestApplyLoopingImageSet(unittest.TestCase):
+    """
+    Image-set ``multifilesrc`` nodes only need ``loop=true``; the TS
+    dance and demuxer rewrites that apply to file sources must be
+    skipped. Marker flag presence (``__image_set``) is what selects
+    the lightweight branch.
+    """
+
+    def test_image_set_node_only_flips_loop_to_true(self):
+        graph = Graph(
+            nodes=[
+                Node(
+                    id="0",
+                    type="multifilesrc",
+                    data={
+                        "location": "/images/input/uploaded/x/x_%01d.jpg",
+                        "index": "1",
+                        "stop-index": "5",
+                        "loop": "false",
+                        "caps": "image/jpeg,framerate=30/1",
+                        "__image_set": "jpg",
+                    },
+                ),
+                Node(id="1", type="jpegdec", data={}),
+                Node(id="2", type="fakesink", data={}),
+            ],
+            edges=[
+                Edge(id="0", source="0", target="1"),
+                Edge(id="1", source="1", target="2"),
+            ],
+        )
+
+        # ``apply_looping_modifications`` instantiates VideosManager
+        # eagerly even though the image-set branch does not use it. We
+        # mock the class to keep the test independent of the videos
+        # filesystem layout.
+        with patch("graph.VideosManager"):
+            result = graph.apply_looping_modifications()
+
+        src = result.nodes[0]
+        self.assertEqual(src.type, "multifilesrc")
+        self.assertEqual(src.data["loop"], "true")
+        # Location pattern must stay intact - no TS conversion.
+        self.assertEqual(src.data["location"], "/images/input/uploaded/x/x_%01d.jpg")
+        self.assertEqual(src.data["stop-index"], "5")
+        # No TS demuxer was inserted - the decoder is preserved as-is.
+        self.assertEqual(result.nodes[1].type, "jpegdec")
+
+    def test_image_set_node_skips_ts_resolution(self):
+        """
+        For an image-set ``multifilesrc`` node, no per-node ``get_ts_path``
+        call is issued - the marker flag short-circuits the pass before
+        the TS dance kicks in. Other VideosManager methods may still be
+        touched at construction time, so we only assert the per-node
+        helpers are not invoked.
+        """
+        graph = Graph(
+            nodes=[
+                Node(
+                    id="0",
+                    type="multifilesrc",
+                    data={
+                        "location": "/images/input/uploaded/x/x_%01d.png",
+                        "index": "1",
+                        "stop-index": "3",
+                        "loop": "false",
+                        "caps": "image/png,framerate=30/1",
+                        "__image_set": "png",
+                    },
+                ),
+                Node(id="1", type="pngdec", data={}),
+                Node(id="2", type="fakesink", data={}),
+            ],
+            edges=[
+                Edge(id="0", source="0", target="1"),
+                Edge(id="1", source="1", target="2"),
+            ],
+        )
+
+        with patch("graph.VideosManager") as mock_videos_cls:
+            instance = MagicMock()
+            mock_videos_cls.return_value = instance
+            result = graph.apply_looping_modifications()
+
+        # The image-set branch must NOT consult per-node TS helpers.
+        instance.get_ts_path.assert_not_called()
+        instance.ensure_ts_file.assert_not_called()
+        self.assertEqual(result.nodes[0].data["loop"], "true")
+
+
+# --------------------------------------------------------------------------- #
+# determine_input_codec for image-set sources.
+# --------------------------------------------------------------------------- #
+
+
+class TestDetermineInputCodecImageSet(unittest.TestCase):
+    def _graph_with(self, ext: str) -> Graph:
+        return Graph(
+            nodes=[
+                Node(
+                    id="0",
+                    type="multifilesrc",
+                    data={
+                        "location": f"/images/input/uploaded/x/x_%01d.{ext}",
+                        "index": "1",
+                        "stop-index": "1",
+                        "loop": "false",
+                        "caps": f"image/{ext},framerate=30/1",
+                        "__image_set": ext,
+                    },
+                ),
+                Node(id="1", type="fakesink", data={}),
+            ],
+            edges=[Edge(id="0", source="0", target="1")],
+        )
+
+    def test_jpg(self):
+        self.assertEqual(self._graph_with("jpg").determine_input_codec(), "jpg")
+
+    def test_png(self):
+        self.assertEqual(self._graph_with("png").determine_input_codec(), "png")
+
+    def test_empty_marker_returns_none(self):
+        graph = Graph(
+            nodes=[
+                Node(
+                    id="0",
+                    type="multifilesrc",
+                    data={
+                        "location": "/foo/bar_%01d.jpg",
+                        "__image_set": "",
+                    },
+                ),
+                Node(id="1", type="fakesink", data={}),
+            ],
+            edges=[Edge(id="0", source="0", target="1")],
+        )
+        self.assertIsNone(graph.determine_input_codec())
+
+
+# --------------------------------------------------------------------------- #
+# _input_video_name_to_path: absolute paths bypass.
+# --------------------------------------------------------------------------- #
+
+
+class TestInputVideoNameToPathAbsoluteBypass(unittest.TestCase):
+    """
+    Image-set ``multifilesrc`` nodes carry an absolute location pattern
+    (``/images/input/uploaded/.../x_%02d.jpg``) that must be passed to
+    GStreamer untouched. The video-name → path mapping has to detect
+    absolute paths and skip them; any other behaviour breaks the
+    image-set pipeline.
+    """
+
+    @patch("graph.VideosManager")
+    def test_absolute_location_is_left_untouched(self, mock_videos_cls):
+        from graph import _input_video_name_to_path
+
+        nodes = [
+            Node(
+                id="0",
+                type="multifilesrc",
+                data={"location": "/images/input/uploaded/dorota/dorota_%02d.jpg"},
+            )
+        ]
+        _input_video_name_to_path(nodes)
+
+        # The mapping must not be invoked for absolute paths.
+        mock_videos_cls.assert_not_called()
+        self.assertEqual(
+            nodes[0].data["location"],
+            "/images/input/uploaded/dorota/dorota_%02d.jpg",
+        )
+
+    @patch("graph.VideosManager")
+    def test_relative_filename_still_resolved_through_videos_manager(
+        self, mock_videos_cls
+    ):
+        from graph import _input_video_name_to_path
+
+        instance = MagicMock()
+        instance.get_video_path.return_value = "/videos/input/uploaded/foo.mp4"
+        mock_videos_cls.return_value = instance
+
+        nodes = [Node(id="0", type="filesrc", data={"location": "foo.mp4"})]
+        _input_video_name_to_path(nodes)
+
+        instance.get_video_path.assert_called_once_with("foo.mp4")
+        self.assertEqual(nodes[0].data["location"], "/videos/input/uploaded/foo.mp4")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/images_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/images_test.py
@@ -1,0 +1,599 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for ``vippet.images``.
+
+The tests exercise the full upload pipeline (validation + extraction +
+rename + sidecar) against real archives written to a per-test temporary
+directory, so the assertions also cover the on-disk layout and the
+``set.json`` schema. Where possible the tests avoid mocking cv2 so the
+resolution check is verified end-to-end.
+"""
+
+import io
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+import threading
+import unittest
+import zipfile
+from unittest.mock import patch
+
+import cv2
+import numpy as np
+
+import images as images_mod
+from images import (
+    ARCHIVE_EXTENSIONS,
+    IMAGE_EXTENSIONS,
+    ImageSet,
+    ImageUploadError,
+    ImagesManager,
+    sanitise_trunk,
+)
+
+
+def _png_bytes(width: int = 16, height: int = 16, color: int = 200) -> bytes:
+    """Return a valid PNG byte stream of the requested dimensions."""
+    arr = np.full((height, width, 3), color, dtype=np.uint8)
+    ok, buf = cv2.imencode(".png", arr)
+    assert ok, "cv2.imencode failed in test fixture"
+    return buf.tobytes()
+
+
+def _jpg_bytes(width: int = 16, height: int = 16, color: int = 200) -> bytes:
+    arr = np.full((height, width, 3), color, dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", arr)
+    assert ok, "cv2.imencode failed in test fixture"
+    return buf.tobytes()
+
+
+def _bmp_bytes(width: int = 16, height: int = 16, color: int = 200) -> bytes:
+    arr = np.full((height, width, 3), color, dtype=np.uint8)
+    ok, buf = cv2.imencode(".bmp", arr)
+    assert ok
+    return buf.tobytes()
+
+
+def _make_zip(entries: dict[str, bytes]) -> bytes:
+    """Build a flat or nested zip from a {arcname: payload} mapping."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for arcname, payload in entries.items():
+            zf.writestr(arcname, payload)
+    return buf.getvalue()
+
+
+def _make_tar(entries: dict[str, bytes], gz: bool = False) -> bytes:
+    buf = io.BytesIO()
+    mode = "w:gz" if gz else "w"
+    with tarfile.open(fileobj=buf, mode=mode) as tf:
+        for arcname, payload in entries.items():
+            info = tarfile.TarInfo(name=arcname)
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+def _write_archive(tmpdir: str, name: str, content: bytes) -> str:
+    path = os.path.join(tmpdir, name)
+    with open(path, "wb") as fh:
+        fh.write(content)
+    return path
+
+
+class _BaseImagesTest(unittest.TestCase):
+    """
+    Base class that gives every test its own UPLOADED_IMAGES_DIR and
+    resets the singleton so cross-test state does not leak.
+    """
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp(prefix="vippet-images-test-")
+        self.uploads_dir = os.path.join(self.tmpdir, "uploads")
+        os.makedirs(self.uploads_dir, exist_ok=True)
+
+        # Reset the singleton so each test gets a fresh manager bound
+        # to its own uploads directory.
+        ImagesManager._instance = None
+
+        self._patch = patch.object(images_mod, "UPLOADED_IMAGES_DIR", self.uploads_dir)
+        self._patch.start()
+        # Re-create root via the manager constructor.
+        self.manager = ImagesManager()
+
+    def tearDown(self) -> None:
+        self._patch.stop()
+        ImagesManager._instance = None
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers / pure functions.
+# --------------------------------------------------------------------------- #
+
+
+class TestSanitiseTrunk(unittest.TestCase):
+    def test_keeps_alnum(self) -> None:
+        self.assertEqual(sanitise_trunk("Cats_2024-01"), "cats_2024-01")
+
+    def test_collapses_runs_of_invalid(self) -> None:
+        self.assertEqual(sanitise_trunk("hello   world!!!"), "hello_world")
+
+    def test_strips_edge_underscores(self) -> None:
+        self.assertEqual(sanitise_trunk("___abc___"), "abc")
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(sanitise_trunk(""))
+
+    def test_only_invalid_returns_none(self) -> None:
+        self.assertIsNone(sanitise_trunk("!!!"))
+
+    def test_dot_returns_none(self) -> None:
+        self.assertIsNone(sanitise_trunk("."))
+
+
+class TestDeriveTrunk(unittest.TestCase):
+    def test_zip(self) -> None:
+        self.assertEqual(ImagesManager.derive_trunk("dorota.zip"), "dorota")
+
+    def test_tar_gz(self) -> None:
+        self.assertEqual(ImagesManager.derive_trunk("Dataset.tar.gz"), "dataset")
+
+    def test_tgz(self) -> None:
+        self.assertEqual(ImagesManager.derive_trunk("ds.tgz"), "ds")
+
+    def test_strips_path_components(self) -> None:
+        # Defends against client-supplied paths.
+        self.assertEqual(ImagesManager.derive_trunk("/etc/passwd/foo.zip"), "foo")
+
+    def test_unsupported_extension(self) -> None:
+        self.assertIsNone(ImagesManager.derive_trunk("foo.7z"))
+
+    def test_no_extension(self) -> None:
+        self.assertIsNone(ImagesManager.derive_trunk("foo"))
+
+    def test_empty(self) -> None:
+        self.assertIsNone(ImagesManager.derive_trunk(""))
+
+    def test_sanitisation_collapses_to_empty(self) -> None:
+        # ``!!!.zip`` strips to ``!!!`` then sanitises to empty.
+        self.assertIsNone(ImagesManager.derive_trunk("!!!.zip"))
+
+
+# --------------------------------------------------------------------------- #
+# Singleton behaviour.
+# --------------------------------------------------------------------------- #
+
+
+class TestSingleton(_BaseImagesTest):
+    def test_returns_same_instance(self) -> None:
+        a = ImagesManager()
+        b = ImagesManager()
+        self.assertIs(a, b)
+
+    def test_concurrent_construction_returns_same_instance(self) -> None:
+        ImagesManager._instance = None
+        results: list[ImagesManager] = []
+
+        def worker() -> None:
+            results.append(ImagesManager())
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        first = results[0]
+        for inst in results[1:]:
+            self.assertIs(inst, first)
+
+
+# --------------------------------------------------------------------------- #
+# Discovery / lookup.
+# --------------------------------------------------------------------------- #
+
+
+class TestDiscovery(_BaseImagesTest):
+    def _make_set_dir(
+        self,
+        name: str,
+        *,
+        write_set_json: bool = True,
+        image_count: int = 2,
+        extension: str = "png",
+    ) -> str:
+        set_dir = os.path.join(self.uploads_dir, name)
+        os.makedirs(set_dir, exist_ok=True)
+        for i in range(1, image_count + 1):
+            with open(os.path.join(set_dir, f"{name}_{i:03d}.{extension}"), "wb") as fh:
+                fh.write(_png_bytes())
+        if write_set_json:
+            payload = {
+                "name": name,
+                "source_archive": f"{name}.zip",
+                "image_count": image_count,
+                "extension": extension,
+                "width": 16,
+                "height": 16,
+                "uploaded_at": "2026-04-28T00:00:00Z",
+            }
+            with open(os.path.join(set_dir, "set.json"), "w") as fh:
+                json.dump(payload, fh)
+        return set_dir
+
+    def test_get_all_image_sets_empty(self) -> None:
+        self.assertEqual(self.manager.get_all_image_sets(), {})
+
+    def test_get_all_image_sets_returns_only_sets_with_set_json(self) -> None:
+        self._make_set_dir("alpha")
+        self._make_set_dir("beta", write_set_json=False)
+        result = self.manager.get_all_image_sets()
+        self.assertIn("alpha", result)
+        self.assertNotIn("beta", result)
+
+    def test_get_all_image_sets_skips_staging_dirs(self) -> None:
+        os.makedirs(os.path.join(self.uploads_dir, ".staging-foo"))
+        self.assertEqual(self.manager.get_all_image_sets(), {})
+
+    def test_image_set_exists(self) -> None:
+        self._make_set_dir("alpha")
+        self.assertTrue(self.manager.image_set_exists("alpha"))
+        self.assertFalse(self.manager.image_set_exists("missing"))
+
+    def test_image_set_exists_rejects_traversal(self) -> None:
+        self.assertFalse(self.manager.image_set_exists("../etc"))
+        self.assertFalse(self.manager.image_set_exists(""))
+        self.assertFalse(self.manager.image_set_exists("."))
+        self.assertFalse(self.manager.image_set_exists("a/b"))
+
+    def test_get_image_set_returns_none_for_missing(self) -> None:
+        self.assertIsNone(self.manager.get_image_set("nope"))
+
+    def test_get_image_set_overrides_name_with_dir(self) -> None:
+        # Persist a set.json whose ``name`` field disagrees with the
+        # directory name; the directory wins.
+        set_dir = self._make_set_dir("alpha")
+        with open(os.path.join(set_dir, "set.json"), "r") as fh:
+            data = json.load(fh)
+        data["name"] = "tampered"
+        with open(os.path.join(set_dir, "set.json"), "w") as fh:
+            json.dump(data, fh)
+        result = self.manager.get_image_set("alpha")
+        assert result is not None
+        self.assertEqual(result.name, "alpha")
+
+    def test_get_image_set_handles_corrupted_set_json(self) -> None:
+        set_dir = self._make_set_dir("alpha")
+        with open(os.path.join(set_dir, "set.json"), "w") as fh:
+            fh.write("{not json")
+        self.assertIsNone(self.manager.get_image_set("alpha"))
+
+    def test_get_image_set_handles_non_object_set_json(self) -> None:
+        set_dir = self._make_set_dir("alpha")
+        with open(os.path.join(set_dir, "set.json"), "w") as fh:
+            json.dump([1, 2, 3], fh)
+        self.assertIsNone(self.manager.get_image_set("alpha"))
+
+    def test_get_images_in_set_excludes_set_json(self) -> None:
+        self._make_set_dir("alpha", image_count=3)
+        infos = self.manager.get_images_in_set("alpha")
+        assert infos is not None
+        names = [i.filename for i in infos]
+        self.assertEqual(len(infos), 3)
+        self.assertNotIn("set.json", names)
+        # All entries share the canonical extension and metadata.
+        for info in infos:
+            self.assertEqual(info.extension, "png")
+            self.assertEqual(info.width, 16)
+            self.assertEqual(info.height, 16)
+            self.assertGreater(info.size_bytes, 0)
+
+    def test_get_images_in_set_returns_none_for_missing(self) -> None:
+        self.assertIsNone(self.manager.get_images_in_set("nope"))
+
+    def test_get_location_pattern(self) -> None:
+        self._make_set_dir("dorota", image_count=40)
+        pattern = self.manager.get_location_pattern("dorota")
+        self.assertEqual(
+            pattern,
+            os.path.join(self.uploads_dir, "dorota", "dorota_%02d.png"),
+        )
+
+    def test_get_location_pattern_widths(self) -> None:
+        self._make_set_dir("a", image_count=9)
+        self._make_set_dir("b", image_count=10)
+        self._make_set_dir("c", image_count=1000)
+        pat_a = self.manager.get_location_pattern("a")
+        pat_b = self.manager.get_location_pattern("b")
+        pat_c = self.manager.get_location_pattern("c")
+        assert pat_a is not None and pat_b is not None and pat_c is not None
+        self.assertTrue(pat_a.endswith("a_%01d.png"))
+        self.assertTrue(pat_b.endswith("b_%02d.png"))
+        self.assertTrue(pat_c.endswith("c_%04d.png"))
+
+    def test_get_location_pattern_missing(self) -> None:
+        self.assertIsNone(self.manager.get_location_pattern("nope"))
+
+
+# --------------------------------------------------------------------------- #
+# Upload pipeline: register_uploaded_archive.
+# --------------------------------------------------------------------------- #
+
+
+class TestRegisterUploadedArchive(_BaseImagesTest):
+    @staticmethod
+    def _temp_name_for(original: str) -> str:
+        """
+        Pick a temp filename whose extension matches the original so
+        ``_safe_extract`` dispatches to the right archive handler.
+        """
+        lower = original.lower()
+        if lower.endswith(".zip"):
+            return "incoming.zip"
+        if lower.endswith(".tar.gz") or lower.endswith(".tgz"):
+            return "incoming.tar.gz"
+        if lower.endswith(".tar"):
+            return "incoming.tar"
+        return "incoming.bin"
+
+    def _register(self, archive_bytes: bytes, original_name: str) -> ImageSet:
+        path = _write_archive(
+            self.tmpdir, self._temp_name_for(original_name), archive_bytes
+        )
+        return self.manager.register_uploaded_archive(path, original_name)
+
+    def _expect_error(
+        self, archive_bytes: bytes, original_name: str, expected_kind: str
+    ) -> ImageUploadError:
+        path = _write_archive(
+            self.tmpdir, self._temp_name_for(original_name), archive_bytes
+        )
+        with self.assertRaises(ImageUploadError) as cm:
+            self.manager.register_uploaded_archive(path, original_name)
+        self.assertEqual(cm.exception.kind, expected_kind)
+        return cm.exception
+
+    # ---- success ---------------------------------------------------------
+
+    def test_zip_with_pngs_succeeds(self) -> None:
+        entries = {
+            "frame_b.png": _png_bytes(width=32, height=24),
+            "frame_a.png": _png_bytes(width=32, height=24),
+        }
+        result = self._register(_make_zip(entries), "Cats Set.zip")
+
+        self.assertEqual(result.name, "cats_set")
+        self.assertEqual(result.source_archive, "Cats Set.zip")
+        self.assertEqual(result.image_count, 2)
+        self.assertEqual(result.extension, "png")
+        self.assertEqual(result.width, 32)
+        self.assertEqual(result.height, 24)
+        self.assertTrue(result.uploaded_at.endswith("Z"))
+
+        # On-disk layout matches the renamed pattern.
+        set_dir = os.path.join(self.uploads_dir, "cats_set")
+        files = sorted(os.listdir(set_dir))
+        self.assertIn("set.json", files)
+        # Width is len(str(2)) == 1.
+        self.assertIn("cats_set_1.png", files)
+        self.assertIn("cats_set_2.png", files)
+
+        # set.json round-trips through ImageSet.from_dict.
+        with open(os.path.join(set_dir, "set.json")) as fh:
+            sidecar = json.load(fh)
+        self.assertEqual(sidecar["image_count"], 2)
+        self.assertEqual(sidecar["extension"], "png")
+
+    def test_jpeg_normalised_to_jpg(self) -> None:
+        entries = {
+            "a.JPEG": _jpg_bytes(),
+            "b.jpg": _jpg_bytes(),
+            "c.jpeg": _jpg_bytes(),
+        }
+        result = self._register(_make_zip(entries), "mixed_case.zip")
+        self.assertEqual(result.extension, "jpg")
+        files = os.listdir(os.path.join(self.uploads_dir, "mixed_case"))
+        for f in files:
+            if f != "set.json":
+                self.assertTrue(f.endswith(".jpg"))
+
+    def test_tiff_normalised_to_tif(self) -> None:
+        entries = {
+            "a.tif": _png_bytes(),  # cv2 imencode for tif requires libtiff; reuse png bytes via avdec irrelevant
+        }
+        # Build real tiff bytes through cv2.imencode.
+        arr = np.full((8, 8, 3), 100, dtype=np.uint8)
+        ok, buf = cv2.imencode(".tif", arr)
+        if not ok:
+            self.skipTest("cv2 build lacks TIFF support")
+        tif_payload = buf.tobytes()
+        entries = {"a.tiff": tif_payload, "b.tif": tif_payload}
+        result = self._register(_make_zip(entries), "tdata.zip")
+        self.assertEqual(result.extension, "tif")
+
+    def test_zip_with_tar_gz_archive(self) -> None:
+        entries = {
+            "img1.png": _png_bytes(),
+            "img2.png": _png_bytes(),
+        }
+        result = self._register(_make_tar(entries, gz=True), "set.tar.gz")
+        self.assertEqual(result.image_count, 2)
+        self.assertEqual(result.extension, "png")
+
+    def test_renamed_files_zero_padded_by_count(self) -> None:
+        entries = {f"img{i:02d}.png": _png_bytes() for i in range(1, 13)}
+        result = self._register(_make_zip(entries), "twelve.zip")
+        files = sorted(
+            f
+            for f in os.listdir(os.path.join(self.uploads_dir, "twelve"))
+            if f != "set.json"
+        )
+        # 12 files -> width = 2.
+        self.assertEqual(files[0], "twelve_01.png")
+        self.assertEqual(files[-1], "twelve_12.png")
+        self.assertEqual(result.image_count, 12)
+
+    # ---- error paths -----------------------------------------------------
+
+    def test_invalid_archive_name(self) -> None:
+        # Trunk sanitises to empty -> invalid_archive_name.
+        self._expect_error(
+            _make_zip({"a.png": _png_bytes()}), "!!!.zip", "invalid_archive_name"
+        )
+
+    def test_unsupported_archive_format_handled_at_filename_level(self) -> None:
+        # Manager-level entry point: derive_trunk returns None.
+        self._expect_error(b"junk", "foo.7z", "invalid_archive_name")
+
+    def test_archive_corrupted(self) -> None:
+        self._expect_error(b"not a real zip", "x.zip", "archive_corrupted")
+
+    def test_archive_contains_subdirectories(self) -> None:
+        entries = {
+            "sub/a.png": _png_bytes(),
+            "sub/b.png": _png_bytes(),
+        }
+        self._expect_error(
+            _make_zip(entries), "nested.zip", "archive_contains_subdirectories"
+        )
+
+    def test_archive_contains_no_images(self) -> None:
+        # Empty zip archive (no entries at all): extraction succeeds,
+        # leaving the staging dir empty, which trips the no-images guard.
+        empty_zip = _make_zip({})
+        self._expect_error(empty_zip, "empty.zip", "archive_contains_no_images")
+
+    def test_archive_disallowed_image_extension(self) -> None:
+        entries = {"a.txt": b"hi"}
+        self._expect_error(
+            _make_zip(entries), "txt.zip", "archive_disallowed_image_extension"
+        )
+
+    def test_archive_mixed_image_extensions(self) -> None:
+        entries = {
+            "a.png": _png_bytes(),
+            "b.jpg": _jpg_bytes(),
+        }
+        exc = self._expect_error(
+            _make_zip(entries), "mixed.zip", "archive_mixed_image_extensions"
+        )
+        # Sorted families exposed for the API layer.
+        assert isinstance(exc.found, list)
+        self.assertEqual(sorted(exc.found), ["jpg", "png"])
+
+    def test_archive_mixed_image_resolutions(self) -> None:
+        entries = {
+            "a.png": _png_bytes(width=16, height=16),
+            "b.png": _png_bytes(width=32, height=16),
+        }
+        self._expect_error(
+            _make_zip(entries), "mixed.zip", "archive_mixed_image_resolutions"
+        )
+
+    def test_image_set_already_exists_pre_check(self) -> None:
+        os.makedirs(os.path.join(self.uploads_dir, "dup"), exist_ok=False)
+        entries = {"a.png": _png_bytes()}
+        self._expect_error(_make_zip(entries), "dup.zip", "image_set_already_exists")
+
+    def test_archive_uncompressed_too_large(self) -> None:
+        # Force the cap down to 100 bytes total uncompressed.
+        with patch.dict(os.environ, {"UPLOAD_MAX_SIZE_BYTES": "10"}):
+            # 10 * 10 = 100 bytes uncompressed allowed.
+            entries = {
+                "a.png": _png_bytes(),  # PNGs are ~70-90 bytes for 16x16 solid.
+                "b.png": _png_bytes(),
+            }
+            self._expect_error(
+                _make_zip(entries), "big.zip", "archive_uncompressed_too_large"
+            )
+
+    def test_unsafe_archive_path_via_traversal(self) -> None:
+        # Build a zip with a path-traversal entry by hand.
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("../escape.png", _png_bytes())
+        # Either subdirectories or unsafe_archive_path is acceptable -
+        # the slash in the name trips ``_check_member_layout`` first.
+        with self.assertRaises(ImageUploadError) as cm:
+            path = _write_archive(self.tmpdir, "evil.zip", buf.getvalue())
+            self.manager.register_uploaded_archive(path, "evil.zip")
+        self.assertIn(
+            cm.exception.kind,
+            ("archive_contains_subdirectories", "unsafe_archive_path"),
+        )
+
+    def test_tar_with_symlink_rejected(self) -> None:
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tf:
+            info = tarfile.TarInfo("link.png")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "/etc/passwd"
+            tf.addfile(info)
+        path = _write_archive(self.tmpdir, "evil.tar", buf.getvalue())
+        with self.assertRaises(ImageUploadError) as cm:
+            self.manager.register_uploaded_archive(path, "evil.tar")
+        self.assertEqual(cm.exception.kind, "unsafe_archive_path")
+
+    # ---- staging cleanup -------------------------------------------------
+
+    def test_failure_cleans_up_staging(self) -> None:
+        entries = {"a.txt": b"nope"}
+        with self.assertRaises(ImageUploadError):
+            self._register(_make_zip(entries), "fail.zip")
+        # No leftover .staging-* directories.
+        leftovers = [
+            e for e in os.listdir(self.uploads_dir) if e.startswith(".staging-")
+        ]
+        self.assertEqual(leftovers, [])
+
+    def test_success_cleans_up_staging(self) -> None:
+        entries = {"a.png": _png_bytes(), "b.png": _png_bytes()}
+        self._register(_make_zip(entries), "ok.zip")
+        leftovers = [
+            e for e in os.listdir(self.uploads_dir) if e.startswith(".staging-")
+        ]
+        self.assertEqual(leftovers, [])
+
+    # ---- integration with discovery -------------------------------------
+
+    def test_uploaded_set_is_discoverable(self) -> None:
+        entries = {"a.png": _png_bytes(), "b.png": _png_bytes()}
+        self._register(_make_zip(entries), "discover.zip")
+        sets = self.manager.get_all_image_sets()
+        self.assertIn("discover", sets)
+        self.assertEqual(sets["discover"].image_count, 2)
+
+        pattern = self.manager.get_location_pattern("discover")
+        assert pattern is not None
+        self.assertTrue(pattern.endswith("discover_%01d.png"))
+
+
+class TestImageSetSchema(unittest.TestCase):
+    def test_archive_extensions_constant(self) -> None:
+        self.assertEqual(set(ARCHIVE_EXTENSIONS), {"zip", "tar", "tar.gz", "tgz"})
+
+    def test_image_extensions_constant(self) -> None:
+        # webp removed; tiff and jpeg accepted as aliases.
+        self.assertEqual(
+            set(IMAGE_EXTENSIONS),
+            {"jpg", "jpeg", "png", "bmp", "tif", "tiff"},
+        )
+
+    def test_image_set_round_trip(self) -> None:
+        original = ImageSet(
+            name="x",
+            source_archive="x.zip",
+            image_count=3,
+            extension="png",
+            width=10,
+            height=20,
+            uploaded_at="2026-01-01T00:00:00Z",
+        )
+        revived = ImageSet.from_dict(original.to_dict())
+        self.assertEqual(revived, original)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Lets uploaded image sets be used as an input source in pipeline graphs, and rewrites the image-set upload flow to be safer and more predictable. Existing behavior (listing sets, listing images, the upload endpoint) is preserved at the API surface; the internals and the failure modes change.

## What changes

### Image sets as a pipeline source

- New `image_set` source kind in the pipeline graph. A simple `source` node with `kind=image_set` is expanded into a `multifilesrc` (with the resolved location pattern, `index`, `stop-index`, caps, and framerate) plus a matching software decoder (`jpegdec`, `pngdec`, `avdec_bmp`, `avdec_tiff`). All edges that previously left the source are rewired through the decoder.
- An internal marker on the rewritten `multifilesrc` lets: the looping pass flip `loop` on/off according to `ExecutionConfig` (`output_mode` + `max_runtime`) instead of leaving it pinned to `true`, codec detection report the image extension as the input codec.
- The video-name → path mapper now leaves absolute paths untouched, so the image-set `multifilesrc` location reaches GStreamer as-is (this fixes the `can't map '...' to video path` error that previously blocked image-set runs).

### Hardened image-set upload

- Stricter validation with a structured 422 envelope (`detail`, `error`, `found`, `allowed`) and an explicit `ImageUploadErrorKind` enum covering: missing filename, unsupported archive format, invalid archive name, archive too large, archive corrupted, contains subdirectories, contains no images, mixed image extensions, disallowed image extension, mixed image resolutions, uncompressed too large, image set already exists, unsafe archive path.
- Streaming upload with mid-stream size enforcement against `UPLOAD_MAX_SIZE_BYTES`.
- Per-archive zip-bomb guard (uncompressed total capped at the upload limit × 10).
- Tar safety: symlinks, hardlinks, devices and other non-regular entries are rejected as `unsafe_archive_path`; zip path-traversal entries are rejected before extraction.
- Extraction goes through a hidden staging directory and only the finished, validated set is moved into place; the staging dir is always cleaned up, on success and on failure.
- Image extensions are normalized to a single canonical family per set (`jpeg`/`JPG` → `jpg`, `tiff` → `tif`); a set must contain exactly one extension family and exactly one resolution.
- Files are renamed to a zero-padded `<name>_<NNNN>.<ext>` pattern whose width matches the image count, and a `set.json` sidecar is written with the canonical metadata.
- Image-set names are derived from a sanitized archive trunk; bad names (empty, traversal, dot, only special chars) are rejected early with `invalid_archive_name`.
- The `ImageSet` response schema now exposes the full metadata: `source_archive`, `extension`, `width`, `height`, `uploaded_at` (in addition to the previous `name` and `image_count`).

### Configuration / wiring

- New env var `UPLOADED_IMAGES_DIR` (default `/images/input/uploaded`) replaces the previous `INPUT_IMAGES_DIR` / `OUTPUT_IMAGES_DIR` pair in `compose.yml`. Documented in `AGENTS.md`.
- `ImagesManager` is initialized at app startup so the upload directory exists before the first request.
- The UI image-asset path is moved under `assets/images/input/uploaded/...` and the nginx allow-list is updated accordingly. `webp` is dropped from the served image types to match the upload allow-list.
- `pyrightconfig.json`: ignore the whole `shared/` tree.

## Notes

- API routes are unchanged: `GET /images`, `GET /images/{name}`, `GET /images/check-image-set-exists`, `POST /images/upload`. The response shape for `ImageSet` gains fields but stays backward-compatible at the field level.
- Video uploads and existing video-source behavior are untouched.