### PR TITLE
[VSS] Remove audio-analyzer from build pipeline and update release notes

### DIFF
--- a/sample-applications/video-search-and-summarization/build.sh
+++ b/sample-applications/video-search-and-summarization/build.sh
@@ -51,7 +51,7 @@ fi
 # Usage information
 show_usage() {
   echo -e "Usage: $0 [OPTION]"
-  echo -e "  --dependencies\t Build sample application dependencies (vdms-dataprep, multimodal-embedding, audio-analyzer)"
+  echo -e "  --dependencies\t Build sample application dependencies (vdms-dataprep, multimodal-embedding-serving)"
   echo -e "  --help, -h\t\t Show this help message"
   echo -e "  --push\t Push all built Docker images to the registry"
   echo -e "  <no option>\t Build sample application services (video-ingestion, pipeline-manager, search-ms, and UI)"
@@ -136,7 +136,6 @@ build_dependencies() {
     local dep_images=(
       "${REGISTRY}vdms-dataprep:${TAG}"
       "${REGISTRY}multimodal-embedding-serving:${TAG}"
-      "${REGISTRY}audio-analyzer:${TAG}"
     )
     for img in "${dep_images[@]}"; do
       if docker image inspect "$img" &> /dev/null; then
@@ -254,7 +253,6 @@ push_images() {
   local all_images=(
     "${REGISTRY}vdms-dataprep:${TAG}"
     "${REGISTRY}multimodal-embedding-serving:${TAG}"
-    "${REGISTRY}audio-analyzer:${TAG}"
     "${REGISTRY}video-ingestion:${TAG}"
     "${REGISTRY}pipeline-manager:${TAG}"
     "${REGISTRY}video-search:${TAG}"

--- a/sample-applications/video-search-and-summarization/docs/user-guide/release-notes.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/release-notes.md
@@ -12,7 +12,7 @@
 - Refactored Helm chart to use a reusable `vssui` subchart with multi-mode nginx and consolidated embedding model config under `global.embeddingModelName`.
 - Bumped DLStreamer base image to 2026.1.0-ubuntu24-rc1 for Video Ingestion Microservice.
 - **Setup Script:** Updates in environment variable to setup embedding models. New MULTIMODAL_EMBEDDING_MODEL and existing TEXT_EMBEDDING_MODEL are used to provide embedding models in relevant modes.
-- **Docker Compose:** Replaced `curl` with Python `urllib` in container healthchecks for a lighter runtime footprint for some of the dependencies.
+- **Docker Compose:** Replaced `curl` with Python `urllib` in container healthcheck for a lighter runtime footprint for some of the dependencies.
 - **Docker Compose:** Replaced environment variables with hard coded mount paths. This helps in stopping containers without looking for preset variables.
 - **Build Script:** Removed Audio-Analyzer from the dependency build pipeline. A frozen version 1.3.3 will be used for the Audio Analyzer microservice for current and all subsequent releases.
 - **Setup Script:** Minor cleanup to remove unused environment variables and remove several environment variables being used as mount directories in Docker Compose files _(some of these environment variables are still used pertaining to design issues)_.

--- a/sample-applications/video-search-and-summarization/docs/user-guide/release-notes.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/release-notes.md
@@ -9,13 +9,13 @@
 - Introducing new Dual UI mode with a new `--summary --search` CLI argument for `setup.sh`. This runs both summary and search applications simultaneously at **/summary** and **/search** URI endpoints respectively.
 - New Dual UI setup for helm chart installation. This is implemented by enabling ways to provide values override file for summary and search mode simultaneously.
 - Updates to setup script and nginx configuration files for flexible UI routing for each mode of deployment - existing summary mode, search mode, Unified UI Mode and the new Dual UI mode.
-- Updates in environment variable to setup embedding models. New MULTIMODAL_EMBEDDING_MODEL and existing TEXT_EMBEDDING_MODEL are used to provide embedding models in relevant modes.
 - Refactored Helm chart to use a reusable `vssui` subchart with multi-mode nginx and consolidated embedding model config under `global.embeddingModelName`.
-- Bumped DLStreamer base image to 2026.1.0-ubuntu24-rc1 for video-ingestion.
-- Docker Compose: Replaced `curl` with Python `urllib` in container healthchecks for a lighter runtime footprint for Audio Analyzer.
-- Removed Audio-Analyzer from the dependency build pipeline. A frozen version 1.3.3 will be used for the Audio Analyzer microservice for current and all subsequent releases.
-- Minor refactoring in setup script to remove unused environment variables and avoid using environment variables to be used as mount directories in Docker Compose files.
-- Minor refactoring in Docker Compose to remove env vars being used as mount path.
+- Bumped DLStreamer base image to 2026.1.0-ubuntu24-rc1 for Video Ingestion Microservice.
+- **Setup Script:** Updates in environment variable to setup embedding models. New MULTIMODAL_EMBEDDING_MODEL and existing TEXT_EMBEDDING_MODEL are used to provide embedding models in relevant modes.
+- **Docker Compose:** Replaced `curl` with Python `urllib` in container healthchecks for a lighter runtime footprint for some of the dependencies.
+- **Docker Compose:** Replaced environment variables with hard coded mount paths. This helps in stopping containers without looking for preset variables.
+- **Build Script:** Removed Audio-Analyzer from the dependency build pipeline. A frozen version 1.3.3 will be used for the Audio Analyzer microservice for current and all subsequent releases.
+- **Setup Script:** Minor cleanup to remove unused environment variables and remove several environment variables being used as mount directories in Docker Compose files _(some of these environment variables are still used pertaining to design issues)_.
 
 ## Previous Release
 

--- a/sample-applications/video-search-and-summarization/docs/user-guide/release-notes.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/release-notes.md
@@ -12,7 +12,7 @@
 - Refactored Helm chart to use a reusable `vssui` subchart with multi-mode nginx and consolidated embedding model config under `global.embeddingModelName`.
 - Bumped DLStreamer base image to 2026.1.0-ubuntu24-rc1 for Video Ingestion Microservice.
 - **Setup Script:** Updates in environment variable to setup embedding models. New MULTIMODAL_EMBEDDING_MODEL and existing TEXT_EMBEDDING_MODEL are used to provide embedding models in relevant modes.
-- **Docker Compose:** Replaced `curl` with Python `urllib` in container healthcheck for a lighter runtime footprint for some of the dependencies.
+- **Docker Compose:** Replaced `curl` with Python `urllib` package in container healthcheck command for a lighter runtime footprint for Audio Analyzer.
 - **Docker Compose:** Replaced environment variables with hard coded mount paths. This helps in stopping containers without looking for preset variables.
 - **Build Script:** Removed Audio-Analyzer from the dependency build pipeline. A frozen version 1.3.3 will be used for the Audio Analyzer microservice for current and all subsequent releases.
 - **Setup Script:** Minor cleanup to remove unused environment variables and remove several environment variables being used as mount directories in Docker Compose files _(some of these environment variables are still used pertaining to design issues)_.

--- a/sample-applications/video-search-and-summarization/docs/user-guide/release-notes.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/release-notes.md
@@ -12,7 +12,7 @@
 - Updates in environment variable to setup embedding models. New MULTIMODAL_EMBEDDING_MODEL and existing TEXT_EMBEDDING_MODEL are used to provide embedding models in relevant modes.
 - Refactored Helm chart to use a reusable `vssui` subchart with multi-mode nginx and consolidated embedding model config under `global.embeddingModelName`.
 - Bumped DLStreamer base image to 2026.1.0-ubuntu24-rc1 for video-ingestion.
-- Docker Compose: Replaced `curl` with Python `urllib` in container healthchecks for a lighter runtime footprint for some of the dependencies.
+- Docker Compose: Replaced `curl` with Python `urllib` in container healthchecks for a lighter runtime footprint for Audio Analyzer.
 - Removed Audio-Analyzer from the dependency build pipeline. A frozen version 1.3.3 will be used for the Audio Analyzer microservice for current and all subsequent releases.
 - Minor refactoring in setup script to remove unused environment variables and avoid using environment variables to be used as mount directories in Docker Compose files.
 - Minor refactoring in Docker Compose to remove env vars being used as mount path.

--- a/sample-applications/video-search-and-summarization/docs/user-guide/release-notes.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/release-notes.md
@@ -5,21 +5,17 @@
 **Version**: 2026.1.0-rc1 \
 **Release Date**: 15 May 2026
 
-**Bug Fixes:**
-Following fixes have been added in MultiModal Embedding Microservice:
-  - PyTorch fallback support for non-OpenVINO scenario.
-  - Fallback for all supported model variants.
-  - Handle preprocess metadata support in blip2 transformers.
-
 **Changes:**
-- Introducing new Dual UI mode with `--summary --search` flags to run both summary and search applications simultaneously at /summary and /search endpoints respectively.
-- New Dual UI setup for helm chart installations by providing summary and search mode override values file simulatneously.
-- Updates to setup script and nginx configuration files for flexible UI routing via nginx for each mode of deployment.
+- Introducing new Dual UI mode with a new `--summary --search` CLI argument for `setup.sh`. This runs both summary and search applications simultaneously at **/summary** and **/search** URI endpoints respectively.
+- New Dual UI setup for helm chart installation. This is implemented by enabling ways to provide values override file for summary and search mode simultaneously.
+- Updates to setup script and nginx configuration files for flexible UI routing for each mode of deployment - existing summary mode, search mode, Unified UI Mode and the new Dual UI mode.
 - Updates in environment variable to setup embedding models. New MULTIMODAL_EMBEDDING_MODEL and existing TEXT_EMBEDDING_MODEL are used to provide embedding models in relevant modes.
 - Refactored Helm chart to use a reusable `vssui` subchart with multi-mode nginx and consolidated embedding model config under `global.embeddingModelName`.
 - Bumped DLStreamer base image to 2026.1.0-ubuntu24-rc1 for video-ingestion.
-- Replaced `curl` with Python `urllib` in container healthchecks for a lighter runtime footprint.
-- Removed audio-analyzer from the dependency build pipeline.
+- Docker Compose: Replaced `curl` with Python `urllib` in container healthchecks for a lighter runtime footprint for some of the dependencies.
+- Removed Audio-Analyzer from the dependency build pipeline. A frozen version 1.3.3 will be used for the Audio Analyzer microservice for current and all subsequent releases.
+- Minor refactoring in setup script to remove unused environment variables and avoid using environment variables to be used as mount directories in Docker Compose files.
+- Minor refactoring in Docker Compose to remove env vars being used as mount path.
 
 ## Previous Release
 
@@ -107,7 +103,7 @@ Following fixes have been added in MultiModal Embedding Microservice:
 
 - Video_Summary: Link to Multimodal embedding models are missing in the getting started guide
 - Video_Search: Change in models with different embedding dimension results in no video search
-- Video_Summary: When Video search is deployed with embedding model as Blip2/blip2_feature_extractor, Multimodal embedding serving doesnt run
+- Video_Summary: When Video search is deployed with embedding model as Blip2/blip2_feature_extractor, Multimodal embedding serving does not run
 
 **HW used for validation**:
 


### PR DESCRIPTION
### Description

Removes the `audio-analyzer` Docker image from the Video Search and
Summarization (VSS) dependency build and push pipeline. A frozen version
(1.3.3) will be used for the Audio Analyzer microservice for all current
and subsequent releases. Also updates the 2026.1.0-rc1 release notes with
clearer descriptions, additional context, and minor corrections.

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

Changes were reviewed by inspecting the diffs. The build.sh script no longer
references audio-analyzer in the dependency image list or push list. The
release notes content was verified for accuracy and clarity against the
actual changes made in this release cycle.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0.
- [x] I have not included any company confidential information, trade secret, password or security token.
- [x] I have performed a self-review of my code.