### PR TITLE
[ViPPET] Update metrics charts

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/MetricsDashboard.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/MetricsDashboard.tsx
@@ -318,7 +318,7 @@ export const MetricsDashboard = ({
         isSummary ? summaryContainerClassName : ""
       }`}
     >
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <MetricCard
           title={isSummary ? "Frame Rate Average" : "Frame Rate"}
           value={metrics.fps}

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/MetricsDashboard.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/MetricsDashboard.tsx
@@ -399,76 +399,47 @@ export const MetricsDashboard = ({
       </div>
 
       <div
-        className={`grid grid-cols-1 gap-4 ${hasNpuData ? "sm:grid-cols-4" : "sm:grid-cols-3"}`}
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2"
       >
-        <div className="space-y-4">
-          <FrameRateChart
-            data={fpsData}
-            yAxisMax={fpsYAxisMax}
-            isSummary={isSummary}
-            forceDark={forceDark}
-            useDemoStyles={useDemoStyles}
-          />
-          <MemoryUtilizationChart
-            data={memoryData}
-            isSummary={isSummary}
-            forceDark={forceDark}
-            useDemoStyles={useDemoStyles}
-          />
-          {showLatencySection && (
-            <LatencyChart
-              data={latencyData}
-              yAxisMax={latencyYAxisMax}
-              isSummary={isSummary}
-              forceDark={forceDark}
-              useDemoStyles={useDemoStyles}
-            />
-          )}
-        </div>
-
-        <div className="space-y-4">
-          <CpuUsageChart
-            data={cpuData}
-            isSummary={isSummary}
-            forceDark={forceDark}
-            useDemoStyles={useDemoStyles}
-          />
-          <CpuTemperatureChart
-            data={cpuTempData}
-            yAxisMax={cpuTempYAxisMax}
-            isSummary={isSummary}
-            forceDark={forceDark}
-            useDemoStyles={useDemoStyles}
-          />
-          <CpuFrequencyChart
-            data={cpuFrequencyData}
-            yAxisMax={cpuFrequencyYAxisMax}
-            isSummary={isSummary}
-            forceDark={forceDark}
-            useDemoStyles={useDemoStyles}
-          />
-        </div>
-
-        <div className="space-y-4">
-          {!useDemoStyles && (
-            <GpuUsageChart
-              data={gpuChartData}
-              dataKeys={availableEngines}
-              colors={availableEngines.map((engine) => engineColors[engine])}
-              labels={availableEngines.map((engine) => engineLabels[engine])}
-              selectedGpu={selectedGpu}
-              availableGpus={availableGpus}
-              onGpuChange={setSelectedGpu}
-              isSummary={isSummary}
-              forceDark={forceDark}
-              useDemoStyles={useDemoStyles}
-              summarySectionClassName={summarySectionClassName}
-              summaryTitleClassName={summaryTitleClassName}
-            />
-          )}
-          <GpuPowerChart
-            data={gpuPowerData}
-            yAxisMax={gpuPowerYAxisMax}
+        <FrameRateChart
+          data={fpsData}
+          yAxisMax={fpsYAxisMax}
+          isSummary={isSummary}
+          forceDark={forceDark}
+          useDemoStyles={useDemoStyles}
+        />
+        <CpuUsageChart
+          data={cpuData}
+          isSummary={isSummary}
+          forceDark={forceDark}
+          useDemoStyles={useDemoStyles}
+        />
+        <MemoryUtilizationChart
+          data={memoryData}
+          isSummary={isSummary}
+          forceDark={forceDark}
+          useDemoStyles={useDemoStyles}
+        />
+        <CpuTemperatureChart
+          data={cpuTempData}
+          yAxisMax={cpuTempYAxisMax}
+          isSummary={isSummary}
+          forceDark={forceDark}
+          useDemoStyles={useDemoStyles}
+        />
+        <CpuFrequencyChart
+          data={cpuFrequencyData}
+          yAxisMax={cpuFrequencyYAxisMax}
+          isSummary={isSummary}
+          forceDark={forceDark}
+          useDemoStyles={useDemoStyles}
+        />
+        {!useDemoStyles && (
+          <GpuUsageChart
+            data={gpuChartData}
+            dataKeys={availableEngines}
+            colors={availableEngines.map((engine) => engineColors[engine])}
+            labels={availableEngines.map((engine) => engineLabels[engine])}
             selectedGpu={selectedGpu}
             availableGpus={availableGpus}
             onGpuChange={setSelectedGpu}
@@ -478,9 +449,37 @@ export const MetricsDashboard = ({
             summarySectionClassName={summarySectionClassName}
             summaryTitleClassName={summaryTitleClassName}
           />
-          <GpuFrequencyChart
-            data={gpuFrequencyData}
-            yAxisMax={gpuFrequencyYAxisMax}
+        )}
+        <GpuPowerChart
+          data={gpuPowerData}
+          yAxisMax={gpuPowerYAxisMax}
+          selectedGpu={selectedGpu}
+          availableGpus={availableGpus}
+          onGpuChange={setSelectedGpu}
+          isSummary={isSummary}
+          forceDark={forceDark}
+          useDemoStyles={useDemoStyles}
+          summarySectionClassName={summarySectionClassName}
+          summaryTitleClassName={summaryTitleClassName}
+        />
+        <GpuFrequencyChart
+          data={gpuFrequencyData}
+          yAxisMax={gpuFrequencyYAxisMax}
+          selectedGpu={selectedGpu}
+          availableGpus={availableGpus}
+          onGpuChange={setSelectedGpu}
+          isSummary={isSummary}
+          forceDark={forceDark}
+          useDemoStyles={useDemoStyles}
+          summarySectionClassName={summarySectionClassName}
+          summaryTitleClassName={summaryTitleClassName}
+        />
+        {useDemoStyles && (
+          <GpuUsageChart
+            data={gpuChartData}
+            dataKeys={availableEngines}
+            colors={availableEngines.map((engine) => engineColors[engine])}
+            labels={availableEngines.map((engine) => engineLabels[engine])}
             selectedGpu={selectedGpu}
             availableGpus={availableGpus}
             onGpuChange={setSelectedGpu}
@@ -490,47 +489,41 @@ export const MetricsDashboard = ({
             summarySectionClassName={summarySectionClassName}
             summaryTitleClassName={summaryTitleClassName}
           />
-          {useDemoStyles && (
-            <GpuUsageChart
-              data={gpuChartData}
-              dataKeys={availableEngines}
-              colors={availableEngines.map((engine) => engineColors[engine])}
-              labels={availableEngines.map((engine) => engineLabels[engine])}
-              selectedGpu={selectedGpu}
-              availableGpus={availableGpus}
-              onGpuChange={setSelectedGpu}
-              isSummary={isSummary}
-              forceDark={forceDark}
-              useDemoStyles={useDemoStyles}
-              summarySectionClassName={summarySectionClassName}
-              summaryTitleClassName={summaryTitleClassName}
-            />
-          )}
-        </div>
-
+        )}
         {hasNpuData && (
-          <div className="space-y-4">
-            <NpuUsageChart
-              data={npuData}
-              isSummary={isSummary}
-              forceDark={forceDark}
-              useDemoStyles={useDemoStyles}
-            />
-            <NpuPowerChart
-              data={npuPowerData}
-              yAxisMax={npuPowerYAxisMax}
-              isSummary={isSummary}
-              forceDark={forceDark}
-              useDemoStyles={useDemoStyles}
-            />
-            <NpuFrequencyChart
-              data={npuFrequencyData}
-              yAxisMax={npuFrequencyYAxisMax}
-              isSummary={isSummary}
-              forceDark={forceDark}
-              useDemoStyles={useDemoStyles}
-            />
-          </div>
+          <NpuUsageChart
+            data={npuData}
+            isSummary={isSummary}
+            forceDark={forceDark}
+            useDemoStyles={useDemoStyles}
+          />
+        )}
+        {hasNpuData && (
+          <NpuPowerChart
+            data={npuPowerData}
+            yAxisMax={npuPowerYAxisMax}
+            isSummary={isSummary}
+            forceDark={forceDark}
+            useDemoStyles={useDemoStyles}
+          />
+        )}
+        {hasNpuData && (
+          <NpuFrequencyChart
+            data={npuFrequencyData}
+            yAxisMax={npuFrequencyYAxisMax}
+            isSummary={isSummary}
+            forceDark={forceDark}
+            useDemoStyles={useDemoStyles}
+          />
+        )}
+        {showLatencySection && (
+          <LatencyChart
+            data={latencyData}
+            yAxisMax={latencyYAxisMax}
+            isSummary={isSummary}
+            forceDark={forceDark}
+            useDemoStyles={useDemoStyles}
+          />
         )}
       </div>
     </div>

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/charts/GpuChartSection.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/charts/GpuChartSection.tsx
@@ -20,6 +20,7 @@ interface GpuChartSectionProps
   availableGpus?: number[];
   onGpuChange?: (gpu: number) => void;
   wrapLegend?: boolean;
+  showLegend?: boolean;
 }
 
 export const GpuChartSection = ({
@@ -39,6 +40,7 @@ export const GpuChartSection = ({
   summarySectionClassName,
   summaryTitleClassName,
   wrapLegend = false,
+  showLegend = true,
 }: GpuChartSectionProps) => {
   const hasGpuSelector =
     selectedGpu !== undefined && availableGpus && onGpuChange;
@@ -65,7 +67,7 @@ export const GpuChartSection = ({
             ? `text-[10px] font-semibold uppercase tracking-widest mb-6 ${
                 isSummary ? summaryTitleClassName : "text-neutral-400"
               }`
-            : "text-sm font-medium text-foreground mb-5 min-h-[2.5rem]"
+            : "text-sm font-medium text-foreground mb-5"
         }`}
       >
         {title}
