### PR TITLE
[ViPPET] Rename metrics-service to metrics-manager across codebase

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/AGENTS.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/AGENTS.md
@@ -121,7 +121,7 @@ make format      # Auto-format with ruff
 - **Backend API**: `http://localhost:7860/api/v1/` (FastAPI, auto-documented at `/docs`)
 - **UI**: `http://localhost:80`
 - **RTSP live streams**: `rtsp://localhost:8554/{stream_name}` (via mediamtx)
-- **SSE metrics stream**: `http://localhost/metrics/stream` (proxied by nginx to metrics-service)
+- **SSE metrics stream**: `http://localhost/metrics/stream` (proxied by nginx to metrics-manager)
 
 The OpenAPI schema can be regenerated with:
 
@@ -137,7 +137,7 @@ make generate_openapi
 | `vippet-ui`       | Frontend (Nginx)                          | 80   |
 | `mediamtx`        | RTSP server                               | 8554 |
 | `models`          | Model installer (profile: `do-not-start`) | -    |
-| `metrics-service` | Metrics collector                         | 9090 |
+| `metrics-manager` | Metrics collector                         | 9090 |
 
 Hardware profiles (`COMPOSE_PROFILES`): `cpu`, `gpu`, `npu` — set automatically by `setup_env.sh`.
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
@@ -6,7 +6,7 @@ SHELL := bash -eu -o pipefail
 # default goal to show help
 .DEFAULT_GOAL := help
 .PHONY: all lint build mdlint ruff fix-linter format pyright run build-dev run-dev test \
-	shell shell-vippet shell-models shell-model-download shell-metrics-service shell-videogenerator stop clean clean-output-videos help \
+	shell shell-vippet shell-models shell-model-download shell-metrics-manager shell-videogenerator stop clean clean-output-videos help \
 	build-videogenerator build-models build-onvif-discovery docker-build env-setup \
 	install-models-once install-models-force install-models-all \
 	test-smoke test-full
@@ -147,14 +147,14 @@ shell-models: ## Open shell in models container
 shell-model-download: ## Open shell in model-download container
 	$(MAKE) shell SERVICE=model-download
 
-shell-metrics-service: ## Open shell in metrics-service container
-	$(MAKE) shell SERVICE=metrics-service
+shell-metrics-manager: ## Open shell in metrics-manager container
+	$(MAKE) shell SERVICE=metrics-manager
 
 shell-videogenerator: ## Open shell in videogenerator container
 	$(MAKE) shell SERVICE=videogenerator
 
 stop: ## Stop the docker compose services
-	docker compose down models model-download metrics-service videogenerator mediamtx vippet-ui vippet onvif-discovery
+	docker compose down models model-download metrics-manager videogenerator mediamtx vippet-ui vippet onvif-discovery
 
 clean: ## Clean all build artifacts
 	rm -rf shared/models/output/ shared/model-download/ shared/onvif/onvif_cameras.json shared/videos/input shared/videos/output shared/videos/video-generator

--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -50,10 +50,10 @@ x-vippet: &vippet
     LIVE_STREAM_SERVER_HOST: ${LIVE_STREAM_SERVER_HOST:-mediamtx}
     LIVE_STREAM_SERVER_PORT: ${LIVE_STREAM_SERVER_PORT:-8554}
     RTSPSRC_DEFAULT_LATENCY_MS: ${RTSPSRC_DEFAULT_LATENCY_MS:-100}
