### PR TITLE
[ViPPET] Bump images to RC1, remove legacy models Dockerfile, and update dev dependencies

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -117,7 +117,7 @@ services:
       - ./shared/videos/:/videos
       - ./vippet/api/static:/usr/share/nginx/html/static
   model-download:
-    image: docker.io/intel/model-download:2026.1.0-20260512-weekly
+    image: docker.io/intel/model-download:2026.1.0-rc1
     container_name: model-download
     ports:
       - "8000:8000"

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -25,7 +25,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install necessary dependencies
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends python3.12-dev gstreamer1.0-plugins-ugly yq v4l-utils && \
+    apt-get install --yes --no-install-recommends gstreamer1.0-plugins-ugly yq v4l-utils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/requirements-dev.txt
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 # Development dependencies
-ruff==0.15.12
+ruff==0.15.13
 pyright==1.1.409
 coverage==7.14.0
 pytest==9.0.3


### PR DESCRIPTION
Description:
- Update `model-download` image from `20260512-weekly` to `2026.1.0-rc1`
- Update `DLStreamer` base image to `2026.1.0-ubuntu24-rc1.1` (in `vippet` and `video_generator` Dockerfiles)
- Remove deprecated `models/Dockerfile` (`model-download` service replaces it)
- Remove `python3.12-dev` from `vippet` apt dependencies (DLS base image provides it)
- Bump `ruff` from `0.15.12` to `0.15.13`