### PR TITLE
chatqna-core: Enforce version-pinned defaults for backend and UI images

### DIFF
--- a/sample-applications/chat-question-and-answer-core/docker/compose.yaml
+++ b/sample-applications/chat-question-and-answer-core/docker/compose.yaml
@@ -7,7 +7,6 @@ x-nginx-common: &nginx-common
     - ../nginx_config/nginx.conf:/etc/nginx/nginx.conf:ro
 
 x-chatqna-core-common: &chatqna-core-common
-  image: ${REGISTRY:-}chatqna:${BACKEND_TAG:-latest}
   build:
     context: ../
     dockerfile: docker/Dockerfile
@@ -53,12 +52,14 @@ services:
     <<: *chatqna-core-common
     profiles:
       - OPENVINO
+    image: ${REGISTRY:-}chatqna:${BACKEND_TAG:-core_1.3.3}
     container_name: chatqna-core-ov-cpu
 
   chatqna-core-ov-gpu:
     <<: *chatqna-core-common
     profiles:
       - OPENVINO-GPU
+    image: ${REGISTRY:-}chatqna:${BACKEND_TAG:-core_gpu_1.3.3}
     container_name: chatqna-core-ov-gpu
     build:
       context: ../
@@ -75,6 +76,7 @@ services:
     <<: *chatqna-core-common
     profiles:
       - OLLAMA
+    image: ${REGISTRY:-}chatqna:${BACKEND_TAG:-core_ollama_1.3.3}
     container_name: chatqna-core-ollama
     build:
       context: ../
@@ -85,7 +87,7 @@ services:
       no_proxy: ${no_proxy},127.0.0.1
 
   chatqna-core-ui:
-    image: ${REGISTRY:-}chatqna-ui:${UI_TAG:-latest}
+    image: ${REGISTRY:-}chatqna-ui:${UI_TAG:-core_1.3.3}
     container_name: chatqna-core-ui
     build:
       context: ../ui/


### PR DESCRIPTION
### Description

As chatqna-core and chatqna modular shared the same image name. Tag 'latest' has been assigned for chatqna modular.Avoid fallback to `latest` when env vars are unset to ensure reproducible deployments.

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