-    METRICS_SERVICE_URL: ${METRICS_SERVICE_URL:-http://metrics-service:9090}
+    METRICS_MANAGER_URL: ${METRICS_MANAGER_URL:-http://metrics-manager:9090}
     http_proxy: ${http_proxy}
     https_proxy: ${https_proxy}
-    no_proxy: "${no_proxy:+${no_proxy},}mediamtx,metrics-service"
+    no_proxy: "${no_proxy:+${no_proxy},}mediamtx,metrics-manager"
   device_cgroup_rules:
     # Broad access to USB devices is required to support a wide range of USB cameras.
     - 'c 189:* rmw'
@@ -84,12 +84,12 @@ services:
     depends_on:
       vippet:
         condition: service_healthy
-      metrics-service:
+      metrics-manager:
         condition: service_healthy
     environment:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
-      no_proxy: "${no_proxy:+${no_proxy},}mediamtx,metrics-service"
+      no_proxy: "${no_proxy:+${no_proxy},}mediamtx,metrics-manager"
     volumes:
       - ./shared/images/:/images
       - ./shared/videos/:/videos
@@ -153,9 +153,9 @@ services:
     container_name: vippet
     ports:
       - "7860:7860"
-  metrics-service:
-    image: docker.io/intel/metrics-service:2026.1.0-20260506-weekly.1
-    container_name: metrics-service
+  metrics-manager:
+    image: docker.io/intel/metrics-manager:2026.1.0-20260507-weekly
+    container_name: metrics-manager
     ports:
       - "9090:9090"
       - "9273:9273"

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/nginx.conf
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/nginx.conf
@@ -45,9 +45,9 @@ server {
         client_max_body_size 5G;
     }
 
-    # SSE proxy for metrics stream (served by metrics-service)
+    # SSE proxy for metrics stream (served by metrics-manager)
     location /metrics/stream {
-        proxy_pass http://metrics-service:9090/metrics/stream;
+        proxy_pass http://metrics-manager:9090/metrics/stream;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header Host $host;

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/benchmark.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/benchmark.py
@@ -114,7 +114,7 @@ class Benchmark:
         # `enable_latency_metrics` is forwarded so that the GStreamer subprocess
         # is launched with the DLStreamer latency_tracer active when requested.
         # `job_id` is forwarded so FPS metrics pushed during each density
-        # iteration are tagged with the owning job's id in metrics-service.
+        # iteration are tagged with the owning job's id in metrics-manager.
         self.runner = PipelineRunner(
             mode="normal",
             max_runtime=max_runtime,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipeline_runner.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipeline_runner.py
@@ -144,8 +144,8 @@ class PipelineRunner:
     including timeout enforcement, output parsing, and error handling.
     """
 
-    # Default metrics-service URL for pushing FPS metrics
-    DEFAULT_METRICS_SERVICE_URL = "http://metrics-service:9090"
+    # Default metrics-manager URL for pushing FPS metrics
+    DEFAULT_METRICS_MANAGER_URL = "http://metrics-manager:9090"
 
     # ------------------------------------------------------------------
     # Shared worker pool for fire-and-forget metric pushes.
@@ -167,7 +167,7 @@ class PipelineRunner:
     # Shared at the class level (not per-instance) on purpose: many
     # runners may exist in the same process (density `Benchmark`
     # reuses one, the validation path creates one per job, etc.) and
-    # metrics-service traffic is I/O-bound, so one pool is enough to
+    # metrics-manager traffic is I/O-bound, so one pool is enough to
     # absorb all of them and no coordination is needed across
     # instances. The executor is created lazily on first push so
     # importing this module stays side-effect free.
@@ -291,7 +291,7 @@ class PipelineRunner:
             job_id: Identifier of the owning job. When provided, every
                 metric pushed by this runner — both FPS and
                 ``pipeline_latency`` — carries a ``tags.job_id`` field
-                so metrics-service can partition data per job; this is
+                so metrics-manager can partition data per job; this is
                 how concurrent jobs are distinguished in the metrics
                 backend. When ``None`` (default), the ``job_id`` tag is
                 omitted from every payload (FPS pushes then carry no
@@ -308,7 +308,7 @@ class PipelineRunner:
         self.poll_interval = poll_interval
         self.inactivity_timeout = inactivity_timeout
         self.hard_timeout = hard_timeout
-        # Resolve the metrics-service base URL once and pre-compute the
+        # Resolve the metrics-manager base URL once and pre-compute the
         # two endpoint URLs used by the push helpers. Trailing slashes
         # on the configured base are stripped so concatenation with the
         # fixed paths cannot produce `//api/v1/...`, which some proxies
@@ -321,13 +321,13 @@ class PipelineRunner:
         #     {name, fields, tags} entries, used for latency pushes
         #     so all four tracer fields travel in one request per
         #     stream sample.
-        self.metrics_service_url = os.environ.get(
-            "METRICS_SERVICE_URL", self.DEFAULT_METRICS_SERVICE_URL
+        self.metrics_manager_url = os.environ.get(
+            "METRICS_MANAGER_URL", self.DEFAULT_METRICS_MANAGER_URL
         ).rstrip("/")
-        self._metrics_service_fps_url = (
-            f"{self.metrics_service_url}/api/v1/metrics/simple"
+        self._metrics_manager_fps_url = (
+            f"{self.metrics_manager_url}/api/v1/metrics/simple"
         )
-        self._metrics_service_batch_url = f"{self.metrics_service_url}/api/v1/metrics"
+        self._metrics_manager_batch_url = f"{self.metrics_manager_url}/api/v1/metrics"
         self.enable_latency_metrics = enable_latency_metrics
         self.job_id = job_id
         self.logger = logging.getLogger("PipelineRunner")
@@ -681,7 +681,7 @@ class PipelineRunner:
 
                             latest_fps = result["per_stream_fps"]
 
-                            # Push latest FPS to metrics-service
+                            # Push latest FPS to metrics-manager
                             self._push_fps_metric(latest_fps)
 
                         # ----------------------------------------------------------
@@ -932,11 +932,11 @@ class PipelineRunner:
             self.logger.error(f"Pipeline execution error: {e}")
             raise
         finally:
-            # Push 0.0 to metrics-service after pipeline completion (success or failure)
+            # Push 0.0 to metrics-manager after pipeline completion (success or failure)
             self._push_fps_metric(0.0)
             # Re-push the last observed latency sample per stream so
             # that at least one final pipeline_latency point per stream
-            # reaches metrics-service even if the last in-flight live
+            # reaches metrics-manager even if the last in-flight live
             # push raced with pipeline teardown. No-op when the tracer
             # was disabled or produced no samples.
             self._push_final_latency_metrics()
@@ -948,12 +948,12 @@ class PipelineRunner:
         description: str,
     ) -> None:
         """
-        Fire-and-forget HTTP POST to metrics-service.
+        Fire-and-forget HTTP POST to metrics-manager.
 
         Submits the POST to a shared class-level
         ``ThreadPoolExecutor`` (see ``_get_metrics_executor``) so the
         pipeline hot loop is never blocked by a slow or unavailable
-        metrics-service. The pool caps concurrency at
+        metrics-manager. The pool caps concurrency at
         ``_METRICS_EXECUTOR_WORKERS`` and reuses threads across
         pushes, which avoids the unbounded-thread-spawn pattern a
         per-push ``threading.Thread`` would create under load (many
@@ -1037,7 +1037,7 @@ class PipelineRunner:
 
     def _push_fps_metric(self, fps: float) -> None:
         """
-        Push the given FPS value to metrics-service.
+        Push the given FPS value to metrics-manager.
 
         Called:
         - During pipeline execution, every time a new average FPS line
@@ -1047,7 +1047,7 @@ class PipelineRunner:
 
         Uses the ``/api/v1/metrics/simple`` endpoint: one metric name
         and one scalar value per request. When ``self.job_id`` is set,
-        the payload carries ``tags.job_id`` so metrics-service can
+        the payload carries ``tags.job_id`` so metrics-manager can
         partition data per job; otherwise the ``tags`` field is omitted.
 
         Args:
@@ -1058,7 +1058,7 @@ class PipelineRunner:
             payload["tags"] = {"job_id": self.job_id}
 
         self._post_metrics_async(
-            url=self._metrics_service_fps_url,
+            url=self._metrics_manager_fps_url,
             payload=payload,
             description="fps",
         )
@@ -1067,7 +1067,7 @@ class PipelineRunner:
         self, stream_id: str, sample: "LatencyTracerSample"
     ) -> None:
         """
-        Push a single ``latency_tracer`` sample to metrics-service.
+        Push a single ``latency_tracer`` sample to metrics-manager.
 
         Called live from the stdout hot loop every time a new
         ``latency_tracer_pipeline_interval`` line is parsed for an
@@ -1084,7 +1084,7 @@ class PipelineRunner:
 
         Fields sent: ``avg_ms``, ``min_ms``, ``max_ms``, ``latency_ms``.
         ``interval_ms`` is intentionally omitted — the emission cadence
-        is fixed at 1000 ms and metrics-service timestamps each sample
+        is fixed at 1000 ms and metrics-manager timestamps each sample
         on receipt, so the field would only add noise. ``fps`` is also
         intentionally omitted because it is already reported by
         ``gvafpscounter`` via ``_push_fps_metric`` — re-sending it
@@ -1120,7 +1120,7 @@ class PipelineRunner:
         }
 
         self._post_metrics_async(
-            url=self._metrics_service_batch_url,
+            url=self._metrics_manager_batch_url,
             payload=payload,
             description="latency",
         )
@@ -1134,7 +1134,7 @@ class PipelineRunner:
         iterating the in-memory ``latency_tracer_metrics`` map and
         re-pushing the last observed sample for every stream. This
         guarantees that at least one final sample per stream reaches
-        metrics-service even if the last in-flight per-sample push
+        metrics-manager even if the last in-flight per-sample push
         raced with pipeline teardown.
 
         No-op when ``enable_latency_metrics`` is False (the map stays
@@ -1216,13 +1216,13 @@ class PipelineRunner:
         )
         self.latency_tracer_metrics[stream_id] = metrics
 
-        # Live push: forward every new sample to metrics-service as
+        # Live push: forward every new sample to metrics-manager as
         # soon as it is parsed. The call is fire-and-forget (runs on
         # a daemon thread in `_post_metrics_async`) so a slow or
         # unavailable backend can never stall the stdout reader.
         self._push_latency_sample(stream_id, metrics)
 
-        # Per-sample log is kept at DEBUG level: metrics-service is
+        # Per-sample log is kept at DEBUG level: metrics-manager is
         # now the primary surface for tracer values, so this log is
         # only useful for local troubleshooting when the backend is
         # unavailable or the payload shape is under review.

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/pipeline_runner_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/pipeline_runner_test.py
@@ -79,7 +79,7 @@ def _extract_pushed_fps_values(mock_urlopen: MagicMock) -> list[float]:
 
 
 def _extract_latency_payloads(mock_urlopen: MagicMock) -> list[dict]:
-    """Extract every batch-endpoint payload sent to metrics-service.
+    """Extract every batch-endpoint payload sent to metrics-manager.
 
     Returns each JSON body as a dict, filtered to calls targeting the
     ``/api/v1/metrics`` batch endpoint used by `_push_latency_sample`
@@ -262,7 +262,7 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
     def test_run_pipeline_pushes_zero_fps_on_completion(
         self, mock_urlopen, mock_select, mock_ps, mock_popen
     ):
-        """PipelineRunner should push 0.0 to metrics-service after successful completion."""
+        """PipelineRunner should push 0.0 to metrics-manager after successful completion."""
         process_mock = _make_process_mock(
             [
                 "FpsCounter(average 10.0sec): total=100.0 fps, number-streams=1, per-stream=100.0 fps",
@@ -290,7 +290,7 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
         # Last push should be 0.0 (from finally block).
         self.assertEqual(pushed[-1], 0.0, "Last FPS push should be 0.0")
 
-        # Every request targets the metrics-service `/api/v1/metrics/simple` endpoint.
+        # Every request targets the metrics-manager `/api/v1/metrics/simple` endpoint.
         for call in mock_urlopen.call_args_list:
             req = call[0][0]
             self.assertTrue(req.full_url.endswith("/api/v1/metrics/simple"))
@@ -302,7 +302,7 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
     def test_run_pipeline_pushes_zero_fps_on_error(
         self, mock_urlopen, mock_select, mock_popen
     ):
-        """PipelineRunner should push 0.0 to metrics-service after pipeline failure."""
+        """PipelineRunner should push 0.0 to metrics-manager after pipeline failure."""
         process_mock = _make_process_mock([], exit_code=1)
         process_mock.stderr.readline.side_effect = itertools.repeat(b"")
         mock_select.return_value = ([], [], [])
@@ -318,7 +318,7 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
         self.assertEqual(
             pushed.count(0.0),
             1,
-            "0.0 should be pushed exactly once to metrics-service after pipeline error",
+            "0.0 should be pushed exactly once to metrics-manager after pipeline error",
         )
 
     @patch("pipeline_runner.Popen")
@@ -327,7 +327,7 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
     def test_pipeline_hang_pushes_zero_fps_before_raising(
         self, mock_urlopen, mock_select, mock_popen
     ):
-        """PipelineRunner should push 0.0 to metrics-service when raising inactivity timeout error."""
+        """PipelineRunner should push 0.0 to metrics-manager when raising inactivity timeout error."""
         runner = PipelineRunner(
             mode="normal",
             max_runtime=0,
@@ -355,13 +355,13 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
         self.assertEqual(
             pushed.count(0.0),
             1,
-            "0.0 should be pushed exactly once to metrics-service after timeout error",
+            "0.0 should be pushed exactly once to metrics-manager after timeout error",
         )
 
     @patch("pipeline_runner.Popen")
     @patch("pipeline_runner.urllib.request.urlopen")
     def test_stop_pipeline_pushes_zero_fps(self, mock_urlopen, mock_popen):
-        """PipelineRunner should push 0.0 to metrics-service when cancelled."""
+        """PipelineRunner should push 0.0 to metrics-manager when cancelled."""
         process_mock = MagicMock()
         # First poll() returns None (main loop: process running),
         # second poll() returns None (_graceful_terminate: still running).
@@ -388,14 +388,14 @@ class TestPipelineRunnerNormalMode(unittest.TestCase):
         self.assertEqual(
             pushed.count(0.0),
             1,
-            "0.0 should be pushed exactly once to metrics-service after cancellation",
+            "0.0 should be pushed exactly once to metrics-manager after cancellation",
         )
 
     @patch("pipeline_runner.urllib.request.urlopen")
     def test_push_fps_metric_uses_configured_url(self, mock_urlopen):
-        """`_push_fps_metric` must POST JSON to `{METRICS_SERVICE_URL}/api/v1/metrics/simple`."""
+        """`_push_fps_metric` must POST JSON to `{METRICS_MANAGER_URL}/api/v1/metrics/simple`."""
         with patch.dict(
-            "os.environ", {"METRICS_SERVICE_URL": "http://example:1234"}, clear=False
+            "os.environ", {"METRICS_MANAGER_URL": "http://example:1234"}, clear=False
         ):
             runner = PipelineRunner(mode="normal", max_runtime=0)
 
@@ -1200,7 +1200,7 @@ class TestLatencyTracerIntervalParser(unittest.TestCase):
 
 @_patch_sync_metrics_executor
 class TestLatencyMetricsPush(unittest.TestCase):
-    """Tests for the live + final latency push to metrics-service.
+    """Tests for the live + final latency push to metrics-manager.
 
     Covers the runner behaviour introduced by ITEP-89980:
     ``_push_latency_sample`` fires on every parsed interval line, and
@@ -1245,7 +1245,7 @@ class TestLatencyMetricsPush(unittest.TestCase):
         """Latency pushes target the batch `/api/v1/metrics` endpoint (NOT `/simple`)."""
         with patch.dict(
             "os.environ",
-            {"METRICS_SERVICE_URL": "http://example:1234"},
+            {"METRICS_MANAGER_URL": "http://example:1234"},
             clear=False,
         ):
             runner = PipelineRunner(


### PR DESCRIPTION
## Summary
Update all references from `metrics-service` to `metrics-manager` throughout the codebase and configuration files.
## Changes

### Configuration Files
- **compose.yml**: Updated Docker Compose service name, container name, environment variables, and dependencies
- **AGENTS.md**: Updated service documentation and API endpoint descriptions
- **Makefile**: Updated Make targets for shell access and service management
- **ui/nginx.conf**: Updated RTSP proxy configuration

### Python Code
- **vippet/pipeline_runner.py**: 
  - Renamed `DEFAULT_METRICS_SERVICE_URL` constant to `DEFAULT_METRICS_MANAGER_URL`
  - Updated environment variable from `METRICS_SERVICE_URL` to `METRICS_MANAGER_URL`
  - Renamed internal URL attributes and comments for consistency
  
- **vippet/benchmark.py**: Updated comments referencing metrics service
- **vippet/tests/unit/pipeline_runner_test.py**: Updated test code to match renamed attributes