@@ -94,7 +96,7 @@ export const GpuChartSection = ({
             colors={chartColors}
             unit={chartUnit}
             yAxisDomain={chartYAxisDomain}
-            showLegend={true}
+            showLegend={showLegend}
             className={`${useDemoStyles ? "!bg-transparent !border-0" : ""} !shadow-none !p-0`}
             labels={chartLabels}
             wrapLegend={wrapLegend}

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/charts/GpuFrequencyChart.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/charts/GpuFrequencyChart.tsx
@@ -35,6 +35,7 @@ export const GpuFrequencyChart = ({
       chartUnit=" GHz"
       chartYAxisDomain={[0, yAxisMax]}
       chartLabels={["Frequency"]}
+      showLegend={false}
       selectedGpu={selectedGpu}
       availableGpus={availableGpus}
       onGpuChange={onGpuChange}

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/PerformanceTestPanel.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/PerformanceTestPanel.tsx
@@ -166,6 +166,7 @@ type PerformanceTestPanelProps = {
   livePreviewEnabled?: boolean;
   videoOutputEnabled?: boolean;
   enableLatencyMetrics?: boolean;
+  enableMetadata?: boolean;
   liveStreamUrl?: string | null;
   resultOverrides?: FrozenSnapshotOverrides | null;
 };
@@ -177,6 +178,7 @@ const PerformanceTestPanel = ({
   livePreviewEnabled = false,
   videoOutputEnabled = false,
   enableLatencyMetrics = false,
+  enableMetadata = true,
   liveStreamUrl,
   resultOverrides,
 }: PerformanceTestPanelProps) => {
@@ -388,8 +390,17 @@ const PerformanceTestPanel = ({
   const hasLiveStream = livePreviewEnabled && (isRunning || !!liveStreamUrl);
   const hasOutputVideo =
     !livePreviewEnabled && !isRunning && !!completedVideoPath;
+  const showMetadataSection = enableMetadata && showMetadataTab;
+  const visibleTabCount =
+    (hasMediaTab ? 1 : 0) + (showMetadataSection ? 1 : 0);
   const effectiveMainTab =
-    activeMainTab === "media" && !hasMediaTab ? "metadata" : activeMainTab;
+    activeMainTab === "media" && !hasMediaTab
+      ? "metadata"
+      : activeMainTab === "metadata" && !showMetadataSection
+        ? hasMediaTab
+          ? "media"
+          : "metadata"
+        : activeMainTab;
 
   return (
     <div className="flex flex-col w-full h-full bg-background p-4 space-y-4 overflow-y-auto overflow-x-hidden min-w-0">
@@ -400,14 +411,16 @@ const PerformanceTestPanel = ({
         onValueChange={setActiveMainTab}
         className="flex flex-col min-w-0"
       >
-        <TabsList>
-          {hasMediaTab && (
-            <TabsTrigger value="media">{mediaTabLabel}</TabsTrigger>
-          )}
-          <TabsTrigger value="metadata" disabled={!showMetadataTab}>
-            Metadata JSON
-          </TabsTrigger>
-        </TabsList>
+        {visibleTabCount > 1 && (
+          <TabsList>
+            {hasMediaTab && (
+              <TabsTrigger value="media">{mediaTabLabel}</TabsTrigger>
+            )}
+            {showMetadataSection && (
+              <TabsTrigger value="metadata">Metadata JSON</TabsTrigger>
+            )}
+          </TabsList>
+        )}
 
         {hasMediaTab && (
           <TabsContent value="media" className="space-y-4 mt-2">
@@ -446,15 +459,16 @@ const PerformanceTestPanel = ({
           </TabsContent>
         )}
 
-        <TabsContent
-          value="metadata"
-          className="space-y-4 mt-2 overflow-hidden min-w-0"
-        >
-          {!showMetadataTab && isRunning && (
-            <p className="text-sm text-muted-foreground">
-              Waiting for metadata stream URLs from the API...
-            </p>
-          )}
+        {enableMetadata && (
+          <TabsContent
+            value="metadata"
+            className="space-y-4 mt-2 overflow-hidden min-w-0"
+          >
+            {!showMetadataTab && isRunning && (
+              <p className="text-sm text-muted-foreground">
+                Waiting for metadata stream URLs from the API...
+              </p>
+            )}
 
           {showMetadataTab &&
             displayEntries.length === 1 &&
@@ -563,7 +577,8 @@ const PerformanceTestPanel = ({
               })}
             </Tabs>
           )}
-        </TabsContent>
+          </TabsContent>
+        )}
       </Tabs>
 
       {isRunning && (

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/Pipelines.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/Pipelines.tsx
@@ -55,6 +55,7 @@ import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import {
   ArrowLeft,
+  Braces,
   Eye,
   Film,
   Infinity as InfinityIcon,
@@ -142,6 +143,7 @@ export const Pipelines = () => {
   const [videoOutputEnabled, setVideoOutputEnabled] = useState(true);
   const [livePreviewEnabled, setLivePreviewEnabled] = useState(false);
   const [latencyMetricsEnabled, setLatencyMetricsEnabled] = useState(false);
+  const [metadataEnabled, setMetadataEnabled] = useState(false);
   const [loopingEnabled, setLoopingEnabled] = useState(false);
   const [loopingRuntimeSeconds, setLoopingRuntimeSeconds] = useState(
     DEFAULT_LOOPING_RUNTIME_SECONDS,
@@ -351,7 +353,8 @@ export const Pipelines = () => {
           execution_config: {
             output_mode: outputMode,
             max_runtime: maxRuntimeSeconds,
-            metadata_mode: hasMetadata ? "file" : "disabled",
+            metadata_mode:
+              hasMetadata && metadataEnabled ? "file" : "disabled",
             enable_latency_metrics: latencyMetricsEnabled,
           },
         },
@@ -463,6 +466,10 @@ export const Pipelines = () => {
           : 0;
     const currentVariantData = data.variants.find((v) => v.id === variant);
     const isReadOnly = currentVariantData?.read_only ?? false;
+    const pipelineHasMetadata =
+      currentVariantData?.pipeline_graph.nodes.some(
+        (n) => n.type === "gvametapublish",
+      ) ?? false;
 
     const editorContent = (
       <div className="w-full h-full relative">
@@ -818,6 +825,19 @@ export const Pipelines = () => {
                           onCheckedChange={setLatencyMetricsEnabled}
                         />
                       </div>
+
+                      {pipelineHasMetadata && (
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="flex items-center gap-2 text-sm">
+                            <Braces className="h-4 w-4 text-muted-foreground" />
+                            <span>Metadata JSON</span>
+                          </div>
+                          <Switch
+                            checked={metadataEnabled}
+                            onCheckedChange={setMetadataEnabled}
+                          />
+                        </div>
+                      )}
                     </div>
                   </div>
                 </PopoverContent>
@@ -899,6 +919,7 @@ export const Pipelines = () => {
                       livePreviewEnabled={livePreviewEnabled}
                       videoOutputEnabled={videoOutputEnabled}
                       enableLatencyMetrics={latencyMetricsEnabled}
+                      enableMetadata={metadataEnabled && pipelineHasMetadata}
                       liveStreamUrl={
                         Object.values(jobStatus?.live_stream_urls ?? {})[0] ??
                         null


### PR DESCRIPTION
Updated metrics dashboard:
- Divided dashboard into two columns of charts
- Made charts windows the same length
- Provided switch for Metadata Json, where disabling metadata provides it from being sent from backend
- When switch is disabled, tabs for output video and metadata won't show when not necessary

**PREVIEW:**


https://github.com/user-attachments/assets/b34b51bc-d2a7-4ecf-9be2-d614deb0aa03

