### PR TITLE
[ViPPET] Repair 1m window for metrics charts

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/MetricChart.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/MetricChart.tsx
@@ -98,10 +98,8 @@ export const MetricChart = ({
       (lastPoint.timestamp - firstPoint.timestamp) / 1000,
     );
 
-    if (seconds >= 60) {
-      const minutes = Math.floor(seconds / 60);
-      const remainingSeconds = seconds % 60;
-      return `${minutes}m ${remainingSeconds}s`;
+    if (seconds >= 58) {
+      return "1m 0s";
     }
 
     return `${seconds}s`;

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/charts/shared.ts
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/charts/shared.ts
@@ -1,6 +1,6 @@
 /*SPDX-License-Identifier: Apache-2.0*/
 
-export const CHART_MAX_DATA_POINTS = 30;
+export const CHART_MAX_DATA_POINTS = 56;
 
 export const getRecentYAxisMax = (
   values: number[],

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/hooks/useMetricHistory.ts
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/hooks/useMetricHistory.ts
@@ -34,7 +34,7 @@ export interface MetricHistoryPoint {
   gpus: Record<string, GpuMetrics>;
 }
 
-const MAX_HISTORY_POINTS = 60;
+const MAX_HISTORY_WINDOW_MS = 60_000;
 
 export const useMetricHistory = () => {
   const metrics = useMetrics();
@@ -91,12 +91,8 @@ export const useMetricHistory = () => {
       };
 
       const updated = [...prev, newPoint];
-
-      if (updated.length > MAX_HISTORY_POINTS) {
-        return updated.slice(updated.length - MAX_HISTORY_POINTS);
-      }
-
-      return updated;
+      const cutoff = now - MAX_HISTORY_WINDOW_MS;
+      return updated.filter((point) => point.timestamp >= cutoff);
     });
   }, [
     isConnected,


### PR DESCRIPTION
- Changed metrics chart window to 1m
- Changed cutting off metrics history by time instead of data points number
- Adjusting data points number to best visualize 1 minute window, taking into account jitter