### PR TITLE
[ViPPET] Restrict optimizer device scope by variant name

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/how-to-guides/optimize-pipelines.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/how-to-guides/optimize-pipelines.md
@@ -1,0 +1,249 @@
+<!--SPDX-License-Identifier: Apache-2.0-->
+
+# Optimize Pipelines
+
+ViPPET integrates the **DL Streamer Pipeline Optimizer** (DLS Optimizer)
+to help you find a well-performing configuration of a GStreamer
+pipeline on the hardware available to the application. Instead of
+manually editing element properties such as inference device,
+`batch-size`, `nireq` or the pre-processing backend, you describe the
+pipeline once as a variant and let the optimizer search for a
+configuration that maximizes throughput.
+
+This page describes how the optimizer behaves inside ViPPET today: how
+to prepare a variant so that it can be optimized at all, what happens
+between the moment you press **Optimize pipeline** and the moment a
+result is returned, and how the variant name controls which device(s)
+the optimizer is allowed to use.
+
+For background information about the optimizer itself, see the upstream
+documentation:
+[DL Streamer Optimizer](https://github.com/open-edge-platform/dlstreamer/blob/main/docs/user-guide/dev_guide/optimizer.md).
+
+## Prerequisite: an editable variant in advanced mode
+
+The **Optimize pipeline** action is only available when **both**
+conditions below are satisfied:
+
+1. The pipeline editor is in **advanced mode**.
+2. The currently selected variant is **not read-only**.
+
+If either condition is not met, the menu entry is disabled and a lock
+icon explains why.
+
+### Advanced mode
+
+The editor has two view modes, controlled by the **Enable advanced
+mode** switch in the editor toolbar:
+
+- **Simple mode** shows only the user-relevant elements of the
+  pipeline (sources, sinks, `gvadetect`, `gvaclassify`, `gvatrack`,
+  etc.). This view is intentionally restricted and several actions —
+  including **Optimize pipeline**, **Import pipeline** and **Export
+  pipeline** — are unavailable.
+- **Advanced mode** shows every GStreamer element in the pipeline,
+  including queues, converters, `gvafpscounter`, `gvametaconvert`,
+  `gvametapublish`, `fakesink`, etc. The optimizer needs the full
+  pipeline graph to work, so optimization is only exposed in this
+  view.
+
+When you toggle the switch, ViPPET saves the current graph (unless you
+discard unsaved changes), refetches the variant, and re-renders the
+editor in the requested mode.
+
+### Read-only versus editable variants
+
+Every pipeline has one or more **variants**. Variants come from two
+sources:
+
+- **Predefined variants** ship with ViPPET as part of the built-in
+  pipeline templates. They are loaded at startup with `read_only=true`
+  and represent a known-good configuration. They cannot be renamed,
+  edited, deleted or optimized in place — the backend rejects update
+  and delete requests with a clear error, and the UI disables the
+  corresponding actions.
+- **User-created variants** are variants you add yourself, either by
+  saving an existing variant under a new name (**Save as new
+  variant**) or by importing a pipeline. They are always created with
+  `read_only=false` and are fully editable.
+
+The optimizer overwrites the variant's `pipeline_graph` with the
+optimized graph when you accept the result, so it can only run on a
+variant that is allowed to be modified. To optimize a predefined
+configuration you therefore have three options:
+
+- **Save as new variant.** Open a predefined variant, choose
+  **Save as new variant** from the actions menu, give it a new name,
+  and optimize the new variant.
+- **Create a new variant.** Add a fresh variant to the pipeline and
+  build the graph in advanced mode.
+- **Create a new pipeline.** Create a brand-new user-defined pipeline.
+  All variants of a user-created pipeline are created with
+  `read_only=false`.
+
+In all three cases the resulting variant is editable, advanced mode
+can be enabled on it, and **Optimize pipeline** becomes available.
+
+## What happens when you press "Optimize pipeline"
+
+The optimization flow is a two-step asynchronous operation. ViPPET
+always validates the pipeline first and only invokes the optimizer if
+validation succeeds.
+
+### Step 1 — Pipeline validation
+
+Before any optimizer code is called, the UI converts the current graph
+into a `PipelineValidation` request and calls
+`POST /api/v1/pipelines/validate`. The backend:
+
+1. Converts the pipeline graph into a GStreamer launch string (the
+   same string that would be used to run the pipeline).
+2. Starts a short-lived validation job that runs `gst_runner.py` in
+   the background against this launch string.
+3. Reports whether the pipeline can be constructed and started
+   successfully on the host.
+
+If validation fails (for example because an element property is
+invalid, a model file is missing or two elements cannot be linked),
+the UI shows an error toast with the details from `validationStatus`
+and the optimizer is **not** invoked. You must fix the pipeline and
+try again.
+
+If validation succeeds, the variant's `pipeline_graph` is saved
+(`updateVariant`) and the optimization request is dispatched.
+
+### Step 2 — Optimization
+
+ViPPET submits an `optimize` request to
+`POST /api/v1/pipelines/{pipelineId}/variants/{variantId}/optimize`.
+The backend then:
+
+1. Reads the variant's `pipeline_graph` and serializes it to a
+   GStreamer pipeline string.
+2. Creates an `InternalOptimizationJobStatus` in state `RUNNING`,
+   assigns a job id, and spawns a background thread.
+3. Resolves the **allowed devices** from the variant name
+   (see [Variant names and devices](#variant-names-and-devices)).
+4. Calls into the optimizer that ships with the DL Streamer image
+   mounted under `/opt/intel/dlstreamer/scripts/optimizer`.
+
+The job runs entirely inside the `vippet` container; you do not need
+to install DLS Optimizer separately.
+
+## How DLS Optimizer searches for a configuration
+
+For `optimize` jobs ViPPET calls `DLSOptimizer.optimize_for_fps()` on
+the pipeline string. The optimizer performs the following work, as
+described in the upstream DLS Optimizer documentation:
+
+1. **Pre-processing rewrite.** The pipeline is first normalized so
+   that color conversions, resizing and other pre-inference operations
+   are placed on the most efficient elements for the configured
+   hardware (for example, moving CSC/resize into `vapostproc` on GPU,
+   or into the inference element's `pre-process-backend` on CPU).
+2. **Baseline measurement.** The normalized pipeline is run for a
+   short sample window to establish a baseline FPS and the expected
+   number of inference detections per sample. The detection count is
+   used later as a sanity check to reject configurations that
+   silently dropped inference work.
+3. **Configuration search.** The optimizer iteratively varies
+   inference-related properties on `gvadetect` / `gvaclassify` —
+   primarily the **inference device** (within the allowed device
+   list), `batch-size`, `nireq`, and the `pre-process-backend` — and
+   re-runs the pipeline for another sample window to measure FPS.
+4. **Best-configuration selection.** Candidates whose detection count
+   drops below the baseline (within the optimizer's tolerance) are
+   discarded; the surviving candidate with the highest measured FPS
+   wins.
+
+Both the **time budget for the search** and the **duration of each
+sample window** are configured by ViPPET to fixed values; they are
+not exposed as user-tunable parameters in this stack. The optimizer
+stops as soon as its internal time budget is exceeded and returns the
+best configuration it has confirmed so far.
+
+When the job completes, ViPPET converts the optimizer's returned
+pipeline string back into a graph and stores both views on the job:
+
+- `optimized_pipeline_description` — the GStreamer pipeline string
+  returned by the optimizer,
+- `optimized_pipeline_graph` — the **advanced view** (full graph with
+  every GStreamer element),
+- `optimized_pipeline_graph_simple` — the **simple view** (only the
+  user-relevant elements),
+- `total_fps` — the measured total FPS of the winning configuration.
+
+The UI offers an **Apply** action on the success toast; choosing it
+replaces the editor's current nodes and edges with the optimized graph
+so that you can inspect it, save it, run a performance test on it, or
+export it.
+
+## Variant names and devices
+
+When you start an `optimize` job, ViPPET inspects the **name** of the
+selected variant and decides whether to restrict the optimizer to a
+single OpenVINO device. The matching is **case-insensitive**.
+
+| Variant name (case-insensitive) | Optimizer search scope                           |
+|---------------------------------|--------------------------------------------------|
+| `CPU`                           | Restricted to `["CPU"]`                          |
+| `GPU`                           | Restricted to `["GPU"]`                          |
+| `NPU`                           | Restricted to `["NPU"]`                          |
+| Any other name                  | Default scope (all devices detected by OpenVINO) |
+
+Internally, ViPPET calls `DLSOptimizer.set_allowed_devices()` exactly
+once with the resolved list before `optimize_for_fps()` is invoked.
+For non-matching variant names the call is skipped and the optimizer
+keeps its default behavior, meaning every `gvadetect` / `gvaclassify`
+element in the pipeline may be moved to any device that OpenVINO
+detected at startup (CPU, integrated and discrete GPUs, NPU).
+
+Practical consequences:
+
+- To benchmark a specific device, name the variant exactly `CPU`,
+  `GPU`, or `NPU` (case does not matter). The optimizer will not move
+  inference to any other device.
+- To let DLS Optimizer pick the best assignment across all available
+  devices, use any other name (for example, `default` or `mixed`).
+- The variant name only affects the **search scope**. It does not
+  change how the input pipeline is read; if the input graph already
+  pins `gvadetect` to `device=GPU` and the variant is named `CPU`,
+  the optimizer is allowed to move it to CPU.
+
+## Job lifecycle and result payload
+
+Every optimization job is tracked by a job id and has the following
+state machine:
+
+| State       | Meaning                                                                                                                    |
+|-------------|----------------------------------------------------------------------------------------------------------------------------|
+| `RUNNING`   | The job is queued or executing. Created immediately when you submit an optimization request.                               |
+| `COMPLETED` | The optimizer finished successfully. An optimized pipeline string and both graph views are stored on the job.              |
+| `FAILED`    | The job ended without producing a usable result. The `details` field contains a human-readable error or cancellation note. |
+
+A cancelled job is always reported as `FAILED` because partial
+optimization results are not reliable.
+
+You can poll the status through:
+
+- `GET /api/v1/jobs/optimization/{job_id}/status` — full status,
+- `GET /api/v1/jobs/optimization/{job_id}` — short summary.
+
+For a successful job, ViPPET stores and returns:
+
+- `original_pipeline_graph` and `original_pipeline_graph_simple` —
+  the variant graph you submitted, in both advanced and simple views.
+- `original_pipeline_description` — the GStreamer pipeline string
+  that was actually sent to the optimizer.
+- `optimized_pipeline_description` — the GStreamer pipeline string
+  returned by the optimizer.
+- `optimized_pipeline_graph` and `optimized_pipeline_graph_simple` —
+  the optimized graph, in both advanced and simple views.
+- `total_fps` — measured total FPS of the optimized pipeline.
+- `start_time` / `end_time` — UNIX timestamps in milliseconds.
+- `details` — list of status messages (success message on completion
+  or error/cancellation notes on failure).
+
+The two graph views let the UI display both a clean overview of the
+optimized pipeline and the full element-level detail used by advanced
+users.

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/use-vippet.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/use-vippet.md
@@ -31,6 +31,7 @@ You can also adjust element parameters and prepare variants for testing.
 Related article:
 
 - [Configure Pipeline](./how-to-guides/configure-pipelines.md)
+- [Optimize Pipelines](./how-to-guides/optimize-pipelines.md)
 - [How To Use Gvapython Scripts](./how-to-guides/use-gvapython-scripts.md)
 
 ## Performance
@@ -97,6 +98,7 @@ Related article:
 ./how-to-guides/performance-testing
 ./how-to-guides/density-testing.md
 ./how-to-guides/use-cameras
+./how-to-guides/optimize-pipelines
 ./how-to-guides/use-video-generator
 ./how-to-guides/use-gvapython-scripts
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/PipelineActionsMenu.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipeline-editor/PipelineActionsMenu.tsx
@@ -260,7 +260,7 @@ export const PipelineActionsMenu = ({
       toast.info("Validating pipeline...");
 
       const validationStatus = await executeValidation({
-        pipelineValidationInput: {
+        pipelineValidation: {
           pipeline_graph: pipelineGraph,
         },
       });

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipelines/CreatePipelineDialog.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/pipelines/CreatePipelineDialog.tsx
@@ -206,7 +206,7 @@ export const CreatePipelineDialog = ({
 
       // Step 2: Validate pipeline graph
       await validatePipeline({
-        pipelineValidationInput: {
+        pipelineValidation: {
           pipeline_graph: graphResponse.pipeline_graph,
         },
       });

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/optimization_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/optimization_manager.py
@@ -17,6 +17,12 @@ from internal_types import (
 DEFAULT_SEARCH_DURATION = 300  # seconds
 DEFAULT_SAMPLE_DURATION = 10  # seconds
 
+# Variant names (case-insensitive) that map directly to a single OpenVINO
+# device. When a variant has one of these names, the optimizer search scope
+# is restricted to that device via DLSOptimizer.set_allowed_devices().
+# Any other variant name keeps the optimizer's default (all devices).
+DEVICE_VARIANT_NAMES: frozenset[str] = frozenset({"CPU", "GPU", "NPU"})
+
 logger = logging.getLogger("optimization_manager")
 
 
@@ -82,7 +88,11 @@ class OptimizationRunner:
         )
 
     def run_optimization(
-        self, pipeline_description: str, search_duration: int, sample_duration: int
+        self,
+        pipeline_description: str,
+        search_duration: int,
+        sample_duration: int,
+        allowed_devices: list[str] | None = None,
     ) -> PipelineOptimizationResult:
         """
         Run the full optimization process on the provided GStreamer pipeline string.
@@ -94,6 +104,9 @@ class OptimizationRunner:
             pipeline_description: Original GStreamer pipeline string to optimize.
             search_duration: Duration in seconds for the optimization search phase.
             sample_duration: Duration in seconds for measuring each configuration.
+            allowed_devices: Optional list of device strings (e.g. ["CPU"]) used to
+                restrict the optimizer's device search scope. When None, the
+                optimizer keeps its default scope (all detected devices).
 
         Returns:
             PipelineOptimizationResult: Result containing the optimized GStreamer
@@ -105,6 +118,22 @@ class OptimizationRunner:
 
         opt = optimizer.DLSOptimizer()
         opt.set_sample_duration(sample_duration)
+
+        # Restrict the device search scope only when an explicit list is
+        # provided. Calling set_allowed_devices with None would override the
+        # default behavior, which is undesirable.
+        if allowed_devices is not None:
+            opt.set_allowed_devices(allowed_devices)
+
+        # Log the exact values that are about to be forwarded to
+        # DLSOptimizer so the search time budget can be verified end-to-end
+        # in the application log.
+        self.logger.info(
+            f"Calling DLSOptimizer.optimize_for_fps with "
+            f"search_duration={search_duration}s, "
+            f"sample_duration={sample_duration}s, "
+            f"allowed_devices={allowed_devices}"
+        )
 
         optimized_pipeline, total_fps = opt.optimize_for_fps(
             pipeline_description, search_duration=search_duration
@@ -171,6 +200,30 @@ class OptimizationManager:
         """
         return uuid.uuid1().hex
 
+    @staticmethod
+    def _resolve_allowed_devices(variant_name: str) -> list[str] | None:
+        """
+        Map a variant name to the optimizer's allowed device list.
+
+        The match is case-insensitive. Only the names "CPU", "GPU" and "NPU"
+        are recognized as device names. Any other variant name returns None,
+        meaning the optimizer should keep its default device search scope
+        (all detected devices).
+
+        Args:
+            variant_name: Name of the variant being optimized.
+
+        Returns:
+            A single-element list with the device string (e.g. ["CPU"]) when
+            the variant name matches a known device, otherwise None.
+        """
+        if not variant_name:
+            return None
+        normalized = variant_name.strip().upper()
+        if normalized in DEVICE_VARIANT_NAMES:
+            return [normalized]
+        return None
+
     def run_optimization(
         self,
         variant: InternalVariant,
@@ -185,6 +238,10 @@ class OptimizationManager:
         * converts the pipeline graph to a GStreamer pipeline string,
         * creates a new :class:`InternalOptimizationJobStatus` with RUNNING state,
         * spawns a background thread that executes the optimization.
+
+        The variant name is also forwarded to the background worker so the
+        optimizer can restrict its device search scope when the name matches
+        a known device (CPU/GPU/NPU).
 
         Args:
             variant: InternalVariant with Graph objects to optimize.
@@ -213,10 +270,12 @@ class OptimizationManager:
         with self._jobs_lock:
             self.jobs[job_id] = job
 
-        # Start execution in background thread
+        # Start execution in background thread. The variant name is passed
+        # down so _execute_optimization can map it to an allowed device list
+        # for the optimizer (only relevant for full OPTIMIZE jobs).
         thread = threading.Thread(
             target=self._execute_optimization,
-            args=(job_id, pipeline_description, optimization_request),
+            args=(job_id, pipeline_description, optimization_request, variant.name),
             daemon=True,
         )
         thread.start()
@@ -294,6 +353,7 @@ class OptimizationManager:
         job_id: str,
         pipeline_description: str,
         optimization_request: InternalPipelineRequestOptimize,
+        variant_name: str = "",
     ) -> None:
         """
         Execute the optimization process in a background thread.
@@ -301,6 +361,12 @@ class OptimizationManager:
         The method chooses between preprocessing or full optimization,
         delegates work to :class:`OptimizationRunner` and then updates
         the corresponding :class:`InternalOptimizationJobStatus` accordingly.
+
+        For full OPTIMIZE jobs, the variant name is used to restrict the
+        optimizer's device search scope: variant names equal (case-insensitive)
+        to "CPU", "GPU" or "NPU" map to a single-device allowed list. Any
+        other variant name keeps the optimizer's default search scope.
+        The PREPROCESS type is not affected by this mapping.
 
         After successful optimization, both advanced and simple views
         are generated from the optimized GStreamer pipeline string as
@@ -318,6 +384,8 @@ class OptimizationManager:
             job_id: Unique identifier of the optimization job.
             pipeline_description: GStreamer pipeline string to optimize.
             optimization_request: Internal optimization parameters and type.
+            variant_name: Name of the variant being optimized. Used to map
+                to an allowed device list for the OPTIMIZE type.
 
         Returns:
             None (updates job status in place via self.jobs[job_id])
@@ -358,14 +426,37 @@ class OptimizationManager:
                 )
             else:  # InternalOptimizationType.OPTIMIZE
                 params = optimization_request.parameters or {}
+                # Map the variant name to a device allow-list. Only "CPU",
+                # "GPU" and "NPU" (case-insensitive) are recognized as
+                # device names; other names keep the default search scope.
+                allowed_devices = self._resolve_allowed_devices(variant_name)
+                if allowed_devices is not None:
+                    self.logger.info(
+                        f"Restricting optimizer device search to {allowed_devices} "
+                        f"for job {job_id} (variant name: {variant_name!r})"
+                    )
+                # Resolve effective values once so they can be both logged
+                # and forwarded to the runner. This makes it easy to verify
+                # in the logs that the values from the request (or defaults)
+                # actually reach DLSOptimizer.
+                effective_search_duration = params.get(
+                    "search_duration", DEFAULT_SEARCH_DURATION
+                )
+                effective_sample_duration = params.get(
+                    "sample_duration", DEFAULT_SAMPLE_DURATION
+                )
+                self.logger.info(
+                    f"Starting DLSOptimizer for job {job_id} with "
+                    f"search_duration={effective_search_duration}s, "
+                    f"sample_duration={effective_sample_duration}s, "
+                    f"allowed_devices={allowed_devices} "
+                    f"(raw parameters={params!r})"
+                )
                 results = runner.run_optimization(
                     pipeline_description=pipeline_description,
-                    search_duration=params.get(
-                        "search_duration", DEFAULT_SEARCH_DURATION
-                    ),
-                    sample_duration=params.get(
-                        "sample_duration", DEFAULT_SAMPLE_DURATION
-                    ),
+                    search_duration=effective_search_duration,
+                    sample_duration=effective_sample_duration,
+                    allowed_devices=allowed_devices,
                 )
 
             # Update job with results

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_pipeline_optimize_flow.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_pipeline_optimize_flow.py
@@ -16,18 +16,31 @@ logger = logging.getLogger(__name__)
 
 
 PIPELINE_ID = "license-plate-recognition"
-PIPELINE_VARIANT = "cpu"
 
+# Functional cases cover both:
+#   * preprocess and optimize request types,
+#   * a device-named variant ("cpu" -> optimizer search restricted to CPU)
+#     and a non-device variant ("gpu_npu" -> optimizer keeps default scope).
 OPTIMIZATION_CASES = [
     (
-        "preprocess",
+        "preprocess-cpu-variant",
+        "cpu",
         {
             "type": "preprocess",
             "parameters": {"search_duration": 10, "sample_duration": 3},
         },
     ),
     (
-        "optimize",
+        "optimize-cpu-variant",
+        "cpu",
+        {
+            "type": "optimize",
+            "parameters": {"search_duration": 10, "sample_duration": 3},
+        },
+    ),
+    (
+        "optimize-non-device-variant",
+        "gpu_npu",
         {
             "type": "optimize",
             "parameters": {"search_duration": 10, "sample_duration": 3},
@@ -38,15 +51,22 @@ OPTIMIZATION_CASES = [
 
 @pytest.mark.full
 @pytest.mark.parametrize(
-    "case_id,payload", OPTIMIZATION_CASES, ids=[c[0] for c in OPTIMIZATION_CASES]
+    "case_id,variant_id,payload",
+    OPTIMIZATION_CASES,
+    ids=[c[0] for c in OPTIMIZATION_CASES],
 )
 def test_pipeline_optimize_flow(
     http_client: requests.Session,
     case_id: str,
+    variant_id: str,
     payload: JsonDict,
 ) -> None:
-    logger.info("Running pipeline optimize flow case '%s'", case_id)
-    job_id = start_optimization_job(http_client, PIPELINE_ID, PIPELINE_VARIANT, payload)
+    logger.info(
+        "Running pipeline optimize flow case '%s' on variant '%s'",
+        case_id,
+        variant_id,
+    )
+    job_id = start_optimization_job(http_client, PIPELINE_ID, variant_id, payload)
     status_url = f"{BASE_URL}/jobs/optimization/{job_id}/status"
     final_status = wait_for_job_completion(
         http_client,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/optimization_manager_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/optimization_manager_test.py
@@ -671,7 +671,175 @@ class TestOptimizationManager(unittest.TestCase):
             pipeline_description="filesrc ! decodebin3 ! sink",
             search_duration=42,
             sample_duration=7,
+            allowed_devices=None,
         )
+
+    # ------------------------------------------------------------------
+    # Variant-name -> allowed devices mapping
+    # ------------------------------------------------------------------
+
+    def _run_optimize_with_variant_name(
+        self, mock_runner_cls, mock_graph_cls, variant_name: str
+    ) -> MagicMock:
+        """
+        Helper to run _execute_optimization with InternalOptimizationType.OPTIMIZE
+        and a given variant_name. Returns the mocked runner so the caller can
+        inspect run_optimization call arguments.
+        """
+        manager = OptimizationManager()
+        graph = _create_test_graph()
+        request = self._make_internal_request(
+            InternalOptimizationType.OPTIMIZE,
+            parameters={"search_duration": 10, "sample_duration": 2},
+        )
+
+        job_id = f"job-variant-{variant_name}"
+        job = InternalOptimizationJobStatus(
+            id=job_id,
+            original_pipeline_graph=graph,
+            original_pipeline_graph_simple=graph,
+            original_pipeline_description="filesrc ! decodebin3 ! sink",
+            request=request,
+            state=InternalOptimizationJobState.RUNNING,
+            start_time=int(time.time() * 1000),
+        )
+        manager.jobs[job_id] = job
+
+        mock_runner = MagicMock()
+        mock_result = MagicMock()
+        mock_result.optimized_pipeline_description = "optimized ! sink"
+        mock_result.total_fps = 10.0
+        mock_runner.run_optimization.return_value = mock_result
+        mock_runner.is_cancelled.return_value = False
+        mock_runner_cls.return_value = mock_runner
+
+        mock_optimized_graph = MagicMock(spec=Graph)
+        mock_simple_graph = MagicMock(spec=Graph)
+        mock_optimized_graph.to_simple_view.return_value = mock_simple_graph
+        mock_graph_cls.from_pipeline_description.return_value = mock_optimized_graph
+
+        manager._execute_optimization(
+            job_id,
+            pipeline_description="filesrc ! decodebin3 ! sink",
+            optimization_request=request,
+            variant_name=variant_name,
+        )
+
+        return mock_runner
+
+    @patch("managers.optimization_manager.Graph")
+    @patch("managers.optimization_manager.OptimizationRunner")
+    def test_execute_optimization_cpu_variant_passes_cpu_allowed_devices(
+        self, mock_runner_cls, mock_graph_cls
+    ):
+        """Variant name "CPU" (case-insensitive) should pass allowed_devices=["CPU"]."""
+        for name in ("CPU", "cpu", "Cpu"):
+            mock_runner_cls.reset_mock()
+            mock_graph_cls.reset_mock()
+            mock_runner = self._run_optimize_with_variant_name(
+                mock_runner_cls, mock_graph_cls, name
+            )
+            mock_runner.run_optimization.assert_called_once()
+            kwargs = mock_runner.run_optimization.call_args.kwargs
+            self.assertEqual(kwargs.get("allowed_devices"), ["CPU"])
+
+    @patch("managers.optimization_manager.Graph")
+    @patch("managers.optimization_manager.OptimizationRunner")
+    def test_execute_optimization_gpu_variant_passes_gpu_allowed_devices(
+        self, mock_runner_cls, mock_graph_cls
+    ):
+        """Variant name "GPU" (case-insensitive) should pass allowed_devices=["GPU"]."""
+        mock_runner = self._run_optimize_with_variant_name(
+            mock_runner_cls, mock_graph_cls, "gpu"
+        )
+        mock_runner.run_optimization.assert_called_once()
+        kwargs = mock_runner.run_optimization.call_args.kwargs
+        self.assertEqual(kwargs.get("allowed_devices"), ["GPU"])
+
+    @patch("managers.optimization_manager.Graph")
+    @patch("managers.optimization_manager.OptimizationRunner")
+    def test_execute_optimization_npu_variant_passes_npu_allowed_devices(
+        self, mock_runner_cls, mock_graph_cls
+    ):
+        """Variant name "NPU" (case-insensitive) should pass allowed_devices=["NPU"]."""
+        mock_runner = self._run_optimize_with_variant_name(
+            mock_runner_cls, mock_graph_cls, "NPU"
+        )
+        mock_runner.run_optimization.assert_called_once()
+        kwargs = mock_runner.run_optimization.call_args.kwargs
+        self.assertEqual(kwargs.get("allowed_devices"), ["NPU"])
+
+    @patch("managers.optimization_manager.Graph")
+    @patch("managers.optimization_manager.OptimizationRunner")
+    def test_execute_optimization_other_variant_passes_none_allowed_devices(
+        self, mock_runner_cls, mock_graph_cls
+    ):
+        """Any non-device variant name should leave allowed_devices as None."""
+        for name in ("my-pipeline", "default", "", "CPU+GPU"):
+            mock_runner_cls.reset_mock()
+            mock_graph_cls.reset_mock()
+            mock_runner = self._run_optimize_with_variant_name(
+                mock_runner_cls, mock_graph_cls, name
+            )
+            mock_runner.run_optimization.assert_called_once()
+            kwargs = mock_runner.run_optimization.call_args.kwargs
+            self.assertIsNone(kwargs.get("allowed_devices"))
+
+    @patch("managers.optimization_manager.Graph")
+    @patch("managers.optimization_manager.OptimizationRunner")
+    def test_execute_optimization_preprocess_ignores_variant_name(
+        self, mock_runner_cls, mock_graph_cls
+    ):
+        """PREPROCESS type must not call run_optimization and must not pass allowed_devices."""
+        manager = OptimizationManager()
+        graph = _create_test_graph()
+        request = self._make_internal_request(InternalOptimizationType.PREPROCESS)
+
+        job_id = "job-preprocess-variant"
+        job = InternalOptimizationJobStatus(
+            id=job_id,
+            original_pipeline_graph=graph,
+            original_pipeline_graph_simple=graph,
+            original_pipeline_description="filesrc ! decodebin3 ! sink",
+            request=request,
+            state=InternalOptimizationJobState.RUNNING,
+            start_time=int(time.time() * 1000),
+        )
+        manager.jobs[job_id] = job
+
+        mock_runner = MagicMock()
+        mock_result = MagicMock()
+        mock_result.optimized_pipeline_description = "filesrc ! decodebin3 ! sink"
+        mock_result.total_fps = None
+        mock_runner.run_preprocessing.return_value = mock_result
+        mock_runner.is_cancelled.return_value = False
+        mock_runner_cls.return_value = mock_runner
+
+        mock_optimized_graph = MagicMock(spec=Graph)
+        mock_simple_graph = MagicMock(spec=Graph)
+        mock_optimized_graph.to_simple_view.return_value = mock_simple_graph
+        mock_graph_cls.from_pipeline_description.return_value = mock_optimized_graph
+
+        manager._execute_optimization(
+            job_id,
+            pipeline_description="filesrc ! decodebin3 ! sink",
+            optimization_request=request,
+            variant_name="CPU",
+        )
+
+        # PREPROCESS path must not call run_optimization at all
+        mock_runner.run_optimization.assert_not_called()
+        mock_runner.run_preprocessing.assert_called_once()
+
+    def test_resolve_allowed_devices_mapping(self):
+        """_resolve_allowed_devices should map known device names case-insensitively."""
+        self.assertEqual(OptimizationManager._resolve_allowed_devices("CPU"), ["CPU"])
+        self.assertEqual(OptimizationManager._resolve_allowed_devices("cpu"), ["CPU"])
+        self.assertEqual(OptimizationManager._resolve_allowed_devices("Gpu"), ["GPU"])
+        self.assertEqual(OptimizationManager._resolve_allowed_devices(" npu "), ["NPU"])
+        self.assertIsNone(OptimizationManager._resolve_allowed_devices(""))
+        self.assertIsNone(OptimizationManager._resolve_allowed_devices("default"))
+        self.assertIsNone(OptimizationManager._resolve_allowed_devices("my-pipeline"))
 
     @patch("managers.optimization_manager.OptimizationRunner")
     def test_execute_optimization_cancelled_job_marks_failed(self, mock_runner_cls):
@@ -799,13 +967,24 @@ class TestOptimizationRunner(unittest.TestCase):
         self.fake_optimizer.preprocess_pipeline = lambda pipeline: pipeline.upper()
 
         class FakeDLSOptimizer:
+            def __init__(self) -> None:
+                # Track set_allowed_devices calls so tests can assert them
+                self.allowed_devices_calls: list[list[str]] = []
+
             def set_sample_duration(self, duration: int) -> None:
                 pass
+
+            def set_allowed_devices(self, devices: list[str]) -> None:
+                # Record the call for later assertions
+                self.allowed_devices_calls.append(list(devices))
 
             def optimize_for_fps(self, pipeline: str, search_duration: int = 300):
                 return (pipeline + " ! OPTIMIZED", 99.9)
 
-        self.fake_optimizer.DLSOptimizer = FakeDLSOptimizer
+        self.FakeDLSOptimizer = FakeDLSOptimizer
+        # Single shared instance so tests can inspect it after the run
+        self._fake_opt_instance = FakeDLSOptimizer()
+        self.fake_optimizer.DLSOptimizer = lambda: self._fake_opt_instance
 
         self.optimizer_patcher = patch.dict(
             "sys.modules", {"optimizer": self.fake_optimizer}
@@ -830,6 +1009,30 @@ class TestOptimizationRunner(unittest.TestCase):
 
         self.assertEqual(result.optimized_pipeline_description, "pipeline ! OPTIMIZED")
         self.assertEqual(result.total_fps, 99.9)
+        # No allowed_devices argument -> set_allowed_devices must NOT be called
+        self.assertEqual(self._fake_opt_instance.allowed_devices_calls, [])
+
+    def test_run_optimization_forwards_allowed_devices(self):
+        """When allowed_devices is provided, set_allowed_devices must be called once with that list."""
+        runner = OptimizationRunner()
+        runner.run_optimization(
+            "pipeline",
+            search_duration=10,
+            sample_duration=2,
+            allowed_devices=["CPU"],
+        )
+        self.assertEqual(self._fake_opt_instance.allowed_devices_calls, [["CPU"]])
+
+    def test_run_optimization_does_not_call_set_allowed_devices_when_none(self):
+        """When allowed_devices is None, set_allowed_devices must not be called."""
+        runner = OptimizationRunner()
+        runner.run_optimization(
+            "pipeline",
+            search_duration=10,
+            sample_duration=2,
+            allowed_devices=None,
+        )
+        self.assertEqual(self._fake_opt_instance.allowed_devices_calls, [])
 
     def test_cancel_and_is_cancelled(self):
         runner = OptimizationRunner()

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/pipeline_runner_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/pipeline_runner_test.py
@@ -1202,7 +1202,7 @@ class TestLatencyTracerIntervalParser(unittest.TestCase):
 class TestLatencyMetricsPush(unittest.TestCase):
     """Tests for the live + final latency push to metrics-manager.
 
-    Covers the runner behaviour introduced by ITEP-89980:
+    Covers the following runner behavior:
     ``_push_latency_sample`` fires on every parsed interval line, and
     ``_push_final_latency_metrics`` re-pushes the last sample per
     stream once the subprocess exits. The shared metrics-push


### PR DESCRIPTION
## PR description

Wires the variant name into the optimizer so that variants named `CPU`, `GPU` or `NPU` (case-insensitive) restrict the DLS Optimizer search scope to that single device, while any other variant name keeps the optimizer's default scope (all detected devices). Adds matching unit, functional and documentation coverage, and fixes two UI call sites that were still using the old `pipelineValidationInput` body field.

### Backend

- `vippet/managers/optimization_manager.py`
  - Added `DEVICE_VARIANT_NAMES = {"CPU", "GPU", "NPU"}` and `OptimizationManager._resolve_allowed_devices()` that maps a variant name to `["CPU"]` / `["GPU"]` / `["NPU"]` (case-insensitive, with whitespace stripping) or to `None` for any other name.
  - `OptimizationManager.run_optimization()` now forwards `variant.name` to the background worker; `_execute_optimization()` accepts `variant_name` and resolves the allowed-device list for `OPTIMIZE` jobs only. `PREPROCESS` jobs are unaffected.
  - `OptimizationRunner.run_optimization()` accepts an optional `allowed_devices: list[str] | None` parameter. When provided, it calls `DLSOptimizer.set_allowed_devices(allowed_devices)` exactly once before `optimize_for_fps()`. When `None`, the call is skipped to preserve the optimizer's default behavior.
  - Added INFO-level logs around the optimizer call that print the effective `search_duration`, `sample_duration`, `allowed_devices` and the raw request `parameters`, so the values reaching `DLSOptimizer` can be verified end-to-end in the application log.

### UI

- `ui/src/features/pipeline-editor/PipelineActionsMenu.tsx` and `ui/src/features/pipelines/CreatePipelineDialog.tsx`
  - Replaced the obsolete `pipelineValidationInput` body field with `pipelineValidation` to match the current generated API client. Without this fix the validation step of the optimize flow (and of pipeline creation) fails on the client side.

### Tests

- `vippet/tests/unit/managers_tests/optimization_manager_test.py`
  - Added unit tests covering the variant-name to `allowed_devices` mapping for `CPU` / `GPU` / `NPU` (including case variants), non-device names, the empty name, and a direct test of `_resolve_allowed_devices()`.
  - Added a test that confirms the `PREPROCESS` path never calls `run_optimization()` and never forwards an allowed-device list.
  - Extended the `OptimizationRunner` test fixture so it can assert when `DLSOptimizer.set_allowed_devices()` is or is not called, and added two tests: one that verifies the call is forwarded with the expected list, and one that verifies it is not called when `allowed_devices=None`.
- `vippet/tests/functional/test_pipeline_optimize_flow.py`
  - The case list now carries an explicit `variant_id` per case and covers three flows on the `license-plate-recognition` pipeline: `preprocess` on the `cpu` variant, `optimize` on the `cpu` variant (device-named) and `optimize` on a non-device variant (`gpu_npu`) that exercises the default device scope.
- `vippet/tests/unit/pipeline_runner_test.py`
  - Replaced an internal-issue reference in a docstring with a neutral description of the behavior under test.

### Documentation

- New `docs/user-guide/how-to-guides/optimize-pipelines.md` that describes the current behavior of the optimizer in ViPPET: the editable-variant-in-advanced-mode prerequisite (and the three ways to obtain one from a predefined variant), the two-step validate-then-optimize flow, what DLS Optimizer does internally (pre-processing rewrite, baseline with detection sanity check, configuration search, best-FPS selection), the CPU/GPU/NPU variant-name mapping, and the job lifecycle and result payload. The page intentionally does not describe `search_duration` / `sample_duration` as user-tunable parameters, because they are fixed in this stack.
- `docs/user-guide/use-vippet.md` links the new page from both the "Pipelines" related-articles section and the how-to-guides toctree.

### Scope

No API schema changes and no changes to existing public types. Behavior change is limited to the optimizer search scope when the variant name matches `CPU` / `GPU` / `NPU`. Backwards compatible for variants with any other name.

