### PR TITLE
[ViPPET] Add clean-model-download target to Makefile

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
@@ -143,6 +143,10 @@ stop: ## Stop the docker compose services
 clean: ## Clean all build artifacts
 	rm -rf shared/models/output/ shared/model-download/ shared/onvif/onvif_cameras.json shared/videos/input shared/videos/output shared/videos/video-generator
 
+clean-model-download: ## Clean only model-download artifacts
+	docker run --rm -v shared/model-download/:/mnt/model-download/ python:3.12-slim sh -c 'rm -r /mnt/model-download/cache/ /mnt/model-download/venv-*/'
+	rm -r shared/model-download/
+
 clean-output-videos: ## Clean only output videos
 	rm -rf shared/videos/output/*
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
@@ -140,8 +140,8 @@ shell-videogenerator: ## Open shell in videogenerator container
 stop: ## Stop the docker compose services
 	docker compose down model-download metrics-manager videogenerator mediamtx vippet-ui vippet onvif-discovery
 
-clean: ## Clean all build artifacts
-	rm -rf shared/models/output/ shared/model-download/ shared/onvif/onvif_cameras.json shared/videos/input shared/videos/output shared/videos/video-generator
+clean: clean-model-download clean-output-videos ## Clean all build artifacts
+	rm -rf shared/models/output/ shared/onvif/onvif_cameras.json shared/videos/input shared/videos/video-generator
 
 clean-model-download: ## Clean only model-download artifacts
 	docker run --rm -v shared/model-download/:/mnt/model-download/ python:3.12-slim sh -c 'rm -r /mnt/model-download/cache/ /mnt/model-download/venv-*/'


### PR DESCRIPTION
### Description

This pull request refactors and expands the cleaning commands in the `Makefile` for the `visual-pipeline-and-platform-evaluation-tool` project. The changes modularize the cleanup process, allowing for more targeted removal of build artifacts, and introduce a new command to specifically clean model-download artifacts.

**Makefile cleanup improvements:**

* The `clean` target now delegates to new `clean-model-download` and `clean-output-videos` targets, making it easier to clean specific types of artifacts.
* Added a `clean-model-download` target that removes model-download cache and virtual environments using a Dockerized Python environment, then deletes the `shared/model-download/` directory.
* The `clean-output-videos` target is now a standalone command for removing only the output videos, improving granularity of cleanup operations.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.
