### PR TITLE
[ViPPET] Bump DLStreamer, model-download and metrics-manager images to latest weekly tags

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -121,7 +121,7 @@ services:
       - no_proxy=${no_proxy}
     command: './model_manager.sh'
   model-download:
-    image: docker.io/intel/model-download:2026.1.0-20260428-weekly
+    image: docker.io/intel/model-download:2026.1.0-20260505-weekly
     container_name: model-download
     ports:
       - "8000:8000"
@@ -158,7 +158,7 @@ services:
     ports:
       - "7860:7860"
   metrics-manager:
-    image: docker.io/intel/metrics-manager:2026.1.0-20260507-weekly
+    image: docker.io/intel/metrics-manager:2026.1.0-20260508-weekly
     container_name: metrics-manager
     ports:
       - "9090:9090"

--- a/tools/visual-pipeline-and-platform-evaluation-tool/models/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/models/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.1.0-20260428-weekly-ubuntu24
+FROM intel/dlstreamer:2026.1.0-20260505-weekly-ubuntu24
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.1.0-20260428-weekly-ubuntu24
+FROM intel/dlstreamer:2026.1.0-20260505-weekly-ubuntu24
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.1.0-20260428-weekly-ubuntu24 AS prod
+FROM intel/dlstreamer:2026.1.0-20260505-weekly-ubuntu24 AS prod
 
 # Switch to root user to install dependencies
 USER root


### PR DESCRIPTION
## Summary
Update Docker base images and service images to the latest weekly builds.

## Changes
- **DLStreamer** base image: `2026.1.0-20260428-weekly` → `2026.1.0-20260505-weekly` (vippet, models, video_generator Dockerfiles)
- **model-download** service image: `2026.1.0-20260428-weekly` → `2026.1.0-20260505-weekly` (compose.yml)
- **metrics-manager** service image: `2026.1.0-20260507-weekly` → `2026.1.0-20260508-weekly` (compose.yml)
