### PR TITLE
[audio-analyzer] Pin image tag to 1.3.3

### DIFF
--- a/sample-applications/video-search-and-summarization/chart/subchart/audio-analyzer/values.yaml
+++ b/sample-applications/video-search-and-summarization/chart/subchart/audio-analyzer/values.yaml
@@ -26,7 +26,7 @@ audioanalyzer:
   name: audioanalyzer
   image:
     repository: intel/audio-analyzer
-    tag: "latest"
+    tag: "1.3.3"
     pullPolicy: IfNotPresent
   resources: {}
   env:

--- a/sample-applications/video-search-and-summarization/docker/compose.summary.yaml
+++ b/sample-applications/video-search-and-summarization/docker/compose.summary.yaml
@@ -147,7 +147,7 @@ services:
       - vs_network
 
   audio-analyzer:
-    image: ${REGISTRY:-}audio-analyzer:${TAG:-latest}
+    image: ${REGISTRY:-}audio-analyzer:1.3.3
     hostname: audio-analyzer
     ports:
       - "${AUDIO_HOST_PORT}:8000"


### PR DESCRIPTION
### Description

Pin the audio-analyzer container image tag from `latest` to `1.3.3` in both the Helm chart values and Docker Compose file for reproducible and consistent deployments.

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

Verified that the tag is correctly set in both `values.yaml` and `compose.summary.yaml` by reviewing the diff.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0.
- [x] I have not included any company confidential information, trade secret, password or security token.
- [x] I have performed a self-review of my code.