### PR TITLE
[ViPPET] Model management test coverage + graph.py uploaded-model fallback + pipeline-case model gating

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/_assets/vippet.json
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/_assets/vippet.json
@@ -1325,7 +1325,7 @@
           "models"
         ],
         "summary": "Start one or more model download jobs",
-        "description": "# Start Model Downloads\n\nStart an asynchronous download job for each model in the request.\nEach entry of `names` is processed **independently** and produces\nits own per-model entry in the response map `jobs`. Names must be\ndeclared in `supported_models.yaml`; OMZ models are downloaded\nlocally by vippet-app because model-download has no OMZ plugin yet.\n\nEach accepted name spawns a background worker right away \u2014 the\nendpoint does **not** wait for any download to finish, so adding\nmore names does not delay the others.\n\n## Request Body\n\n- **`names`** *(required)* - Non-empty list of unique supported-model\n  names to install.\n\n## Response Body\n\nA `ModelDownloadJobResponse` whose `jobs` map is keyed by the\nrequested model name. Each value carries the per-model\n`job_id` / `status_code` / `message`.\n\n## Response Codes\n\n| Code | When |\n|------|------|\n| 202  | Every requested model accepted (`status_code=202` for all entries) |\n| 207  | Some accepted, some rejected (mixed `status_code` values) |\n| 400  | All requested models share the same client error (e.g. no `download_request`) |\n| 404  | All requested models are unknown |\n| 409  | All requested models are already installed or in progress |\n| 422  | Body validation failed (empty list, duplicate names, ...) |\n| 500  | Unexpected error |",
+        "description": "# Start Model Downloads\n\nStart an asynchronous download job for each model in the request.\nEach entry of `names` is processed **independently** and produces\nits own per-model entry in the response map `jobs`. Names must be\ndeclared in `supported_models.yaml`; OMZ models are downloaded\nlocally by vippet-app because model-download has no OMZ plugin yet.\n\nEach accepted name spawns a background worker right away \u2014 the\nendpoint does **not** wait for any download to finish, so adding\nmore names does not delay the others.\n\n## Request Body\n\n- **`names`** *(required)* - Non-empty list of unique supported-model\n  names to install.\n\n## Response Body\n\nA `ModelDownloadJobResponse` whose `jobs` map is keyed by the\nrequested model name. Each value carries the per-model\n`job_id` / `status_code` / `message`.\n\n## Response Codes\n\nThe envelope HTTP status is derived from the per-model\n`status_code` values via `_aggregate_status`:\n\n| Code | When |\n|------|------|\n| 202  | Every requested model accepted (`status_code=202` for all entries) |\n| 207  | At least one accepted **and** at least one rejected (mixed) |\n| 400  | All requested models rejected, **at least one** was `400` (no `download_request`). Takes precedence over 404 / 409. |\n| 404  | All requested models rejected with `404` only (unknown). Takes precedence over 409. |\n| 409  | All requested models rejected with `409` only (already installed / in progress). |\n| 422  | Body validation failed (empty list, duplicate names, ...) |\n| 500  | Unexpected error |\n\nPer-model outcomes are always available in `jobs[<name>].status_code`\nregardless of the envelope status.",
         "operationId": "start_model_download",
         "requestBody": {
           "content": {
@@ -1367,7 +1367,7 @@
             }
           },
           "400": {
-            "description": "All requested models were rejected with the same client error (e.g. missing `download_request`).",
+            "description": "All requested models were rejected and at least one was a `400` (missing `download_request`). Takes precedence over `404`/`409` in the envelope status.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1377,7 +1377,7 @@
             }
           },
           "404": {
-            "description": "All requested models are unknown (not present in `supported_models.yaml`).",
+            "description": "All requested models were rejected with `404` only (unknown / not in `supported_models.yaml`). Takes precedence over `409` in the envelope status.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1387,7 +1387,7 @@
             }
           },
           "409": {
-            "description": "All requested models are already installed or have a download job already running.",
+            "description": "All requested models were rejected with `409` only (already installed or a download job already running).",
             "content": {
               "application/json": {
                 "schema": {

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/routes/models.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/routes/models.py
@@ -218,22 +218,24 @@ async def upload_model(
         },
         400: {
             "description": (
-                "All requested models were rejected with the same "
-                "client error (e.g. missing `download_request`)."
+                "All requested models were rejected and at least one was "
+                "a `400` (missing `download_request`). Takes precedence "
+                "over `404`/`409` in the envelope status."
             ),
             "model": schemas.ModelDownloadJobResponse,
         },
         404: {
             "description": (
-                "All requested models are unknown (not present in "
-                "`supported_models.yaml`)."
+                "All requested models were rejected with `404` only "
+                "(unknown / not in `supported_models.yaml`). Takes "
+                "precedence over `409` in the envelope status."
             ),
             "model": schemas.ModelDownloadJobResponse,
         },
         409: {
             "description": (
-                "All requested models are already installed or have a "
-                "download job already running."
+                "All requested models were rejected with `409` only "
+                "(already installed or a download job already running)."
             ),
             "model": schemas.ModelDownloadJobResponse,
         },
@@ -274,15 +276,21 @@ async def start_model_download(body: schemas.ModelDownloadRequest):
 
     ## Response Codes
 
+    The envelope HTTP status is derived from the per-model
+    `status_code` values via `_aggregate_status`:
+
     | Code | When |
     |------|------|
     | 202  | Every requested model accepted (`status_code=202` for all entries) |
-    | 207  | Some accepted, some rejected (mixed `status_code` values) |
-    | 400  | All requested models share the same client error (e.g. no `download_request`) |
-    | 404  | All requested models are unknown |
-    | 409  | All requested models are already installed or in progress |
+    | 207  | At least one accepted **and** at least one rejected (mixed) |
+    | 400  | All requested models rejected, **at least one** was `400` (no `download_request`). Takes precedence over 404 / 409. |
+    | 404  | All requested models rejected with `404` only (unknown). Takes precedence over 409. |
+    | 409  | All requested models rejected with `409` only (already installed / in progress). |
     | 422  | Body validation failed (empty list, duplicate names, ...) |
     | 500  | Unexpected error |
+
+    Per-model outcomes are always available in `jobs[<name>].status_code`
+    regardless of the envelope status.
     """
     manager = ModelManager()
     try:

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
@@ -4079,6 +4079,19 @@ def _model_path_to_display_name(nodes: list[Node]) -> None:
             model_path, model_proc_path, installed_only=False
         )
 
+        # Fallback: uploaded (custom) models live in the ModelManager
+        # registry, not in supported_models.yaml. Without this, advanced
+        # graphs that reference an uploaded model would lose the
+        # display-name on ingestion and be rejected on conversion back
+        # to a runnable pipeline.
+        if model is None:
+            # Local import to avoid an import cycle with model_manager.
+            from managers.model_manager import ModelManager
+
+            model = ModelManager().find_uploaded_model_by_path(
+                model_path, model_proc_path
+            )
+
         if model is not None:
             # Canonical in-memory key is always ``model`` regardless of how
             # the source pipeline string named it (see NodeModelSpec).
@@ -4134,6 +4147,16 @@ def _model_display_name_to_path(nodes: list[Node]) -> None:
 
         # model handling
         model = SupportedModelsManager().find_installed_model_by_display_name(name)
+        if not model:
+            # Fallback: the display name may identify an uploaded (custom)
+            # model that is tracked by ModelManager rather than the YAML
+            # catalogue. Without this fallback the convert-to-advanced
+            # flow would reject any pipeline referencing an uploaded
+            # model, even though the UI happily lists it.
+            from managers.model_manager import ModelManager
+
+            model = ModelManager().find_installed_uploaded_model_by_display_name(name)
+
         if not model:
             raise ValueError(
                 f"Can't find model '{name}' for {node.type}. Choose an installed model or install it first."
@@ -4228,9 +4251,23 @@ def _validate_models_supported_on_devices(nodes: list[Node]) -> None:
             )
 
         if not SupportedModelsManager().is_model_supported_on_device(name, device):
-            raise ValueError(
-                f"Node {node.type}: model '{name}' is not supported on the '{device}' device"
-            )
+            # Uploaded (custom) models live in the ModelManager registry,
+            # not in supported_models.yaml. They carry no
+            # ``unsupported_devices`` metadata, so if the registry knows
+            # the display name we treat the model as supported on every
+            # device. Without this fallback convert-to-advanced would
+            # reject any graph that references an uploaded model.
+            from managers.model_manager import (
+                ModelManager,
+            )  # local import to avoid cycle
+
+            if (
+                ModelManager().find_installed_uploaded_model_by_display_name(name)
+                is None
+            ):
+                raise ValueError(
+                    f"Node {node.type}: model '{name}' is not supported on the '{device}' device"
+                )
 
         logger.debug(f"Model '{name}' is supported on the '{device}' device")
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/model_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/model_manager.py
@@ -182,6 +182,72 @@ class _InstalledModelRecord:
 
 
 # ----------------------------------------------------------------------
+# Adapter exposing uploaded models through the SupportedModel interface
+# ----------------------------------------------------------------------
+
+
+class _UploadedSupportedModel(SupportedModel):
+    """``SupportedModel`` view over an uploaded model registry record.
+
+    The registry stores absolute on-disk paths (e.g.
+    ``<MODELS_PATH>/custom_uploaded_models/<name>/``), while
+    ``SupportedModel`` normally joins relative ``model_path`` with
+    ``MODELS_PATH``. This adapter bypasses that join and additionally
+    resolves a single ``.xml`` artefact when the record points at a
+    directory, so the resulting ``model_path_full`` is directly usable
+    by GStreamer.
+
+    Uploaded models never carry a model-proc file (custom ZIPs only
+    contain ``.xml``/``.bin``), so ``model_proc_full`` stays empty.
+    """
+
+    def __init__(
+        self,
+        record: "_InstalledModelRecord",
+        precision: "InternalModelPrecision",
+    ) -> None:
+        # Initialise the base with a sentinel relative path; we override
+        # ``model_path_full`` below so the join with MODELS_PATH is moot.
+        super().__init__(
+            name=record.name,
+            display_name=record.display_name,
+            source=record.source.value,
+            model_type=(record.category.value if record.category else ""),
+            model_path=precision.model_path,
+            model_proc=None,
+            unsupported_devices=None,
+            precision=precision.precision or None,
+            default=False,
+            hub=record.source.value,
+            canonical_name=record.name,
+            canonical_display_name=record.display_name,
+        )
+        # Treat the registry path as absolute and resolve the actual
+        # ``.xml`` artefact when the record points at a directory.
+        absolute_path = precision.model_path
+        if os.path.isdir(absolute_path):
+            try:
+                xml_files = sorted(
+                    f for f in os.listdir(absolute_path) if f.endswith(".xml")
+                )
+            except OSError:
+                xml_files = []
+            if xml_files:
+                absolute_path = os.path.join(absolute_path, xml_files[0])
+        self.model_path_full = absolute_path
+        # Uploaded models never carry a model-proc.
+        self.model_proc_full = ""
+
+    def exists_on_disk(self) -> bool:  # pragma: no cover - thin wrapper
+        # Either the resolved ``.xml`` exists, or (genai-style) the
+        # registry path is a populated directory.
+        path = self.model_path_full
+        if os.path.isfile(path):
+            return True
+        return os.path.isdir(path)
+
+
+# ----------------------------------------------------------------------
 # Manager singleton
 # ----------------------------------------------------------------------
 
@@ -327,6 +393,84 @@ class ModelManager:
         with self._registry_lock:
             if self._registry.pop(model_name, None) is not None:
                 self._save_registry_locked()
+
+    # ------------------------------------------------------------------
+    # Public lookups for uploaded models (graph.py fallback)
+    # ------------------------------------------------------------------
+
+    def find_installed_uploaded_model_by_display_name(
+        self, display_name: str
+    ) -> SupportedModel | None:
+        """Return a ``SupportedModel`` view for an uploaded model.
+
+        Used by ``graph.py`` as a fallback when ``SupportedModelsManager``
+        does not know the display name. Uploaded models are registered
+        under ``self._registry`` and live outside the YAML catalogue.
+
+        Args:
+            display_name: Display name as shown in the UI dropdown.
+                Uploaded models use ``model_name`` as their display name.
+
+        Returns:
+            A ``_UploadedSupportedModel`` view of the first precision
+            entry, or ``None`` when no matching record exists or the
+            on-disk files are missing.
+        """
+        with self._registry_lock:
+            record = next(
+                (
+                    r
+                    for r in self._registry.values()
+                    if r.display_name == display_name or r.name == display_name
+                ),
+                None,
+            )
+        if record is None or not record.precisions:
+            return None
+        adapter = _UploadedSupportedModel(record, record.precisions[0])
+        if not adapter.exists_on_disk():
+            return None
+        return adapter
+
+    def find_uploaded_model_by_path(
+        self,
+        model_path: str,
+        model_proc_path: str | None = None,  # noqa: ARG002 - uploads have no model-proc
+    ) -> SupportedModel | None:
+        """Return a ``SupportedModel`` view for an uploaded model by path.
+
+        Mirrors ``SupportedModelsManager.find_model_by_model_and_proc_path``
+        for uploaded models. Matching prefers exact path equality and
+        falls back to filename + parent-dir equality so existing
+        pipelines referencing absolute paths can still be resolved.
+
+        Args:
+            model_path: Path written in the pipeline string. May be the
+                model directory or an ``.xml`` artefact inside it.
+            model_proc_path: Ignored. Uploaded models do not carry a
+                model-proc file (kept for signature symmetry with
+                ``SupportedModelsManager``).
+
+        Returns:
+            A ``_UploadedSupportedModel`` view of the matching record,
+            or ``None`` when no record matches.
+        """
+        normalized = os.path.normpath(model_path)
+        with self._registry_lock:
+            records = list(self._registry.values())
+        for record in records:
+            for precision in record.precisions:
+                registry_path = os.path.normpath(precision.model_path)
+                if registry_path == normalized:
+                    return _UploadedSupportedModel(record, precision)
+                # Allow the pipeline string to point at the resolved
+                # ``.xml`` artefact when the registry stores a directory.
+                if (
+                    os.path.isdir(registry_path)
+                    and os.path.dirname(normalized) == registry_path
+                ):
+                    return _UploadedSupportedModel(record, precision)
+        return None
 
     # ------------------------------------------------------------------
     # Helpers: type conversion

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/conftest.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/conftest.py
@@ -308,3 +308,106 @@ def make_tar_archive(sample_frame_bgr: "np.ndarray[Any, Any]"):
         return payload, archive_name or f"set_{ext}_{count}.{suffix}"
 
     return _make
+
+
+# --------------------------------------------------------------------------- #
+# Uploaded-model fixtures.
+#
+# The functional test suite assumes the underlying source models
+# (``face-detection-retail-0004`` and ``age-gender-recognition-retail-0013``)
+# are present on disk under ``shared/models/output/omz/.../FP16/``. The
+# download-side test (``test_models_download.py``) is responsible for
+# ensuring that, but - to keep these fixtures usable in isolation - we
+# skip whenever the FP16 artefacts are absent rather than fail.
+#
+# The upload itself is session-scoped: the API does not expose a DELETE
+# for models, so we deliberately leak the uploaded copies into the
+# shared volume (CI is expected to wipe the volume between runs). The
+# unique ``upload_run_id`` keeps re-runs from colliding with stale
+# entries left over from previous sessions.
+# --------------------------------------------------------------------------- #
+
+
+_UPLOAD_MODEL_SOURCES: dict[str, dict[str, str]] = {
+    "face-detection-retail-0004": {
+        "category": "detection",
+        "fp16_dir": "shared/models/output/omz/face-detection-retail-0004/FP16",
+    },
+    "age-gender-recognition-retail-0013": {
+        "category": "classification",
+        "fp16_dir": "shared/models/output/omz/age-gender-recognition-retail-0013/FP16",
+    },
+}
+
+
+def _build_model_zip(fp16_dir) -> bytes:
+    """Pack ``model.xml`` + ``model.bin`` into a flat zip.
+
+    The ``model-download`` microservice expects a flat archive
+    containing the OpenVINO IR pair. We deliberately do not include
+    a model-proc JSON: uploaded models never carry one (that is the
+    invariant ``graph.py`` and ``ModelManager`` rely on).
+    """
+    xml_files = sorted(fp16_dir.glob("*.xml"))
+    bin_files = sorted(fp16_dir.glob("*.bin"))
+    assert xml_files and bin_files, f"FP16 directory {fp16_dir} missing xml/bin pair"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(xml_files[0].name, xml_files[0].read_bytes())
+        zf.writestr(bin_files[0].name, bin_files[0].read_bytes())
+    return buf.getvalue()
+
+
+@pytest.fixture(scope="session")
+def uploaded_model_names(
+    http_client: requests.Session, upload_run_id: str
+) -> dict[str, str]:
+    """Upload custom copies of the two reference OMZ models.
+
+    Returns a mapping ``{source_model_name: uploaded_model_name}``. The
+    uploaded names carry the session ``upload_run_id`` so concurrent or
+    repeated runs do not collide.
+
+    Skips the entire test module if either FP16 source is missing on
+    disk - the upload tests only make sense when the donor models are
+    physically present.
+
+    .. note::
+        These uploads are deliberately **not** cleaned up at the end of
+        the test session: the files under
+        ``shared/models/output/custom_uploaded_models/`` are created by
+        the ``model-download`` microservice and the test runner does
+        not have permission to delete them from the host. A dedicated
+        DELETE endpoint / janitor task is tracked separately.
+    """
+    # Imported here to keep the helpers/api_helpers import cost out of
+    # the always-loaded conftest header.
+    from helpers.api_helpers import upload_model_file
+
+    uploaded: dict[str, str] = {}
+    for source_name, info in _UPLOAD_MODEL_SOURCES.items():
+        fp16_dir = PROJECT_ROOT / info["fp16_dir"]
+        if not fp16_dir.is_dir():
+            pytest.skip(
+                f"FP16 source directory {fp16_dir} not found - upload tests "
+                "require the donor OMZ models to be installed on disk."
+            )
+        payload = _build_model_zip(fp16_dir)
+        uploaded_name = f"{source_name}-uploaded-{upload_run_id}"
+        response = upload_model_file(
+            http_client,
+            model_name=uploaded_name,
+            category=info["category"],
+            payload=payload,
+        )
+        assert response.status_code == 201, (
+            f"Upload of {uploaded_name} failed: {response.status_code}: {response.text}"
+        )
+        uploaded[source_name] = uploaded_name
+        logger.info(
+            "Uploaded model %s as %s (category=%s)",
+            source_name,
+            uploaded_name,
+            info["category"],
+        )
+    return uploaded

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/helpers/api_helpers.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/helpers/api_helpers.py
@@ -448,3 +448,133 @@ def run_job_with_retry(
         time.sleep(retry_delay_seconds)
         status = attempt_fn()
     return status
+
+
+# --------------------------------------------------------------------------- #
+# Model management helpers (downloads, uploads, job polling).
+# --------------------------------------------------------------------------- #
+
+
+# OMZ downloads in CI can be slow; allow generous default.
+MODEL_DOWNLOAD_TIMEOUT_SECONDS: float = 120.0
+
+
+def start_model_download(
+    session: requests.Session, names: list[str]
+) -> requests.Response:
+    """POST ``/models/download`` with the batch body ``{"names": [...]}``.
+
+    Returns the raw response so callers can branch on the aggregate
+    status code (202 / 207 / 400 / 404 / 409).
+    """
+    response = session.post(
+        f"{BASE_URL}/models/download", json={"names": names}, timeout=60
+    )
+    logger.info("POST /models/download names=%s status=%d", names, response.status_code)
+    return response
+
+
+def fetch_model_jobs(session: requests.Session) -> list[JsonDict]:
+    """Return the list from ``GET /jobs/models/status``."""
+    response = session.get(f"{BASE_URL}/jobs/models/status", timeout=30)
+    response.raise_for_status()
+    payload = response.json()
+    assert isinstance(payload, list), (
+        f"Expected list response, got {type(payload).__name__}"
+    )
+    return payload
+
+
+def get_model_job_summary(session: requests.Session, job_id: str) -> requests.Response:
+    """Return the raw response of ``GET /jobs/models/{job_id}``."""
+    response = session.get(f"{BASE_URL}/jobs/models/{job_id}", timeout=30)
+    logger.info("GET /jobs/models/%s status=%d", job_id, response.status_code)
+    return response
+
+
+def get_model_job_status(session: requests.Session, job_id: str) -> requests.Response:
+    """Return the raw response of ``GET /jobs/models/{job_id}/status``."""
+    response = session.get(f"{BASE_URL}/jobs/models/{job_id}/status", timeout=30)
+    logger.info("GET /jobs/models/%s/status status=%d", job_id, response.status_code)
+    return response
+
+
+def wait_for_model_download_completion(
+    session: requests.Session,
+    job_id: str,
+    *,
+    timeout: float = MODEL_DOWNLOAD_TIMEOUT_SECONDS,
+    poll_interval: float = POLL_INTERVAL_SECONDS,
+) -> JsonDict:
+    """Poll the model download job until it leaves ``RUNNING`` state.
+
+    Returns the final status payload (``COMPLETED`` or ``FAILED``).
+    Fails the test if the job is still ``RUNNING`` after ``timeout``.
+    """
+    deadline = time.monotonic() + timeout
+    last_status: JsonDict = {}
+    while time.monotonic() < deadline:
+        response = get_model_job_status(session, job_id)
+        if response.status_code == 404:
+            pytest.fail(
+                f"Model job {job_id} disappeared before reaching a terminal state"
+            )
+        response.raise_for_status()
+        last_status = response.json()
+        state = last_status.get("state")
+        logger.info(
+            "Model job %s state=%s elapsed=%s",
+            job_id,
+            state,
+            last_status.get("elapsed_time"),
+        )
+        if state != "RUNNING":
+            return last_status
+        time.sleep(poll_interval)
+
+    pytest.fail(
+        f"Model job {job_id} did not finish within {timeout:.0f}s "
+        f"(last state={last_status.get('state')!r})"
+    )
+
+
+def upload_model_file(
+    session: requests.Session,
+    model_name: str,
+    category: str,
+    payload: bytes,
+    *,
+    filename: str | None = None,
+    content_type: str = "application/zip",
+) -> requests.Response:
+    """POST a multipart upload to ``/models/upload``.
+
+    ``filename`` defaults to ``"<model_name>.zip"`` so the server has a
+    stable basename to log/track. Returns the raw response so callers
+    can assert both the 201 happy path and the 4xx/5xx error cases.
+    """
+    files = {"file": (filename or f"{model_name}.zip", payload, content_type)}
+    data = {"model_name": model_name, "category": category}
+    response = session.post(
+        f"{BASE_URL}/models/upload", data=data, files=files, timeout=120
+    )
+    logger.info(
+        "POST /models/upload model_name=%s category=%s status=%d",
+        model_name,
+        category,
+        response.status_code,
+    )
+    return response
+
+
+def find_model_in_list(
+    models: list[JsonDict], name_or_display_name: str
+) -> JsonDict | None:
+    """Return the first model whose ``name`` or ``display_name`` matches."""
+    for entry in models:
+        if (
+            entry.get("name") == name_or_display_name
+            or entry.get("display_name") == name_or_display_name
+        ):
+            return entry
+    return None

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/helpers/pipeline_case_helpers.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/helpers/pipeline_case_helpers.py
@@ -2,16 +2,22 @@
 
 import logging
 import re
+from collections import defaultdict
 from dataclasses import dataclass
 
 import pytest
 import requests
 
-from .api_helpers import fetch_devices, fetch_pipelines
+from .api_helpers import fetch_devices, fetch_models, fetch_pipelines
 
 logger = logging.getLogger(__name__)
 
 SUPPORTED_DEVICE_FAMILIES: frozenset[str] = frozenset({"CPU", "GPU", "NPU"})
+
+# Install statuses that mark a model as runnable. Anything else
+# (NOT_INSTALLED / INSTALLING / FAILED) makes the pipeline that
+# references it unrunnable.
+_RUNNABLE_INSTALL_STATUSES: frozenset[str] = frozenset({"installed"})
 
 
 @dataclass(frozen=True)
@@ -41,8 +47,45 @@ def _required_families(variant_name: str) -> set[str] | None:
     return parts if parts <= SUPPORTED_DEVICE_FAMILIES else None
 
 
+def missing_models_per_pipeline(
+    session: requests.Session,
+) -> dict[str, set[str]]:
+    """Return ``{pipeline_id: {display_name, ...}}`` of models the pipeline
+    needs but that are **not** installed on the current system.
+
+    Uses the reverse index exposed by ``GET /models`` through
+    ``used_by_pipelines`` (populated by
+    :meth:`PipelineManager.get_model_display_names_used_by_pipelines`).
+    A pipeline missing from the result has all its required models
+    installed and is runnable from the model standpoint.
+
+    Granularity is per-pipeline (not per-variant) because
+    ``used_by_pipelines`` is built from each variant's inference nodes
+    aggregated under the parent pipeline id. In practice every variant
+    of the same pipeline references the same model display names (only
+    the ``device`` property differs), so this is the right granularity.
+    """
+    result: dict[str, set[str]] = defaultdict(set)
+    for model in fetch_models(session):
+        status = str(model.get("install_status") or "").lower()
+        if status in _RUNNABLE_INSTALL_STATUSES:
+            continue
+        display_name = model.get("display_name") or ""
+        for pipeline_id in model.get("used_by_pipelines") or []:
+            result[pipeline_id].add(display_name)
+    return dict(result)
+
+
 def collect_pipeline_cases(session: requests.Session) -> list[PipelineCase]:
-    """Discover runnable (pipeline, variant) combinations from the live API."""
+    """Discover runnable (pipeline, variant) combinations from the live API.
+
+    Returns every variant whose required device families are advertised
+    by the host. Filtering by *model installation* is intentionally not
+    done here so callers that post-filter (e.g. by pipeline name) can
+    decide what to do with model-unrunnable cases; use
+    :func:`wrap_cases_for_pytest` to attach
+    ``pytest.mark.skip`` reasons after filtering.
+    """
     available_families: set[str] = {
         device.get("device_family", "").upper()
         for device in fetch_devices(session)
@@ -80,14 +123,50 @@ def collect_pipeline_cases(session: requests.Session) -> list[PipelineCase]:
     return cases
 
 
+def wrap_cases_for_pytest(
+    cases: list[PipelineCase],
+    missing_models_by_pipeline: dict[str, set[str]],
+) -> tuple[list[PipelineCase | object], list[str]]:
+    """Return ``(params, ids)`` ready for ``pytest.mark.parametrize``.
+
+    Pipeline cases whose required models are not installed are wrapped
+    in ``pytest.param(..., marks=pytest.mark.skip(reason=...))`` so the
+    pytest report shows an explicit ``SKIPPED`` with the missing model
+    names. Other cases are passed through unchanged.
+    """
+    params: list[PipelineCase | object] = []
+    ids: list[str] = []
+    for case in cases:
+        missing = missing_models_by_pipeline.get(case.pipeline_id)
+        if missing:
+            reason = (
+                f"Pipeline {case.pipeline_name!r} requires model(s) that are "
+                f"not installed: {sorted(missing)}. Install them through "
+                f"POST /models/download (or the UI Models page) to enable "
+                f"this case."
+            )
+            params.append(pytest.param(case, marks=pytest.mark.skip(reason=reason)))
+        else:
+            params.append(case)
+        ids.append(case.case_id)
+    return params, ids
+
+
 def discover_pipeline_cases_for_pytest(
     *,
     skip_reason: str | None = None,
 ) -> tuple[list[PipelineCase | object], list[str]]:
     """Return pytest parameter values and ids for pipeline-driven tests.
 
-    If discovery fails or yields no runnable combinations, returns a single
-    skipped parameter to keep collection stable and avoid hard failures.
+    Pipeline cases whose required models are not installed are kept in
+    the parametrize list but wrapped in ``pytest.mark.skip`` with the
+    list of missing model display names, so the pytest report shows an
+    explicit ``SKIPPED`` instead of silently dropping the case from
+    collection.
+
+    If discovery fails or yields no runnable combinations at all,
+    returns a single skipped parameter to keep collection stable and
+    avoid hard failures.
     """
     reason = (
         skip_reason
@@ -99,11 +178,38 @@ def discover_pipeline_cases_for_pytest(
         with requests.Session() as session:
             session.headers.update({"Accept": "application/json"})
             cases = collect_pipeline_cases(session)
+            missing = missing_models_by_pipeline = missing_models_per_pipeline(session)
+            if missing:
+                logger.info(
+                    "Pipelines with missing models: %s",
+                    {k: sorted(v) for k, v in missing.items()},
+                )
     except Exception:
         logger.exception("Failed to collect pipeline cases from VIPPET API")
         cases = []
+        missing_models_by_pipeline = {}
 
     if not cases:
         return [pytest.param(None, marks=pytest.mark.skip(reason=reason))], ["no-cases"]
 
-    return list(cases), [case.case_id for case in cases]
+    return wrap_cases_for_pytest(cases, missing_models_by_pipeline)
+
+
+def skip_if_pipeline_models_missing(
+    session: requests.Session, pipeline_id: str
+) -> None:
+    """Skip the current test if *pipeline_id* has any non-installed model.
+
+    Helper for tests that hard-code a pipeline id (no parametrization
+    through :func:`discover_pipeline_cases_for_pytest`) but still need
+    the same "model installed?" gating, e.g.
+    ``test_pipeline_optimize_flow`` against ``smart-parking``.
+    """
+    missing = missing_models_per_pipeline(session).get(pipeline_id)
+    if missing:
+        pytest.skip(
+            f"Pipeline {pipeline_id!r} requires model(s) that are not "
+            f"installed: {sorted(missing)}. Install them through "
+            f"POST /models/download (or the UI Models page) to enable "
+            f"this test."
+        )

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/pytest.ini
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/pytest.ini
@@ -1,4 +1,10 @@
 [pytest]
+# ``-r fEsxX`` adds a short summary section at the end of the run for
+# every (f)ailed, (E)rrored, (s)kipped, (x)failed and (X)passed test,
+# each entry showing its reason on a single line. Skips listed above
+# the failures make it easy to spot pipelines that were not exercised
+# because their required models are not installed.
+addopts = -r fEsxX
 markers =
 	smoke: Marks tests that only make simple API queries
 	full: Marks tests that submit jobs and poll until completion

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_download.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_download.py
@@ -57,33 +57,67 @@ _REFERENCE_MODELS: tuple[str, ...] = (
 )
 
 
-def _resolve_job_id(
+def _resolve_job_ids(
     http_client: requests.Session,
     download_response: requests.Response,
     requested_names: list[str],
-) -> str | None:
-    """Extract a job id from the download response.
+) -> list[str]:
+    """Extract all job ids from the download response.
 
-    The response shape is one entry per requested model with either a
-    ``job_id`` or a ``status_code`` of 409 (already installed). When at
-    least one job was created, return its id; otherwise return ``None``
-    so the caller can skip the polling portion of the test.
+    The API returns a ``ModelDownloadJobResponse`` whose shape is
+    ``{"jobs": {model_name: {"job_id": ..., "status_code": ...}, ...}}``.
+    Some legacy clients also accept a list of items (``[{...}, {...}]``)
+    or the bare dict variant - we support all three. Models that come
+    back with ``status_code == 409`` (already installed) contribute no
+    job id and are silently skipped.
+
+    If the parsed body yields nothing (e.g. the download finished
+    synchronously between the POST and our parsing), we fall back to
+    ``GET /jobs/models/status`` and pick up any job whose ``model_name``
+    matches the requested batch.
     """
-    body = download_response.json()
-    items = body if isinstance(body, list) else body.get("items", [])
-    for item in items:
-        job_id = item.get("job_id")
-        if job_id:
-            return str(job_id)
+    job_ids: list[str] = []
 
-    # No job was created - fall back to the live job list in case the
-    # download finished synchronously between the POST and our parsing.
+    try:
+        body = download_response.json()
+    except ValueError:
+        body = None
+
+    def _take(entry: dict) -> None:
+        job_id = entry.get("job_id")
+        if job_id:
+            job_ids.append(str(job_id))
+
+    if isinstance(body, dict):
+        jobs_field = body.get("jobs")
+        if isinstance(jobs_field, dict):
+            for entry in jobs_field.values():
+                if isinstance(entry, dict):
+                    _take(entry)
+        elif isinstance(jobs_field, list):
+            for entry in jobs_field:
+                if isinstance(entry, dict):
+                    _take(entry)
+        else:
+            # Bare-dict variant: {"face-detection-...": {"job_id": ...}}
+            for entry in body.values():
+                if isinstance(entry, dict):
+                    _take(entry)
+    elif isinstance(body, list):
+        for entry in body:
+            if isinstance(entry, dict):
+                _take(entry)
+
+    if job_ids:
+        return job_ids
+
+    # Fallback: scan the live job list.
     for job in fetch_model_jobs(http_client):
         if job.get("model_name") in requested_names:
             job_id = job.get("job_id")
             if job_id:
-                return str(job_id)
-    return None
+                job_ids.append(str(job_id))
+    return job_ids
 
 
 @pytest.mark.full
@@ -106,37 +140,47 @@ def test_models_download_reference_models_and_track_jobs(
         f"{response.status_code}: {response.text}"
     )
 
-    job_id = _resolve_job_id(http_client, response, list(_REFERENCE_MODELS))
+    job_ids = _resolve_job_ids(http_client, response, list(_REFERENCE_MODELS))
 
     # GET /jobs/models/status must always be exercised so the
     # coverage test passes regardless of whether a job was created.
     jobs = fetch_model_jobs(http_client)
     assert isinstance(jobs, list)
-    logger.info("/jobs/models/status returned %d active job(s)", len(jobs))
+    logger.info(
+        "/jobs/models/status returned %d active job(s); resolved %d new job id(s)",
+        len(jobs),
+        len(job_ids),
+    )
 
-    if job_id is None:
+    if not job_ids:
         logger.info("All reference models were already installed; skipping wait.")
     else:
-        # Per-job summary (synchronous; just confirm shape + 200).
-        summary_response = get_model_job_summary(http_client, job_id)
-        assert summary_response.status_code == 200, summary_response.text
-        summary = summary_response.json()
-        assert summary.get("job_id") == job_id
+        for job_id in job_ids:
+            # Per-job summary (synchronous; just confirm shape + 200).
+            summary_response = get_model_job_summary(http_client, job_id)
+            assert summary_response.status_code == 200, summary_response.text
+            summary = summary_response.json()
+            # The summary endpoint identifies the job under ``id`` while
+            # the live-status endpoint uses ``job_id``; accept either so
+            # the test does not break if the schema is harmonised later.
+            assert summary.get("job_id") == job_id or summary.get("id") == job_id, (
+                f"Summary for {job_id} does not echo the job id: {summary}"
+            )
 
-        # Per-job live status: at least one poll must succeed.
-        status_response = get_model_job_status(http_client, job_id)
-        assert status_response.status_code == 200, status_response.text
-        assert status_response.json().get("state") in {
-            "RUNNING",
-            "COMPLETED",
-            "FAILED",
-        }
+            # Per-job live status: at least one poll must succeed.
+            status_response = get_model_job_status(http_client, job_id)
+            assert status_response.status_code == 200, status_response.text
+            assert status_response.json().get("state") in {
+                "RUNNING",
+                "COMPLETED",
+                "FAILED",
+            }
 
-        final = wait_for_model_download_completion(http_client, job_id)
-        assert final.get("state") == "COMPLETED", (
-            f"Model download job {job_id} ended in unexpected state "
-            f"{final.get('state')!r}: {final.get('error_message')!r}"
-        )
+            final = wait_for_model_download_completion(http_client, job_id)
+            assert final.get("state") == "COMPLETED", (
+                f"Model download job {job_id} ended in unexpected state "
+                f"{final.get('state')!r}: {final.get('error_message')!r}"
+            )
 
     # Regardless of the path taken above, both reference models must
     # now be visible in GET /models as INSTALLED.

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_download.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_download.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Functional tests for the model-download REST surface.
+
+Covers:
+
+* ``POST /models/download``     - submit a batch download
+* ``GET  /jobs/models/status``  - list active model jobs
+* ``GET  /jobs/models/{id}``    - per-job summary
+* ``GET  /jobs/models/{id}/status`` - per-job live status
+
+Assumptions about the environment (matching how the rest of the
+functional suite runs):
+
+* The vippet stack is up and reachable through ``BASE_URL``.
+* ``shared/models/output`` is mounted into the vippet container; some
+  models from ``supported_models.yaml`` may already be installed.
+
+The two reference models used here (``face-detection-retail-0004``
+and ``age-gender-recognition-retail-0013``) are intentionally tiny
+OpenVINO IRs (~5 MB each) so the download finishes within
+``MODEL_DOWNLOAD_TIMEOUT_SECONDS`` even on slow CI machines. The test
+tolerates both code paths:
+
+* the model is already installed (server returns 409 in the per-name
+  detail) - we simply skip the wait;
+* the model needs downloading - we poll the per-job status endpoints
+  and wait for ``COMPLETED``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+import requests
+
+from helpers.api_helpers import (
+    JsonDict,
+    fetch_model_jobs,
+    fetch_models,
+    find_model_in_list,
+    get_model_job_status,
+    get_model_job_summary,
+    start_model_download,
+    wait_for_model_download_completion,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Two small OMZ models that are listed in the canonical
+# ``supported_models.yaml`` shipped with the repository. The display
+# names are stable and used by the pipeline tests below.
+_REFERENCE_MODELS: tuple[str, ...] = (
+    "face-detection-retail-0004",
+    "age-gender-recognition-retail-0013",
+)
+
+
+def _resolve_job_id(
+    http_client: requests.Session,
+    download_response: requests.Response,
+    requested_names: list[str],
+) -> str | None:
+    """Extract a job id from the download response.
+
+    The response shape is one entry per requested model with either a
+    ``job_id`` or a ``status_code`` of 409 (already installed). When at
+    least one job was created, return its id; otherwise return ``None``
+    so the caller can skip the polling portion of the test.
+    """
+    body = download_response.json()
+    items = body if isinstance(body, list) else body.get("items", [])
+    for item in items:
+        job_id = item.get("job_id")
+        if job_id:
+            return str(job_id)
+
+    # No job was created - fall back to the live job list in case the
+    # download finished synchronously between the POST and our parsing.
+    for job in fetch_model_jobs(http_client):
+        if job.get("model_name") in requested_names:
+            job_id = job.get("job_id")
+            if job_id:
+                return str(job_id)
+    return None
+
+
+@pytest.mark.full
+def test_models_download_reference_models_and_track_jobs(
+    http_client: requests.Session,
+) -> None:
+    """Submit a download for two small reference models and exercise
+    every model-job endpoint along the way.
+
+    The test is robust against the case where the models are already
+    installed: it then only verifies the listing/summary endpoints and
+    skips the wait-for-completion step.
+    """
+    response = start_model_download(http_client, list(_REFERENCE_MODELS))
+    # ``/models/download`` returns 202 (all queued), 207 (mixed - some
+    # already installed), 200/201 in legacy shapes, or 409 when every
+    # requested model is already installed.
+    assert response.status_code in {200, 201, 202, 207, 409}, (
+        f"Unexpected status from POST /models/download: "
+        f"{response.status_code}: {response.text}"
+    )
+
+    job_id = _resolve_job_id(http_client, response, list(_REFERENCE_MODELS))
+
+    # GET /jobs/models/status must always be exercised so the
+    # coverage test passes regardless of whether a job was created.
+    jobs = fetch_model_jobs(http_client)
+    assert isinstance(jobs, list)
+    logger.info("/jobs/models/status returned %d active job(s)", len(jobs))
+
+    if job_id is None:
+        logger.info("All reference models were already installed; skipping wait.")
+    else:
+        # Per-job summary (synchronous; just confirm shape + 200).
+        summary_response = get_model_job_summary(http_client, job_id)
+        assert summary_response.status_code == 200, summary_response.text
+        summary = summary_response.json()
+        assert summary.get("job_id") == job_id
+
+        # Per-job live status: at least one poll must succeed.
+        status_response = get_model_job_status(http_client, job_id)
+        assert status_response.status_code == 200, status_response.text
+        assert status_response.json().get("state") in {
+            "RUNNING",
+            "COMPLETED",
+            "FAILED",
+        }
+
+        final = wait_for_model_download_completion(http_client, job_id)
+        assert final.get("state") == "COMPLETED", (
+            f"Model download job {job_id} ended in unexpected state "
+            f"{final.get('state')!r}: {final.get('error_message')!r}"
+        )
+
+    # Regardless of the path taken above, both reference models must
+    # now be visible in GET /models as INSTALLED.
+    installed_models = fetch_models(http_client)
+    for name in _REFERENCE_MODELS:
+        entry: JsonDict | None = find_model_in_list(installed_models, name)
+        assert entry is not None, (
+            f"Reference model {name!r} missing from GET /models response"
+        )
+        install_status = str(entry.get("install_status") or "").upper()
+        assert install_status == "INSTALLED", (
+            f"Reference model {name!r} not installed: "
+            f"install_status={entry.get('install_status')!r}"
+        )
+
+
+@pytest.mark.full
+def test_models_download_404_for_unknown_model(
+    http_client: requests.Session,
+) -> None:
+    """Submitting a download for a name that is not in
+    ``supported_models.yaml`` must surface an error code (4xx).
+
+    The exact status depends on whether the backend validates the
+    request as a whole (400) or per-item (207 with a 404 inside the
+    per-name detail). Both shapes are accepted.
+    """
+    response = start_model_download(http_client, ["definitely-not-a-real-model"])
+    assert response.status_code in {207, 400, 404, 422}, response.text
+
+
+@pytest.mark.full
+def test_models_job_status_404_for_unknown_id(
+    http_client: requests.Session,
+) -> None:
+    """``GET /jobs/models/{id}`` and ``.../status`` must return 404 for
+    a job id that does not exist. This also locks in the behaviour the
+    UI relies on when a stale polling loop survives a backend restart.
+    """
+    bogus_id = "no-such-job-id-12345"
+    summary = get_model_job_summary(http_client, bogus_id)
+    assert summary.status_code == 404, summary.text
+    status = get_model_job_status(http_client, bogus_id)
+    assert status.status_code == 404, status.text

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_list.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_list.py
@@ -86,7 +86,14 @@ def _assert_models_present_in_api(
 
 @pytest.mark.smoke
 def test_models_endpoint_returns_models(http_client: requests.Session) -> None:
-    """Basic schema validation: every entry returned by the API is well-formed."""
+    """Basic schema validation: every entry returned by the API is well-formed.
+
+    User-uploaded models (``source == "custom"``) are excluded from the
+    precision/category whitelist checks: they are free-form uploads
+    that do not carry a precision tag and may use a category outside
+    the catalogue allow-list. They are still required to satisfy the
+    name/display_name/variants structural invariants.
+    """
     models: list[ModelDict] = fetch_models(http_client)
 
     assert models, "Models endpoint returned an empty list"
@@ -99,10 +106,18 @@ def test_models_endpoint_returns_models(http_client: requests.Session) -> None:
             isinstance(model_entry.get("display_name"), str)
             and model_entry["display_name"]
         ), "Model entry has invalid display_name"
-        assert (
-            isinstance(model_entry.get("category"), str)
-            and model_entry["category"] in VALID_MODEL_CATEGORIES
-        ), f"Model entry has unsupported category: {model_entry.get('category')}"
+
+        is_custom = str(model_entry.get("source") or "").lower() == "custom"
+
+        category = model_entry.get("category")
+        assert isinstance(category, str) and category, (
+            "Model entry has missing or empty category"
+        )
+        if not is_custom:
+            assert category in VALID_MODEL_CATEGORIES, (
+                f"Model entry has unsupported category: {category}"
+            )
+
         variants = model_entry.get("variants")
         assert isinstance(variants, list) and variants, (
             "Model entry has missing or empty variants list"
@@ -115,10 +130,17 @@ def test_models_endpoint_returns_models(http_client: requests.Session) -> None:
             assert (
                 isinstance(variant.get("display_name"), str) and variant["display_name"]
             ), "Variant has invalid display_name"
-            assert (
-                isinstance(variant.get("precision"), str)
-                and variant["precision"] in VALID_MODEL_PRECISIONS
-            ), f"Variant has unsupported precision: {variant.get('precision')}"
+            if is_custom:
+                # Uploaded models do not advertise a precision; accept
+                # any string (including the empty string).
+                assert isinstance(variant.get("precision"), str), (
+                    "Variant precision must be a string"
+                )
+            else:
+                assert (
+                    isinstance(variant.get("precision"), str)
+                    and variant["precision"] in VALID_MODEL_PRECISIONS
+                ), f"Variant has unsupported precision: {variant.get('precision')}"
 
 
 @pytest.mark.smoke

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_upload.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_upload.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Functional tests for ``POST /models/upload``.
+
+These tests upload the two reference OMZ models
+(``face-detection-retail-0004`` and
+``age-gender-recognition-retail-0013``) under per-session unique
+names so they show up as custom (uploaded) models in
+``GET /models``. The pipeline test in
+``test_models_uploaded_pipeline.py`` then exercises the very same
+uploaded models end-to-end through ``/tests/performance`` to lock in
+the ``ModelManager`` fallback added in ``graph.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+import requests
+
+from helpers.api_helpers import (
+    fetch_models,
+    find_model_in_list,
+    upload_model_file,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.full
+def test_uploaded_models_appear_in_models_list(
+    http_client: requests.Session,
+    uploaded_model_names: dict[str, str],
+) -> None:
+    """Both uploaded copies must appear in ``GET /models`` as INSTALLED
+    custom models with the right category.
+    """
+    expected_categories = {
+        "face-detection-retail-0004": "detection",
+        "age-gender-recognition-retail-0013": "classification",
+    }
+
+    models = fetch_models(http_client)
+    for source_name, uploaded_name in uploaded_model_names.items():
+        entry = find_model_in_list(models, uploaded_name)
+        assert entry is not None, (
+            f"Uploaded model {uploaded_name!r} missing from GET /models"
+        )
+        install_status = str(entry.get("install_status") or "").upper()
+        assert install_status == "INSTALLED", (
+            f"Uploaded model {uploaded_name!r} not INSTALLED: "
+            f"install_status={entry.get('install_status')!r}"
+        )
+        # Custom uploads use ``source=custom`` in the registry; the
+        # exact label may vary across API versions, so we only assert
+        # the model is NOT marked as one of the catalogue sources.
+        assert entry.get("source") not in {"omz", "public"}, (
+            f"Uploaded model {uploaded_name!r} mis-tagged with "
+            f"source={entry.get('source')!r}"
+        )
+        assert entry.get("category") == expected_categories[source_name], (
+            f"Uploaded model {uploaded_name!r} got category "
+            f"{entry.get('category')!r}, expected "
+            f"{expected_categories[source_name]!r}"
+        )
+
+
+@pytest.mark.full
+def test_uploading_same_model_name_twice_is_rejected(
+    http_client: requests.Session,
+    uploaded_model_names: dict[str, str],
+) -> None:
+    """A second upload using a model_name that already exists must be
+    rejected (409 from the model-download microservice, surfaced as-is
+    by the vippet upload route).
+    """
+    # We only need a tiny placeholder payload here; the server checks
+    # the name before unpacking the archive.
+    existing_name = next(iter(uploaded_model_names.values()))
+    response = upload_model_file(
+        http_client,
+        model_name=existing_name,
+        category="detection",
+        payload=b"PK\x05\x06" + b"\x00" * 18,  # empty zip
+    )
+    assert response.status_code in {400, 409, 422}, (
+        f"Re-uploading {existing_name!r} should be rejected, got "
+        f"{response.status_code}: {response.text}"
+    )
+
+
+@pytest.mark.full
+def test_uploading_with_invalid_category_rejected(
+    http_client: requests.Session,
+    upload_run_id: str,
+) -> None:
+    """The ``category`` form field is validated against the
+    ``ModelCategory`` enum; an unknown value must be rejected with 422.
+    """
+    response = upload_model_file(
+        http_client,
+        model_name=f"invalid-category-{upload_run_id}",
+        category="not-a-valid-category",
+        payload=b"PK\x05\x06" + b"\x00" * 18,
+    )
+    assert response.status_code == 422, response.text

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_uploaded_pipeline.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_uploaded_pipeline.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end functional test for uploaded (custom) models.
+
+This module exercises the production fix in ``graph.py`` that adds a
+``ModelManager`` fallback to both the model-path -> display-name and
+the display-name -> model-path resolvers. Without that fix, the simple
+-> advanced graph conversion silently drops uploaded models because
+they are absent from the YAML-backed ``SupportedModelsManager`` registry.
+
+Per variant the test:
+1. Fetches the simple graph of the ``Age & Gender Recognition`` pipeline.
+2. Patches ``gvadetect`` / ``gvaclassify`` to reference the uploaded
+   copies created by the ``uploaded_model_names`` session fixture.
+3. Converts the patched simple graph back to the advanced form via
+   ``POST /pipelines/{id}/variants/{vid}/convert-to-advanced`` - this
+   is the call that fails without the fix.
+4. Runs a performance job using the resulting advanced graph and
+   asserts ``COMPLETED`` with positive FPS.
+
+Parametrized over every CPU/GPU/NPU variant the host advertises.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import time
+from collections.abc import Generator
+
+import pytest
+import requests
+
+from helpers.api_helpers import (
+    JsonDict,
+    convert_to_advanced,
+    get_variant_simple_graph,
+    run_job_with_retry,
+    start_performance_job,
+    wait_for_job_completion,
+)
+from helpers.config import BASE_URL
+from helpers.pipeline_case_helpers import (
+    PipelineCase,
+    discover_pipeline_cases_for_pytest,
+)
+
+logger = logging.getLogger(__name__)
+
+_TARGET_PIPELINE_NAME: str = "Age & Gender Recognition"
+_FACE_MODEL: str = "face-detection-retail-0004"
+_AGE_GENDER_MODEL: str = "age-gender-recognition-retail-0013"
+
+RETRY_DELAY_SECONDS: float = 5.0
+
+
+PIPELINE_CASES, CASE_IDS = discover_pipeline_cases_for_pytest()
+
+_AGE_GENDER_CASES: list[PipelineCase] = [
+    case
+    for case in PIPELINE_CASES
+    if isinstance(case, PipelineCase) and case.pipeline_name == _TARGET_PIPELINE_NAME
+]
+
+
+def _age_gender_param_or_skip() -> tuple[list[PipelineCase | object], list[str]]:
+    if not _AGE_GENDER_CASES:
+        return (
+            [
+                pytest.param(
+                    None,
+                    marks=pytest.mark.skip(
+                        reason=(
+                            f"no runnable variants of {_TARGET_PIPELINE_NAME!r} "
+                            "on this system"
+                        )
+                    ),
+                )
+            ],
+            ["no-cases"],
+        )
+    return list(_AGE_GENDER_CASES), [c.case_id for c in _AGE_GENDER_CASES]
+
+
+_PARAMS, _IDS = _age_gender_param_or_skip()
+
+
+@pytest.fixture(autouse=True)
+def _inter_test_pause() -> Generator[None, None, None]:
+    """Small pause between tests, same as other performance flow files."""
+    yield
+    time.sleep(0.5)
+
+
+def _patch_model_nodes(
+    graph: JsonDict,
+    *,
+    face_display_name: str,
+    age_gender_display_name: str,
+) -> JsonDict:
+    """Return a copy of *graph* with the inference nodes pointing at the
+    uploaded model copies.
+
+    The simple graph stores model references as the model's display name
+    in ``node.data["model"]``. We identify nodes by element type:
+      * ``gvadetect``   -> face detection model
+      * ``gvaclassify`` -> age/gender classifier
+    Uploaded models never carry a model-proc, so we drop any existing
+    one from the patched nodes.
+    """
+    modified = copy.deepcopy(graph)
+    patched_detect = False
+    patched_classify = False
+    for node in modified.get("nodes", []):
+        ntype = node.get("type")
+        data = node.setdefault("data", {})
+        if ntype == "gvadetect":
+            data["model"] = face_display_name
+            data.pop("model-proc", None)
+            patched_detect = True
+            logger.info("Patched gvadetect.model -> %s", face_display_name)
+        elif ntype == "gvaclassify":
+            data["model"] = age_gender_display_name
+            data.pop("model-proc", None)
+            patched_classify = True
+            logger.info("Patched gvaclassify.model -> %s", age_gender_display_name)
+    if not patched_detect:
+        pytest.fail("No 'gvadetect' node found in the simple graph")
+    if not patched_classify:
+        pytest.fail("No 'gvaclassify' node found in the simple graph")
+    return modified
+
+
+def _build_payload(advanced_graph: JsonDict, streams: int = 1) -> JsonDict:
+    return {
+        "pipeline_performance_specs": [
+            {
+                "pipeline": {
+                    "source": "graph",
+                    "pipeline_graph": advanced_graph,
+                },
+                "streams": streams,
+            }
+        ],
+        "execution_config": {
+            "output_mode": "disabled",
+        },
+    }
+
+
+def _attempt_job(session: requests.Session, payload: JsonDict) -> JsonDict:
+    job_id = start_performance_job(session, payload)
+    status_url = f"{BASE_URL}/jobs/tests/performance/{job_id}/status"
+    return wait_for_job_completion(session, status_url)
+
+
+# --------------------------------------------------------------------------- #
+# Baseline: the catalogue (YAML) models still work for this pipeline.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.full
+@pytest.mark.parametrize("case", _PARAMS, ids=_IDS)
+def test_age_gender_pipeline_with_original_models(
+    http_client: requests.Session,
+    case: PipelineCase | None,
+) -> None:
+    """Sanity baseline: run the pipeline unmodified.
+
+    If this fails the uploaded-models variant cannot be expected to
+    pass either - the failure is easier to diagnose here first.
+    """
+    assert case is not None
+
+    simple_graph = get_variant_simple_graph(
+        http_client, case.pipeline_id, case.variant_id
+    )
+    advanced = convert_to_advanced(
+        http_client, case.pipeline_id, case.variant_id, simple_graph
+    )
+
+    final = run_job_with_retry(
+        lambda: _attempt_job(http_client, _build_payload(advanced)),
+        retry_delay_seconds=RETRY_DELAY_SECONDS,
+    )
+    label = f"pipeline_id={case.pipeline_id} variant_id={case.variant_id}"
+    assert final.get("state") == "COMPLETED", (
+        f"{label} finished in unexpected state {final.get('state')} "
+        f"(error: {final.get('error_message')})"
+    )
+    assert (final.get("per_stream_fps") or 0) > 0, (
+        f"{label} per_stream_fps must be greater than zero"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The fix under test: uploaded (custom) models go through graph.py's
+# ModelManager fallback and run to completion.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.full
+@pytest.mark.parametrize("case", _PARAMS, ids=_IDS)
+def test_age_gender_pipeline_with_uploaded_models(
+    http_client: requests.Session,
+    uploaded_model_names: dict[str, str],
+    case: PipelineCase | None,
+) -> None:
+    """Run the same pipeline with both model refs swapped for uploaded
+    (custom) copies.
+
+    Without the production fix, ``convert_to_advanced`` would raise 400
+    with ``ValueError("Display name '...-uploaded-...' not found")``
+    because ``SupportedModelsManager`` does not know the custom names;
+    the new ``ModelManager`` fallback in ``graph.py`` is what makes
+    this test green.
+    """
+    assert case is not None
+
+    face_name = uploaded_model_names.get(_FACE_MODEL)
+    age_gender_name = uploaded_model_names.get(_AGE_GENDER_MODEL)
+    if not face_name or not age_gender_name:
+        pytest.skip(
+            "Uploaded copies of the reference models are unavailable; "
+            "this test depends on the uploaded_model_names fixture."
+        )
+
+    simple_graph = get_variant_simple_graph(
+        http_client, case.pipeline_id, case.variant_id
+    )
+    patched = _patch_model_nodes(
+        simple_graph,
+        face_display_name=face_name,
+        age_gender_display_name=age_gender_name,
+    )
+    advanced = convert_to_advanced(
+        http_client, case.pipeline_id, case.variant_id, patched
+    )
+
+    final = run_job_with_retry(
+        lambda: _attempt_job(http_client, _build_payload(advanced)),
+        retry_delay_seconds=RETRY_DELAY_SECONDS,
+    )
+    label = (
+        f"pipeline_id={case.pipeline_id} variant_id={case.variant_id} (uploaded models)"
+    )
+    assert final.get("state") == "COMPLETED", (
+        f"{label} finished in unexpected state {final.get('state')} "
+        f"(error: {final.get('error_message')})"
+    )
+    assert (final.get("per_stream_fps") or 0) > 0, (
+        f"{label} per_stream_fps must be greater than zero"
+    )

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_performance_job_usb_camera.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_performance_job_usb_camera.py
@@ -22,6 +22,8 @@ from helpers.api_helpers import (
 from helpers.pipeline_case_helpers import (
     PipelineCase,
     collect_pipeline_cases,
+    missing_models_per_pipeline,
+    wrap_cases_for_pytest,
 )
 
 logger = logging.getLogger(__name__)
@@ -50,6 +52,7 @@ def _discover_filtered_cases(
         with requests.Session() as _session:
             _session.headers.update({"Accept": "application/json"})
             cases = collect_pipeline_cases(_session)
+            missing = missing_models_per_pipeline(_session)
             if exclude_names:
                 cases = [c for c in cases if c.pipeline_name not in exclude_names]
             if include_names:
@@ -57,9 +60,12 @@ def _discover_filtered_cases(
     except Exception:
         logger.exception("Failed to collect pipeline cases from VIPPET API")
         cases = []
+        missing = {}
     if not cases:
         return [pytest.param(None, marks=pytest.mark.skip(reason=reason))], ["no-cases"]
-    return list(cases), [case.case_id for case in cases]
+    # Wrap cases whose required models are not installed in a skip()
+    # so the pytest report shows the missing-model reason explicitly.
+    return wrap_cases_for_pytest(cases, missing)
 
 
 # Camera-compatible pipelines (file-only pipelines excluded)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_performance_metadata_flow.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_performance_metadata_flow.py
@@ -28,6 +28,8 @@ from helpers.config import BASE_URL
 from helpers.pipeline_case_helpers import (
     PipelineCase,
     collect_pipeline_cases,
+    missing_models_per_pipeline,
+    wrap_cases_for_pytest,
 )
 
 logger = logging.getLogger(__name__)
@@ -67,6 +69,7 @@ def _discover_metadata_pipeline_cases() -> tuple[
         with requests.Session() as session:
             session.headers.update({"Accept": "application/json"})
             all_cases = collect_pipeline_cases(session)
+            missing = missing_models_per_pipeline(session)
             meta_cases = [
                 case
                 for case in all_cases
@@ -75,10 +78,11 @@ def _discover_metadata_pipeline_cases() -> tuple[
     except Exception:
         logger.exception("Failed to collect metadata pipeline cases from VIPPET API")
         meta_cases = []
+        missing = {}
 
     if not meta_cases:
         return [pytest.param(None, marks=pytest.mark.skip(reason=reason))], ["no-cases"]
-    return list(meta_cases), [case.case_id for case in meta_cases]
+    return wrap_cases_for_pytest(meta_cases, missing)
 
 
 METADATA_PIPELINE_CASES, METADATA_CASE_IDS = _discover_metadata_pipeline_cases()

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_pipeline_optimize_flow.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_pipeline_optimize_flow.py
@@ -7,10 +7,15 @@ import requests
 
 from helpers.api_helpers import (
     JsonDict,
+    fetch_devices,
     start_optimization_job,
     wait_for_job_completion,
 )
 from helpers.config import BASE_URL
+from helpers.pipeline_case_helpers import (
+    SUPPORTED_DEVICE_FAMILIES,
+    skip_if_pipeline_models_missing,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +54,17 @@ OPTIMIZATION_CASES = [
 ]
 
 
+def _required_families_for_variant(variant_id: str) -> set[str]:
+    """Return device families a variant id encodes (e.g. ``gpu_npu`` -> {GPU, NPU}).
+
+    Only families listed in :data:`SUPPORTED_DEVICE_FAMILIES` are
+    returned; unknown tokens are ignored so the function never asks for
+    something the host could not advertise.
+    """
+    tokens = {part.upper() for part in variant_id.split("_") if part}
+    return tokens & SUPPORTED_DEVICE_FAMILIES
+
+
 @pytest.mark.full
 @pytest.mark.parametrize(
     "case_id,variant_id,payload",
@@ -61,6 +77,23 @@ def test_pipeline_optimize_flow(
     variant_id: str,
     payload: JsonDict,
 ) -> None:
+    required = _required_families_for_variant(variant_id)
+    if required:
+        available: set[str] = {
+            (device.get("device_family") or "").upper()
+            for device in fetch_devices(http_client)
+        } & SUPPORTED_DEVICE_FAMILIES
+        missing = required - available
+        if missing:
+            pytest.skip(
+                f"Variant '{variant_id}' requires device families {sorted(required)} "
+                f"but the host only advertises {sorted(available)}; "
+                f"missing: {sorted(missing)}"
+            )
+
+    # Also skip if the pipeline references models that are not installed.
+    skip_if_pipeline_models_missing(http_client, PIPELINE_ID)
+
     logger.info(
         "Running pipeline optimize flow case '%s' on variant '%s'",
         case_id,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/api_tests/jobs_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/api_tests/jobs_test.py
@@ -8,6 +8,10 @@ from unittest.mock import patch, MagicMock
 import api.api_schemas as schemas
 from graph import Graph
 from internal_types import (
+    InternalModelDownloadJobState,
+    InternalModelDownloadJobStatus,
+    InternalModelDownloadJobSummary,
+    InternalModelSource,
     InternalOptimizationJobStatus,
     InternalOptimizationJobState,
     InternalOptimizationJobSummary,
@@ -927,3 +931,221 @@ class TestJobsAPI(unittest.TestCase):
 
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0], ("job-1", 7))
+
+
+class TestModelDownloadJobsAPI(unittest.TestCase):
+    """Unit tests for ``/jobs/models/*`` routes.
+
+    The routes are thin adapters around ``ModelManager``: list jobs,
+    fetch a summary, fetch a full status. Tests mock the manager and
+    assert the HTTP envelope plus the internal->API conversion done by
+    ``_model_job_to_api_status`` / ``_model_job_summary_to_api``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        app = FastAPI()
+        app.include_router(jobs_router, prefix="/jobs")
+        cls.client = TestClient(app)
+
+    @staticmethod
+    def _make_job(
+        *,
+        job_id: str = "mdl-1",
+        model_name: str = "yolo11n",
+        state: InternalModelDownloadJobState | None = None,
+        start_time: int = 1_000_000,
+        end_time: int | None = None,
+        details: list[str] | None = None,
+        progress_message: str | None = None,
+        model_path: str | None = None,
+    ) -> InternalModelDownloadJobStatus:
+        """Build a minimal ``InternalModelDownloadJobStatus`` for tests."""
+
+        return InternalModelDownloadJobStatus(
+            id=job_id,
+            model_name=model_name,
+            source=InternalModelSource.ULTRALYTICS,
+            state=state or InternalModelDownloadJobState.RUNNING,
+            start_time=start_time,
+            end_time=end_time,
+            details=details if details is not None else ["working..."],
+            progress_message=progress_message,
+            model_path=model_path,
+        )
+
+    # ------------------------------------------------------------------
+    # GET /jobs/models/status — list all
+    # ------------------------------------------------------------------
+
+    @patch("api.routes.jobs.ModelManager")
+    def test_list_model_jobs_empty(self, mock_manager_cls):
+        """No jobs -> empty list with 200 OK."""
+        mock_manager = MagicMock()
+        mock_manager.get_all_jobs.return_value = []
+        mock_manager_cls.return_value = mock_manager
+
+        response = self.client.get("/jobs/models/status")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    @patch("api.routes.jobs.ModelManager")
+    def test_list_model_jobs_returns_converted_entries(self, mock_manager_cls):
+        """Each job is converted via _model_job_to_api_status."""
+
+        running = self._make_job(
+            job_id="mdl-1",
+            state=InternalModelDownloadJobState.RUNNING,
+            progress_message="Fetching weights",
+        )
+        completed = self._make_job(
+            job_id="mdl-2",
+            model_name="yolov8n",
+            state=InternalModelDownloadJobState.COMPLETED,
+            end_time=1_000_500,
+            details=["installed"],
+            model_path="/models/output/ultralytics/yolov8n",
+        )
+        mock_manager = MagicMock()
+        mock_manager.get_all_jobs.return_value = [running, completed]
+        mock_manager_cls.return_value = mock_manager
+
+        response = self.client.get("/jobs/models/status")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["id"], "mdl-1")
+        self.assertEqual(data[0]["state"], "RUNNING")
+        self.assertEqual(data[0]["progress_message"], "Fetching weights")
+        self.assertEqual(data[1]["id"], "mdl-2")
+        self.assertEqual(data[1]["state"], "COMPLETED")
+        self.assertEqual(data[1]["model_path"], "/models/output/ultralytics/yolov8n")
+        # Completed jobs report a deterministic ``elapsed_time`` derived
+        # from the recorded ``end_time``/``start_time`` pair.
+        self.assertEqual(data[1]["elapsed_time"], 500)
+
+    # ------------------------------------------------------------------
+    # GET /jobs/models/{job_id} — summary
+    # ------------------------------------------------------------------
+
+    @patch("api.routes.jobs.ModelManager")
+    def test_get_model_job_summary_404_when_missing(self, mock_manager_cls):
+        mock_manager = MagicMock()
+        mock_manager.get_job_summary.return_value = None
+        mock_manager_cls.return_value = mock_manager
+
+        response = self.client.get("/jobs/models/unknown")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("not found", response.json()["message"])
+
+    @patch("api.routes.jobs.ModelManager")
+    def test_get_model_job_summary_returns_api_shape(self, mock_manager_cls):
+
+        mock_manager = MagicMock()
+        mock_manager.get_job_summary.return_value = InternalModelDownloadJobSummary(
+            id="mdl-1",
+            model_name="yolo11n",
+            source=InternalModelSource.ULTRALYTICS,
+        )
+        mock_manager_cls.return_value = mock_manager
+
+        response = self.client.get("/jobs/models/mdl-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"id": "mdl-1", "model_name": "yolo11n", "source": "ultralytics"},
+        )
+
+    # ------------------------------------------------------------------
+    # GET /jobs/models/{job_id}/status — full status
+    # ------------------------------------------------------------------
+
+    @patch("api.routes.jobs.ModelManager")
+    def test_get_model_job_status_404_when_missing(self, mock_manager_cls):
+        mock_manager = MagicMock()
+        mock_manager.get_job.return_value = None
+        mock_manager_cls.return_value = mock_manager
+
+        response = self.client.get("/jobs/models/unknown/status")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("not found", response.json()["message"])
+
+    @patch("api.routes.jobs.ModelManager")
+    def test_get_model_job_status_running_uses_wallclock_elapsed(
+        self, mock_manager_cls
+    ):
+        """For a RUNNING job, elapsed_time is computed against ``time.time()``."""
+
+        job = self._make_job(
+            job_id="mdl-running",
+            start_time=2_000_000,
+            state=InternalModelDownloadJobState.RUNNING,
+            progress_message="processing",
+        )
+        mock_manager = MagicMock()
+        mock_manager.get_job.return_value = job
+        mock_manager_cls.return_value = mock_manager
+
+        # Freeze ``time.time`` so elapsed becomes deterministic.
+        with patch("api.routes.jobs.time.time", return_value=2_000.0 + 1.234):
+            response = self.client.get("/jobs/models/mdl-running/status")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["state"], "RUNNING")
+        self.assertEqual(body["start_time"], 2_000_000)
+        # 2_001_234 ms - 2_000_000 ms = 1234 ms
+        self.assertEqual(body["elapsed_time"], 1234)
+        self.assertEqual(body["progress_message"], "processing")
+        self.assertIsNone(body["model_path"])
+
+    @patch("api.routes.jobs.ModelManager")
+    def test_get_model_job_status_completed_uses_end_time(self, mock_manager_cls):
+        """For a completed job, elapsed_time uses ``end_time - start_time``."""
+
+        job = self._make_job(
+            job_id="mdl-done",
+            start_time=10_000,
+            end_time=12_500,
+            state=InternalModelDownloadJobState.COMPLETED,
+            details=["installed"],
+            model_path="/models/output/x",
+        )
+        mock_manager = MagicMock()
+        mock_manager.get_job.return_value = job
+        mock_manager_cls.return_value = mock_manager
+
+        response = self.client.get("/jobs/models/mdl-done/status")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["state"], "COMPLETED")
+        self.assertEqual(body["elapsed_time"], 2_500)
+        self.assertEqual(body["model_path"], "/models/output/x")
+
+    @patch("api.routes.jobs.ModelManager")
+    def test_get_model_job_status_failed_state(self, mock_manager_cls):
+        """A FAILED job exposes the failure details verbatim."""
+
+        job = self._make_job(
+            job_id="mdl-fail",
+            start_time=1000,
+            end_time=2000,
+            state=InternalModelDownloadJobState.FAILED,
+            details=["HTTP error: 502"],
+        )
+        mock_manager = MagicMock()
+        mock_manager.get_job.return_value = job
+        mock_manager_cls.return_value = mock_manager
+
+        response = self.client.get("/jobs/models/mdl-fail/status")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["state"], "FAILED")
+        self.assertEqual(body["details"], ["HTTP error: 502"])

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/api_tests/models_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/api_tests/models_test.py
@@ -1,9 +1,11 @@
+import io
 import unittest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from unittest.mock import patch, MagicMock
 
-from api.routes.models import router as models_router
+import api.api_schemas as schemas
+from api.routes.models import _aggregate_status, router as models_router
 from internal_types import (
     InternalModelCategory,
     InternalModelInstallStatus,
@@ -212,6 +214,352 @@ class TestModelsAPI(unittest.TestCase):
                     }
                 ],
             )
+
+    # ------------------------------------------------------------------
+    # GET /models — error branch
+    # ------------------------------------------------------------------
+
+    def test_get_models_returns_500_when_manager_raises(self):
+        """list_models raising should map to a 500 MessageResponse."""
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.list_models.side_effect = RuntimeError("boom")
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self.client.get("/models")
+
+            self.assertEqual(response.status_code, 500)
+            self.assertIn("Unexpected error", response.json()["message"])
+
+
+class TestModelsUploadAPI(unittest.TestCase):
+    """Tests for POST /models/upload route layer.
+
+    The route is a thin adapter: it streams the upload to a temp file,
+    calls ``ModelManager.upload_model`` and translates the
+    ``(model, status, message)`` tuple into the right HTTP envelope.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        app = FastAPI()
+        app.include_router(models_router, prefix="/models")
+        cls.client = TestClient(app)
+
+    @staticmethod
+    def _make_uploaded_model() -> InternalSupportedModel:
+        """Build a minimal InternalSupportedModel for a freshly uploaded model."""
+        return InternalSupportedModel(
+            name="my-detector",
+            display_name="my-detector",
+            category=InternalModelCategory.DETECTION,
+            source=InternalModelSource.CUSTOM,
+            precisions=[
+                InternalModelPrecision(precision="", model_path="/models/output/x")
+            ],
+            variants=[
+                InternalModelVariant(
+                    name="my-detector",
+                    display_name="my-detector",
+                    precision="",
+                    installed=True,
+                )
+            ],
+            install_status=InternalModelInstallStatus.INSTALLED,
+            used_by_pipelines=[],
+            default=False,
+            unsupported_devices=None,
+            download_request=None,
+        )
+
+    def _post_upload(
+        self,
+        *,
+        model_name: str = "my-detector",
+        category: str = "detection",
+        file_bytes: bytes = b"fake-zip-bytes",
+        file_name: str = "my-detector.zip",
+    ):
+        """Helper to POST a multipart upload with the standard form fields."""
+        return self.client.post(
+            "/models/upload",
+            data={"model_name": model_name, "category": category},
+            files={"file": (file_name, io.BytesIO(file_bytes), "application/zip")},
+        )
+
+    def test_upload_model_success_returns_201(self):
+        """Happy path: ModelManager returns a model + 201, route mirrors it."""
+        model = self._make_uploaded_model()
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_cls.write_upload_to_tempfile.return_value = "/tmp/upload.zip"
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.upload_model.return_value = (
+                model,
+                201,
+                "Model uploaded successfully",
+            )
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self._post_upload()
+
+            self.assertEqual(response.status_code, 201)
+            body = response.json()
+            self.assertEqual(body["model"]["name"], "my-detector")
+            self.assertEqual(body["model"]["source"], "custom")
+            self.assertEqual(body["model"]["install_status"], "installed")
+
+            # The route must always delete the temp file, even on success.
+            mock_manager_cls.cleanup_tempfile.assert_called_once_with("/tmp/upload.zip")
+            # Manager was driven with the form fields verbatim.
+            spec = mock_manager_instance.upload_model.call_args.args[0]
+            self.assertEqual(spec.model_name, "my-detector")
+            self.assertEqual(spec.category, InternalModelCategory.DETECTION)
+            self.assertEqual(spec.file_path, "/tmp/upload.zip")
+
+    def test_upload_model_manager_rejects_with_409(self):
+        """When the manager returns ``(None, 409, msg)`` the route returns 409."""
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_cls.write_upload_to_tempfile.return_value = "/tmp/upload.zip"
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.upload_model.return_value = (
+                None,
+                409,
+                "Model already exists",
+            )
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self._post_upload()
+
+            self.assertEqual(response.status_code, 409)
+            self.assertEqual(response.json()["message"], "Model already exists")
+            mock_manager_cls.cleanup_tempfile.assert_called_once_with("/tmp/upload.zip")
+
+    def test_upload_model_manager_rejects_with_502(self):
+        """Upstream model-download error surfaces as 502."""
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_cls.write_upload_to_tempfile.return_value = "/tmp/upload.zip"
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.upload_model.return_value = (
+                None,
+                502,
+                "Upload failed: connection refused",
+            )
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self._post_upload()
+
+            self.assertEqual(response.status_code, 502)
+            self.assertIn("connection refused", response.json()["message"])
+
+    def test_upload_model_returns_500_on_unexpected_error(self):
+        """An unexpected exception inside the route maps to 500 + cleanup."""
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_cls.write_upload_to_tempfile.return_value = "/tmp/upload.zip"
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.upload_model.side_effect = RuntimeError("nope")
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self._post_upload()
+
+            self.assertEqual(response.status_code, 500)
+            self.assertIn("Unexpected error", response.json()["message"])
+            # Tempfile must still be cleaned up via the ``finally`` block.
+            mock_manager_cls.cleanup_tempfile.assert_called_once_with("/tmp/upload.zip")
+
+    def test_upload_model_forwards_original_filename(self):
+        """The ``InternalModelUploadSpec`` carries the client-provided filename."""
+        model = self._make_uploaded_model()
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_cls.write_upload_to_tempfile.return_value = "/tmp/upload.zip"
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.upload_model.return_value = (model, 201, "ok")
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self._post_upload(file_name="archive.zip")
+            self.assertEqual(response.status_code, 201)
+            spec = mock_manager_instance.upload_model.call_args.args[0]
+            self.assertEqual(spec.original_filename, "archive.zip")
+
+    def test_upload_model_missing_form_field_returns_422(self):
+        """FastAPI validation rejects requests without ``model_name``."""
+        response = self.client.post(
+            "/models/upload",
+            data={"category": "detection"},
+            files={
+                "file": ("a.zip", io.BytesIO(b"x"), "application/zip"),
+            },
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_upload_model_invalid_category_returns_422(self):
+        """Unknown category values are rejected by the Enum validator."""
+        response = self.client.post(
+            "/models/upload",
+            data={"model_name": "x", "category": "not-a-category"},
+            files={
+                "file": ("a.zip", io.BytesIO(b"x"), "application/zip"),
+            },
+        )
+        self.assertEqual(response.status_code, 422)
+
+
+class TestModelsDownloadAPI(unittest.TestCase):
+    """Tests for POST /models/download (batch download endpoint).
+
+    The route delegates per-model decisions to ``ModelManager.start_download``
+    and aggregates the per-model HTTP-like statuses into a single envelope
+    HTTP status via ``_aggregate_status``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        app = FastAPI()
+        app.include_router(models_router, prefix="/models")
+        cls.client = TestClient(app)
+
+    def test_download_single_accepted_returns_202(self):
+        """One model accepted -> envelope status 202 + jobs map entry."""
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.start_download.return_value = (
+                "job-1",
+                202,
+                "Download started (job job-1)",
+            )
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self.client.post("/models/download", json={"names": ["yolo11n"]})
+
+            self.assertEqual(response.status_code, 202)
+            jobs = response.json()["jobs"]
+            self.assertEqual(jobs["yolo11n"]["job_id"], "job-1")
+            self.assertEqual(jobs["yolo11n"]["status_code"], 202)
+            self.assertEqual(jobs["yolo11n"]["name"], "yolo11n")
+
+    def test_download_mixed_results_returns_207(self):
+        """Some accepted + some rejected -> 207 Multi-Status."""
+
+        def fake_start(name: str):
+            if name == "yolo11n":
+                return ("job-1", 202, "Download started")
+            return (None, 409, f"Model '{name}' is already installed")
+
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.start_download.side_effect = fake_start
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self.client.post(
+                "/models/download",
+                json={"names": ["yolo11n", "yolov8n"]},
+            )
+
+            self.assertEqual(response.status_code, 207)
+            jobs = response.json()["jobs"]
+            self.assertEqual(jobs["yolo11n"]["status_code"], 202)
+            self.assertEqual(jobs["yolov8n"]["status_code"], 409)
+            self.assertIsNone(jobs["yolov8n"]["job_id"])
+
+    def test_download_all_rejected_same_code_returns_that_code(self):
+        """All entries fail with the same client error code -> that code."""
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.start_download.return_value = (
+                None,
+                404,
+                "unknown",
+            )
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self.client.post("/models/download", json={"names": ["a", "b"]})
+
+            self.assertEqual(response.status_code, 404)
+
+    def test_download_all_rejected_mixed_codes_picks_400(self):
+        """Mixed rejected codes: precedence is 400 > 404 > 409."""
+
+        def fake_start(name: str):
+            return {
+                "a": (None, 409, "x"),
+                "b": (None, 404, "y"),
+                "c": (None, 400, "z"),
+            }[name]
+
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.start_download.side_effect = fake_start
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self.client.post(
+                "/models/download", json={"names": ["a", "b", "c"]}
+            )
+
+            self.assertEqual(response.status_code, 400)
+
+    def test_download_returns_500_when_manager_raises(self):
+        """An unexpected error inside ``start_download`` maps to 500."""
+        with patch("api.routes.models.ModelManager") as mock_manager_cls:
+            mock_manager_instance = MagicMock()
+            mock_manager_instance.start_download.side_effect = RuntimeError("boom")
+            mock_manager_cls.return_value = mock_manager_instance
+
+            response = self.client.post("/models/download", json={"names": ["yolo11n"]})
+
+            self.assertEqual(response.status_code, 500)
+            self.assertIn("Unexpected error", response.json()["message"])
+
+    def test_download_empty_names_rejected_by_validator(self):
+        """``names=[]`` is rejected by the Pydantic ``min_length=1`` rule."""
+        response = self.client.post("/models/download", json={"names": []})
+        self.assertEqual(response.status_code, 422)
+
+    def test_download_duplicate_names_rejected_by_validator(self):
+        """Duplicate names are rejected (the per-name response map must be unambiguous)."""
+        response = self.client.post("/models/download", json={"names": ["a", "a"]})
+        self.assertEqual(response.status_code, 422)
+
+
+class TestAggregateStatus(unittest.TestCase):
+    """Direct unit tests for ``_aggregate_status`` precedence rules."""
+
+    @staticmethod
+    def _item(code: int) -> schemas.ModelDownloadJobItem:
+        return schemas.ModelDownloadJobItem(
+            name="x", job_id=None, status_code=code, message=""
+        )
+
+    def test_all_accepted_is_202(self):
+        items = {"a": self._item(202), "b": self._item(202)}
+        self.assertEqual(_aggregate_status(items), 202)
+
+    def test_mixed_accept_and_reject_is_207(self):
+        items = {"a": self._item(202), "b": self._item(409)}
+        self.assertEqual(_aggregate_status(items), 207)
+
+    def test_all_rejected_picks_400_first(self):
+        items = {
+            "a": self._item(409),
+            "b": self._item(404),
+            "c": self._item(400),
+        }
+        self.assertEqual(_aggregate_status(items), 400)
+
+    def test_all_rejected_picks_404_when_no_400(self):
+        items = {"a": self._item(409), "b": self._item(404)}
+        self.assertEqual(_aggregate_status(items), 404)
+
+    def test_all_rejected_409_only(self):
+        items = {"a": self._item(409), "b": self._item(409)}
+        self.assertEqual(_aggregate_status(items), 409)
+
+    def test_unknown_codes_fall_back_to_first(self):
+        """Codes outside the documented set fall back to the first value."""
+        items = {"a": self._item(418), "b": self._item(500)}
+        self.assertEqual(_aggregate_status(items), 418)
+
+    def test_empty_mapping_returns_202(self):
+        """Defensive: empty mapping should not crash (validator guards real route)."""
+        self.assertEqual(_aggregate_status({}), 202)
 
 
 if __name__ == "__main__":

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/graph_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/graph_test.py
@@ -7751,5 +7751,105 @@ class TestInternalMarkersStrippedFromPipelineDescription(unittest.TestCase):
         self.assertIn("num-buffers=10", description)
 
 
+class TestUploadedModelFallback(unittest.TestCase):
+    """Cover the ``ModelManager`` fallback added to ``_model_path_to_display_name``
+    and ``_model_display_name_to_path`` so uploaded (custom) models keep
+    working through the simple-graph / convert-to-advanced flow.
+    """
+
+    def _node(self, model_value: str, model_proc: str | None = None) -> Node:
+        data: dict[str, str] = {"model": model_value}
+        if model_proc is not None:
+            data["model-proc"] = model_proc
+        return Node(id="n1", type="gvadetect", data=data)
+
+    # --- path -> display name ---------------------------------------
+
+    def test_path_to_display_name_falls_back_to_model_manager(self) -> None:
+        from graph import _model_path_to_display_name
+
+        node = self._node("/models/output/custom_uploaded_models/face-custom/model.xml")
+
+        yaml_manager = MagicMock()
+        yaml_manager.find_model_by_model_and_proc_path.return_value = None
+        mm = MagicMock()
+        mm.find_uploaded_model_by_path.return_value = MagicMock(
+            display_name="face-custom"
+        )
+
+        with (
+            patch("graph.SupportedModelsManager", return_value=yaml_manager),
+            patch("managers.model_manager.ModelManager", return_value=mm),
+        ):
+            _model_path_to_display_name([node])
+
+        self.assertEqual(node.data["model"], "face-custom")
+        # model-proc must be stripped after conversion.
+        self.assertNotIn("model-proc", node.data)
+        mm.find_uploaded_model_by_path.assert_called_once()
+
+    def test_path_to_display_name_empty_when_neither_resolves(self) -> None:
+        from graph import _model_path_to_display_name
+
+        node = self._node("/totally/unknown.xml")
+        yaml_manager = MagicMock()
+        yaml_manager.find_model_by_model_and_proc_path.return_value = None
+        mm = MagicMock()
+        mm.find_uploaded_model_by_path.return_value = None
+
+        with (
+            patch("graph.SupportedModelsManager", return_value=yaml_manager),
+            patch("managers.model_manager.ModelManager", return_value=mm),
+        ):
+            _model_path_to_display_name([node])
+
+        self.assertEqual(node.data["model"], "")
+
+    # --- display name -> path ---------------------------------------
+
+    def test_display_name_to_path_falls_back_to_model_manager(self) -> None:
+        from graph import _model_display_name_to_path
+
+        node = self._node("my-uploaded-model")
+        yaml_manager = MagicMock()
+        yaml_manager.find_installed_model_by_display_name.return_value = None
+
+        uploaded = MagicMock()
+        uploaded.model_path_full = "/abs/path/my-uploaded-model.xml"
+        uploaded.model_proc_full = ""  # uploads have no model-proc
+        mm = MagicMock()
+        mm.find_installed_uploaded_model_by_display_name.return_value = uploaded
+
+        with (
+            patch("graph.SupportedModelsManager", return_value=yaml_manager),
+            patch("managers.model_manager.ModelManager", return_value=mm),
+        ):
+            _model_display_name_to_path([node])
+
+        self.assertEqual(node.data["model"], "/abs/path/my-uploaded-model.xml")
+        # No model-proc must be injected when the model has none.
+        self.assertNotIn("model-proc", node.data)
+        mm.find_installed_uploaded_model_by_display_name.assert_called_once_with(
+            "my-uploaded-model"
+        )
+
+    def test_display_name_to_path_raises_when_unknown_everywhere(self) -> None:
+        from graph import _model_display_name_to_path
+
+        node = self._node("ghost-model")
+        yaml_manager = MagicMock()
+        yaml_manager.find_installed_model_by_display_name.return_value = None
+        mm = MagicMock()
+        mm.find_installed_uploaded_model_by_display_name.return_value = None
+
+        with (
+            patch("graph.SupportedModelsManager", return_value=yaml_manager),
+            patch("managers.model_manager.ModelManager", return_value=mm),
+        ):
+            with self.assertRaises(ValueError) as cm:
+                _model_display_name_to_path([node])
+        self.assertIn("ghost-model", str(cm.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/images_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/images_test.py
@@ -767,13 +767,12 @@ class TestGetImagesInSetEdgeCases(_BaseImagesTest):
 
 
 # --------------------------------------------------------------------------- #
-# Multi-format archive happy-paths (Jira ITEP-89626 explicit cases).
+# Multi-format archive happy-paths.
 # --------------------------------------------------------------------------- #
 
 
 class TestArchiveFormatsHappyPath(_BaseImagesTest):
-    """Cover the three archive formats with the three canonical image
-    extensions exactly as called out by Jira ITEP-89626."""
+    """Cover the three archive formats with the three canonical image extensions."""
 
     def _register(self, name: str, archive_bytes: bytes) -> ImageSet:
         path = _write_archive(self.tmpdir, "incoming.bin", archive_bytes)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/model_manager_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/model_manager_test.py
@@ -1,0 +1,1695 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``managers.model_manager.ModelManager``.
+
+The manager is a thread-safe singleton with three main concerns:
+
+* Aggregating models from ``supported_models.yaml`` and the installed-
+  models registry into a single API-facing list.
+* Driving background download jobs (either OMZ subprocess or HTTP calls
+  to the model-download microservice) and tracking their state.
+* Forwarding multipart model uploads to model-download and registering
+  the resulting model locally.
+
+These tests avoid touching the real filesystem / network: every external
+dependency (``SupportedModelsManager``, ``PipelineManager``,
+``threading.Thread``, ``httpx``, ``subprocess``, ``os.path.*``) is
+patched. The singleton state is reset between tests so that ``_jobs``
+and ``_registry`` always start empty.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, mock_open, patch
+
+import managers.model_manager as mm_module
+from internal_types import (
+    InternalModelCategory,
+    InternalModelDownloadJobState,
+    InternalModelDownloadJobStatus,
+    InternalModelInstallStatus,
+    InternalModelPrecision,
+    InternalModelSource,
+    InternalModelUploadSpec,
+)
+from managers.model_manager import (
+    ModelManager,
+    _DownloadRequestCache,
+    _InstalledModelRecord,
+)
+
+
+# ----------------------------------------------------------------------
+# Test helpers
+# ----------------------------------------------------------------------
+
+
+def _reset_manager() -> None:
+    """Drop the ``ModelManager`` singleton so each test starts from a clean slate.
+
+    The class uses an ``_initialized`` guard inside ``__init__`` so we
+    cannot just create a new instance — we have to drop ``_instance``
+    too, otherwise ``__new__`` returns the previous one.
+    """
+    ModelManager._instance = None
+    # ``_DownloadRequestCache`` is a class-level lazy cache. Drop it so
+    # tests that patch the YAML loader observe a fresh load.
+    _DownloadRequestCache._data = None
+
+
+def _make_supported_model(
+    *,
+    name: str = "yolo11n",
+    display_name: str | None = None,
+    canonical_name: str | None = None,
+    canonical_display_name: str | None = None,
+    hub: str = "ultralytics",
+    model_type: str = "detection",
+    precision: str | None = "FP16",
+    model_path_full: str = "/models/output/ultralytics/yolo11n/FP16/model.xml",
+    default: bool = False,
+    unsupported_devices: str | None = None,
+    exists_on_disk: bool = False,
+) -> MagicMock:
+    """Build a ``SupportedModel``-shaped mock.
+
+    The manager only touches a small subset of attributes/methods, so we
+    do not instantiate the real class (which would resolve ``MODELS_PATH``
+    and normalize paths). All attributes the manager reads are wired up
+    here.
+    """
+    sm = MagicMock(name=f"SupportedModel({name})")
+    sm.name = name
+    sm.display_name = display_name or f"{name} ({precision})" if precision else name
+    sm.canonical_name = canonical_name or name
+    sm.canonical_display_name = canonical_display_name or (
+        f"{name} ({precision})" if precision else name
+    )
+    sm.hub = hub
+    sm.model_type = model_type
+    sm.precision = precision
+    sm.model_path_full = model_path_full
+    sm.default = default
+    sm.unsupported_devices = unsupported_devices
+    sm.exists_on_disk.return_value = exists_on_disk
+    return sm
+
+
+def _make_running_job(
+    *, job_id: str = "job-1", model_name: str = "yolo11n"
+) -> InternalModelDownloadJobStatus:
+    """Build a RUNNING ``InternalModelDownloadJobStatus`` for direct insertion."""
+    return InternalModelDownloadJobStatus(
+        id=job_id,
+        model_name=model_name,
+        source=InternalModelSource.ULTRALYTICS,
+        state=InternalModelDownloadJobState.RUNNING,
+        start_time=int(time.time() * 1000),
+        details=["starting"],
+    )
+
+
+# ----------------------------------------------------------------------
+# Static helpers and tiny pure-function utilities
+# ----------------------------------------------------------------------
+
+
+class TestStaticHelpers(unittest.TestCase):
+    """Unit tests for the small pure helpers on ``ModelManager``."""
+
+    def test_to_internal_source_maps_known_values(self) -> None:
+        self.assertEqual(
+            ModelManager._to_internal_source("ultralytics"),
+            InternalModelSource.ULTRALYTICS,
+        )
+        self.assertEqual(
+            ModelManager._to_internal_source("omz"), InternalModelSource.OMZ
+        )
+
+    def test_to_internal_source_falls_back_to_custom_for_unknown(self) -> None:
+        """Unknown hub values default to CUSTOM — never raise."""
+        self.assertEqual(
+            ModelManager._to_internal_source("something-new"),
+            InternalModelSource.CUSTOM,
+        )
+
+    def test_to_internal_category_returns_none_for_empty(self) -> None:
+        self.assertIsNone(ModelManager._to_internal_category(None))
+        self.assertIsNone(ModelManager._to_internal_category(""))
+
+    def test_to_internal_category_returns_none_for_unknown(self) -> None:
+        self.assertIsNone(ModelManager._to_internal_category("weird"))
+
+    def test_to_internal_category_maps_known(self) -> None:
+        self.assertEqual(
+            ModelManager._to_internal_category("detection"),
+            InternalModelCategory.DETECTION,
+        )
+
+    def test_strip_precision_suffix_removes_trailing_paren(self) -> None:
+        self.assertEqual(
+            ModelManager._strip_precision_suffix("YOLO 11n (INT8)"),
+            "YOLO 11n",
+        )
+
+    def test_strip_precision_suffix_keeps_input_without_suffix(self) -> None:
+        self.assertEqual(
+            ModelManager._strip_precision_suffix("YOLO 11n"),
+            "YOLO 11n",
+        )
+
+    def test_collect_precisions_dedupes_and_preserves_order(self) -> None:
+        a = _make_supported_model(precision="FP16", model_path_full="/p/a.xml")
+        b = _make_supported_model(precision="INT8", model_path_full="/p/b.xml")
+        # Second FP16 entry must be ignored (already seen).
+        c = _make_supported_model(precision="FP16", model_path_full="/p/c.xml")
+        d = _make_supported_model(precision=None, model_path_full="/p/d.xml")
+
+        mgr = MagicMock(spec=ModelManager)
+        precisions = ModelManager._collect_precisions(mgr, [a, b, c, d])
+
+        self.assertEqual([p.precision for p in precisions], ["FP16", "INT8"])
+        self.assertEqual(precisions[0].model_path, "/p/a.xml")
+
+    def test_collect_variants_dedupes_by_display_name(self) -> None:
+        """Variants are deduped by display_name so duplicate precisions collapse."""
+        a = _make_supported_model(
+            name="m_INT8", display_name="m (INT8)", precision="INT8"
+        )
+        b = _make_supported_model(
+            name="m_INT8", display_name="m (INT8)", precision="INT8"
+        )
+        c = _make_supported_model(
+            name="m_FP16", display_name="m (FP16)", precision="FP16"
+        )
+        a.exists_on_disk.return_value = True
+        b.exists_on_disk.return_value = True
+        c.exists_on_disk.return_value = False
+
+        variants = ModelManager._collect_variants([a, b, c])
+
+        self.assertEqual([v.display_name for v in variants], ["m (INT8)", "m (FP16)"])
+        self.assertTrue(variants[0].installed)
+        self.assertFalse(variants[1].installed)
+
+    def test_variants_from_record_with_precision(self) -> None:
+        record = _InstalledModelRecord(
+            name="custom",
+            display_name="My Custom Model",
+            source=InternalModelSource.CUSTOM,
+            category=InternalModelCategory.DETECTION,
+            precisions=[
+                InternalModelPrecision(precision="FP32", model_path="/p/x.xml")
+            ],
+        )
+        variants = ModelManager._variants_from_record(record)
+        self.assertEqual(len(variants), 1)
+        self.assertEqual(variants[0].display_name, "My Custom Model (FP32)")
+        self.assertEqual(variants[0].precision, "FP32")
+        self.assertTrue(variants[0].installed)
+
+    def test_variants_from_record_without_precision(self) -> None:
+        """Records without a precision label still produce one valid variant."""
+        record = _InstalledModelRecord(
+            name="custom",
+            display_name="My Custom",
+            source=InternalModelSource.CUSTOM,
+            category=None,
+            precisions=[InternalModelPrecision(precision="", model_path="/p/x.xml")],
+        )
+        variants = ModelManager._variants_from_record(record)
+        self.assertEqual(variants[0].display_name, "My Custom")
+        self.assertEqual(variants[0].precision, "")
+
+
+# ----------------------------------------------------------------------
+# Install-status computation
+# ----------------------------------------------------------------------
+
+
+class TestComputeInstallStatus(unittest.TestCase):
+    """Cover every branch of ``_compute_install_status``."""
+
+    def setUp(self) -> None:
+        _reset_manager()
+        # Patch the YAML loader so ``__init__`` does not touch disk.
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._supported_patcher.start()
+        self.mgr = ModelManager()
+        # Drop any pre-loaded registry state.
+        self.mgr._registry = {}
+        self.mgr._jobs = {}
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        _reset_manager()
+
+    def test_files_on_disk_short_circuits_to_installed(self) -> None:
+        entry = _make_supported_model(exists_on_disk=True)
+        status = self.mgr._compute_install_status(
+            name="yolo11n", entries=[entry], active_jobs={}
+        )
+        self.assertEqual(status, InternalModelInstallStatus.INSTALLED)
+
+    def test_registry_only_is_installed(self) -> None:
+        self.mgr._registry["yolo11n"] = _InstalledModelRecord(
+            name="yolo11n",
+            display_name="x",
+            source=InternalModelSource.ULTRALYTICS,
+            category=None,
+            precisions=[],
+        )
+        entry = _make_supported_model(exists_on_disk=False)
+        status = self.mgr._compute_install_status(
+            name="yolo11n", entries=[entry], active_jobs={}
+        )
+        self.assertEqual(status, InternalModelInstallStatus.INSTALLED)
+
+    def test_running_job_yields_installing(self) -> None:
+        entry = _make_supported_model(exists_on_disk=False)
+        job = _make_running_job(model_name="yolo11n")
+        status = self.mgr._compute_install_status(
+            name="yolo11n", entries=[entry], active_jobs={"yolo11n": job}
+        )
+        self.assertEqual(status, InternalModelInstallStatus.INSTALLING)
+
+    def test_failed_job_yields_failed(self) -> None:
+        entry = _make_supported_model(exists_on_disk=False)
+        job = _make_running_job(model_name="yolo11n")
+        job.state = InternalModelDownloadJobState.FAILED
+        status = self.mgr._compute_install_status(
+            name="yolo11n", entries=[entry], active_jobs={"yolo11n": job}
+        )
+        self.assertEqual(status, InternalModelInstallStatus.FAILED)
+
+    def test_completed_job_without_files_is_not_installed(self) -> None:
+        """A COMPLETED job without on-disk files / registry entry must not
+        be reported as INSTALLED — the registry update is the source of
+        truth for "installed", not the job state."""
+        entry = _make_supported_model(exists_on_disk=False)
+        job = _make_running_job(model_name="yolo11n")
+        job.state = InternalModelDownloadJobState.COMPLETED
+        status = self.mgr._compute_install_status(
+            name="yolo11n", entries=[entry], active_jobs={"yolo11n": job}
+        )
+        self.assertEqual(status, InternalModelInstallStatus.NOT_INSTALLED)
+
+    def test_no_job_no_files_no_registry_is_not_installed(self) -> None:
+        entry = _make_supported_model(exists_on_disk=False)
+        status = self.mgr._compute_install_status(
+            name="yolo11n", entries=[entry], active_jobs={}
+        )
+        self.assertEqual(status, InternalModelInstallStatus.NOT_INSTALLED)
+
+
+# ----------------------------------------------------------------------
+# Registry persistence
+# ----------------------------------------------------------------------
+
+
+class TestRegistryPersistence(unittest.TestCase):
+    """Cover ``_load_registry`` / ``_save_registry_locked`` branches."""
+
+    def setUp(self) -> None:
+        _reset_manager()
+        self._tmpdir = tempfile.mkdtemp(prefix="vippet-mm-registry-")
+        self._registry_path = os.path.join(self._tmpdir, "installed_models.json")
+        # Redirect the module-level constant for the duration of the test.
+        self._orig_path = mm_module.INSTALLED_MODELS_REGISTRY
+        mm_module.INSTALLED_MODELS_REGISTRY = self._registry_path
+        # Avoid touching the real SupportedModelsManager.
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._supported_patcher.start()
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        mm_module.INSTALLED_MODELS_REGISTRY = self._orig_path
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        _reset_manager()
+
+    def test_load_registry_no_file_leaves_registry_empty(self) -> None:
+        # File does not exist — manager should boot with an empty registry.
+        mgr = ModelManager()
+        self.assertEqual(mgr._registry, {})
+
+    def test_load_registry_invalid_shape_is_ignored(self) -> None:
+        with open(self._registry_path, "w") as f:
+            json.dump({"not": "a list"}, f)
+        mgr = ModelManager()
+        self.assertEqual(mgr._registry, {})
+
+    def test_load_registry_prunes_entries_with_missing_files(self) -> None:
+        """Records whose ``model_path`` does not exist on disk are dropped
+        and the file rewritten in sync."""
+        with open(self._registry_path, "w") as f:
+            json.dump(
+                [
+                    {
+                        "name": "ghost",
+                        "display_name": "Ghost",
+                        "source": "custom",
+                        "category": "detection",
+                        "precisions": [
+                            {"precision": "FP32", "model_path": "/does/not/exist"}
+                        ],
+                    }
+                ],
+                f,
+            )
+        mgr = ModelManager()
+        self.assertNotIn("ghost", mgr._registry)
+        # Registry file should now reflect the pruned state.
+        with open(self._registry_path) as f:
+            saved = json.load(f)
+        self.assertEqual(saved, [])
+
+    def test_load_registry_keeps_entry_with_existing_file(self) -> None:
+        """An entry whose model file exists is loaded verbatim."""
+        existing_file = os.path.join(self._tmpdir, "model.xml")
+        open(existing_file, "w").close()
+        with open(self._registry_path, "w") as f:
+            json.dump(
+                [
+                    {
+                        "name": "kept",
+                        "display_name": "Kept",
+                        "source": "custom",
+                        "category": "classification",
+                        "precisions": [
+                            {"precision": "FP32", "model_path": existing_file}
+                        ],
+                    }
+                ],
+                f,
+            )
+        mgr = ModelManager()
+        self.assertIn("kept", mgr._registry)
+        record = mgr._registry["kept"]
+        self.assertEqual(record.source, InternalModelSource.CUSTOM)
+        self.assertEqual(record.category, InternalModelCategory.CLASSIFICATION)
+        self.assertEqual(record.precisions[0].model_path, existing_file)
+
+    def test_load_registry_skips_malformed_entries(self) -> None:
+        """Entries without ``name`` or with broken precisions are skipped."""
+        existing_file = os.path.join(self._tmpdir, "ok.xml")
+        open(existing_file, "w").close()
+        with open(self._registry_path, "w") as f:
+            json.dump(
+                [
+                    {"display_name": "no-name"},  # missing name
+                    {
+                        "name": "no-precisions",
+                        "precisions": [],  # pruned by ``not precisions`` guard
+                    },
+                    {
+                        "name": "ok",
+                        "display_name": "OK",
+                        "source": "custom",
+                        "category": "detection",
+                        "precisions": [
+                            {"precision": "FP32", "model_path": existing_file}
+                        ],
+                    },
+                ],
+                f,
+            )
+        mgr = ModelManager()
+        self.assertEqual(set(mgr._registry.keys()), {"ok"})
+
+    def test_upsert_and_remove_persist_to_disk(self) -> None:
+        mgr = ModelManager()
+        existing_file = os.path.join(self._tmpdir, "live.xml")
+        open(existing_file, "w").close()
+
+        mgr._upsert_registry_record(
+            _InstalledModelRecord(
+                name="live",
+                display_name="Live",
+                source=InternalModelSource.CUSTOM,
+                category=None,
+                precisions=[
+                    InternalModelPrecision(precision="", model_path=existing_file)
+                ],
+            )
+        )
+        with open(self._registry_path) as f:
+            saved = json.load(f)
+        self.assertEqual(saved[0]["name"], "live")
+
+        mgr._remove_registry_record("live")
+        with open(self._registry_path) as f:
+            saved = json.load(f)
+        self.assertEqual(saved, [])
+
+    def test_remove_registry_record_missing_name_is_noop(self) -> None:
+        """Removing a name that is not in the registry must not write to disk."""
+        mgr = ModelManager()
+        # File does not exist yet.
+        mgr._remove_registry_record("never-existed")
+        self.assertFalse(os.path.exists(self._registry_path))
+
+
+# ----------------------------------------------------------------------
+# list_models — aggregation of YAML + registry
+# ----------------------------------------------------------------------
+
+
+class TestListModels(unittest.TestCase):
+    """Cover ``list_models`` aggregation paths."""
+
+    def setUp(self) -> None:
+        _reset_manager()
+        self._tmpdir = tempfile.mkdtemp(prefix="vippet-mm-list-")
+        self._orig_path = mm_module.INSTALLED_MODELS_REGISTRY
+        mm_module.INSTALLED_MODELS_REGISTRY = os.path.join(
+            self._tmpdir, "installed_models.json"
+        )
+        # Patch the YAML loader and the pipeline manager. We patch both
+        # the type and its singleton accessor pattern by returning the
+        # same mock instance on each call.
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._pipeline_patcher = patch("managers.model_manager.PipelineManager")
+        self._supported_cls = self._supported_patcher.start()
+        self._pipeline_cls = self._pipeline_patcher.start()
+        self._supported_cls.return_value.get_all_supported_models.return_value = []
+        self._pipeline_cls.return_value.get_model_display_names_used_by_pipelines.return_value = {}
+        # Patch the download_request cache to a fixed value.
+        _DownloadRequestCache._data = {}
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        self._pipeline_patcher.stop()
+        mm_module.INSTALLED_MODELS_REGISTRY = self._orig_path
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        _reset_manager()
+
+    def test_list_models_yaml_entry_not_installed(self) -> None:
+        entry = _make_supported_model(
+            name="yolo11n",
+            display_name="YOLO 11n (FP16)",
+            canonical_name="yolo11n",
+            canonical_display_name="YOLO 11n (FP16)",
+            precision="FP16",
+            exists_on_disk=False,
+        )
+        self._supported_cls.return_value.get_all_supported_models.return_value = [entry]
+
+        mgr = ModelManager()
+        models = mgr.list_models()
+
+        self.assertEqual(len(models), 1)
+        m = models[0]
+        self.assertEqual(m.name, "yolo11n")
+        # Trailing ``(FP16)`` suffix is stripped from the canonical name.
+        self.assertEqual(m.display_name, "YOLO 11n")
+        self.assertEqual(m.source, InternalModelSource.ULTRALYTICS)
+        self.assertEqual(m.install_status, InternalModelInstallStatus.NOT_INSTALLED)
+        self.assertEqual([v.precision for v in m.variants], ["FP16"])
+
+    def test_list_models_marks_installed_when_files_present(self) -> None:
+        entry = _make_supported_model(
+            name="yolo11n",
+            canonical_name="yolo11n",
+            precision="FP16",
+            exists_on_disk=True,
+        )
+        self._supported_cls.return_value.get_all_supported_models.return_value = [entry]
+
+        mgr = ModelManager()
+        models = mgr.list_models()
+        self.assertEqual(models[0].install_status, InternalModelInstallStatus.INSTALLED)
+
+    def test_list_models_groups_multiple_precisions(self) -> None:
+        """Two YAML entries with the same canonical name collapse into one Model."""
+        a = _make_supported_model(
+            name="yolo11n_FP16",
+            canonical_name="yolo11n",
+            canonical_display_name="YOLO 11n (FP16)",
+            display_name="YOLO 11n (FP16)",
+            precision="FP16",
+        )
+        b = _make_supported_model(
+            name="yolo11n_INT8",
+            canonical_name="yolo11n",
+            canonical_display_name="YOLO 11n (INT8)",
+            display_name="YOLO 11n (INT8)",
+            precision="INT8",
+        )
+        self._supported_cls.return_value.get_all_supported_models.return_value = [a, b]
+
+        mgr = ModelManager()
+        models = mgr.list_models()
+        self.assertEqual(len(models), 1)
+        self.assertEqual([p.precision for p in models[0].precisions], ["FP16", "INT8"])
+
+    def test_list_models_includes_registry_only_custom_models(self) -> None:
+        """Custom uploaded models are listed even with no YAML entry."""
+        existing_file = os.path.join(self._tmpdir, "custom.xml")
+        open(existing_file, "w").close()
+
+        mgr = ModelManager()
+        mgr._registry["my-custom"] = _InstalledModelRecord(
+            name="my-custom",
+            display_name="My Custom",
+            source=InternalModelSource.CUSTOM,
+            category=InternalModelCategory.DETECTION,
+            precisions=[
+                InternalModelPrecision(precision="FP32", model_path=existing_file)
+            ],
+        )
+
+        models = mgr.list_models()
+        self.assertEqual(len(models), 1)
+        self.assertEqual(models[0].name, "my-custom")
+        self.assertEqual(models[0].source, InternalModelSource.CUSTOM)
+        self.assertEqual(models[0].install_status, InternalModelInstallStatus.INSTALLED)
+
+    def test_list_models_skips_registry_entries_already_in_yaml(self) -> None:
+        """Registry entries matching a YAML canonical name are not duplicated."""
+        entry = _make_supported_model(name="yolo11n", canonical_name="yolo11n")
+        self._supported_cls.return_value.get_all_supported_models.return_value = [entry]
+        mgr = ModelManager()
+        mgr._registry["yolo11n"] = _InstalledModelRecord(
+            name="yolo11n",
+            display_name="Y",
+            source=InternalModelSource.ULTRALYTICS,
+            category=None,
+            precisions=[],
+        )
+        models = mgr.list_models()
+        names = [m.name for m in models]
+        self.assertEqual(names.count("yolo11n"), 1)
+
+    def test_list_models_used_by_pipelines_is_populated(self) -> None:
+        entry = _make_supported_model(
+            name="yolo11n",
+            canonical_name="yolo11n",
+            display_name="YOLO 11n (FP16)",
+            precision="FP16",
+        )
+        self._supported_cls.return_value.get_all_supported_models.return_value = [entry]
+        self._pipeline_cls.return_value.get_model_display_names_used_by_pipelines.return_value = {
+            "YOLO 11n (FP16)": ["smart-nvr", "goods-detection"]
+        }
+
+        mgr = ModelManager()
+        models = mgr.list_models()
+        self.assertEqual(
+            sorted(models[0].used_by_pipelines), ["goods-detection", "smart-nvr"]
+        )
+
+
+# ----------------------------------------------------------------------
+# start_download — entry-point that picks the right worker
+# ----------------------------------------------------------------------
+
+
+class TestStartDownload(unittest.TestCase):
+    """``start_download`` validation and worker dispatch."""
+
+    def setUp(self) -> None:
+        _reset_manager()
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._supported_cls = self._supported_patcher.start()
+        self._supported_cls.return_value.get_all_supported_models.return_value = []
+        _DownloadRequestCache._data = {}
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        _reset_manager()
+
+    def test_returns_404_for_unknown_model(self) -> None:
+        mgr = ModelManager()
+        job_id, status, msg = mgr.start_download("nope")
+        self.assertIsNone(job_id)
+        self.assertEqual(status, 404)
+        self.assertIn("not supported", msg)
+
+    def test_returns_409_when_files_already_on_disk(self) -> None:
+        entry = _make_supported_model(canonical_name="yolo11n", exists_on_disk=True)
+        self._supported_cls.return_value.get_all_supported_models.return_value = [entry]
+        _DownloadRequestCache._data = {"yolo11n": {"model_id": "yolo11n"}}
+
+        mgr = ModelManager()
+        job_id, status, msg = mgr.start_download("yolo11n")
+        self.assertIsNone(job_id)
+        self.assertEqual(status, 409)
+        self.assertIn("already installed", msg)
+
+    def test_returns_409_when_a_job_is_already_running(self) -> None:
+        entry = _make_supported_model(canonical_name="yolo11n", exists_on_disk=False)
+        self._supported_cls.return_value.get_all_supported_models.return_value = [entry]
+        _DownloadRequestCache._data = {"yolo11n": {"model_id": "yolo11n"}}
+
+        mgr = ModelManager()
+        running = _make_running_job(job_id="existing", model_name="yolo11n")
+        mgr._jobs["existing"] = running
+
+        job_id, status, msg = mgr.start_download("yolo11n")
+        self.assertIsNone(job_id)
+        self.assertEqual(status, 409)
+        self.assertIn("already running", msg)
+
+    def test_returns_400_when_remote_model_has_no_download_request(self) -> None:
+        entry = _make_supported_model(
+            canonical_name="yolo11n", hub="ultralytics", exists_on_disk=False
+        )
+        self._supported_cls.return_value.get_all_supported_models.return_value = [entry]
+        _DownloadRequestCache._data = {}  # No download_request configured.
+
+        mgr = ModelManager()
+        job_id, status, msg = mgr.start_download("yolo11n")
+        self.assertIsNone(job_id)
+        self.assertEqual(status, 400)
+        self.assertIn("download_request", msg)
+
+    @patch("managers.model_manager.threading.Thread")
+    def test_returns_202_and_spawns_remote_worker(self, mock_thread_cls) -> None:
+        """Accepted remote download: a worker thread is started and the job is recorded."""
+        entry = _make_supported_model(
+            canonical_name="yolo11n", hub="ultralytics", exists_on_disk=False
+        )
+        self._supported_cls.return_value.get_all_supported_models.return_value = [entry]
+        _DownloadRequestCache._data = {"yolo11n": {"model_id": "yolo11n"}}
+
+        mgr = ModelManager()
+        job_id, status, msg = mgr.start_download("yolo11n")
+
+        self.assertEqual(status, 202)
+        self.assertIsNotNone(job_id)
+        self.assertIn(job_id, mgr._jobs)
+        # The worker thread was created and started exactly once.
+        mock_thread_cls.assert_called_once()
+        mock_thread_cls.return_value.start.assert_called_once()
+        # Dispatched to the remote worker (not the OMZ one).
+        target = mock_thread_cls.call_args.kwargs["target"]
+        self.assertEqual(target, mgr._execute_remote_download)
+
+    @patch("managers.model_manager.threading.Thread")
+    def test_returns_202_for_omz_without_download_request(
+        self, mock_thread_cls
+    ) -> None:
+        """OMZ source is allowed to start a download with no ``download_request``."""
+        entry = _make_supported_model(
+            canonical_name="age-gender-recognition-retail-0013",
+            hub="omz",
+            exists_on_disk=False,
+        )
+        self._supported_cls.return_value.get_all_supported_models.return_value = [entry]
+        _DownloadRequestCache._data = {}  # OMZ does not need a download_request.
+
+        mgr = ModelManager()
+        job_id, status, _msg = mgr.start_download("age-gender-recognition-retail-0013")
+
+        self.assertEqual(status, 202)
+        target = mock_thread_cls.call_args.kwargs["target"]
+        self.assertEqual(target, mgr._execute_omz_download)
+
+
+# ----------------------------------------------------------------------
+# Remote download worker — happy path / failures / timeout
+# ----------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``httpx.Response`` used by the remote worker tests."""
+
+    def __init__(self, *, status_code: int = 200, json_body: Any = None) -> None:
+        self.status_code = status_code
+        self._json = json_body if json_body is not None else {}
+
+    def json(self) -> Any:
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import httpx
+
+            raise httpx.HTTPStatusError(
+                "http error", request=MagicMock(), response=MagicMock()
+            )
+
+
+class _FakeHttpxClient:
+    """Context-manager stub returning canned responses for POST/GET."""
+
+    def __init__(
+        self,
+        *,
+        post_response: _FakeResponse | None = None,
+        get_responses: list[_FakeResponse] | None = None,
+        raise_on: str | None = None,
+    ) -> None:
+        self._post_response = post_response or _FakeResponse()
+        self._get_queue = list(get_responses or [])
+        self._raise_on = raise_on
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+        self.gets: list[str] = []
+
+    def __enter__(self) -> "_FakeHttpxClient":
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        return None
+
+    def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        import httpx
+
+        if self._raise_on == "post":
+            raise httpx.HTTPError("simulated network error")
+        self.posts.append((url, kwargs))
+        return self._post_response
+
+    def get(self, url: str, **_kwargs: Any) -> _FakeResponse:
+        import httpx
+
+        if self._raise_on == "get":
+            raise httpx.HTTPError("simulated network error during poll")
+        self.gets.append(url)
+        if not self._get_queue:
+            # Tests that don't seed enough responses are typically
+            # exercising the timeout path: keep replying ``processing``
+            # so the polling loop only exits via the deadline.
+            return _FakeResponse(json_body={"status": "processing"})
+        return self._get_queue.pop(0)
+
+
+class TestExecuteRemoteDownload(unittest.TestCase):
+    """Cover the remote download worker — happy path, failures, timeout."""
+
+    def setUp(self) -> None:
+        _reset_manager()
+        self._tmpdir = tempfile.mkdtemp(prefix="vippet-mm-remote-")
+        self._orig_path = mm_module.INSTALLED_MODELS_REGISTRY
+        mm_module.INSTALLED_MODELS_REGISTRY = os.path.join(
+            self._tmpdir, "installed_models.json"
+        )
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._supported_cls = self._supported_patcher.start()
+        self._supported_cls.return_value.get_all_supported_models.return_value = []
+        # Speed up the polling loop and timeout for tests.
+        self._orig_poll = mm_module.DOWNLOAD_POLL_INTERVAL_S
+        self._orig_timeout = mm_module.DOWNLOAD_TIMEOUT_S
+        mm_module.DOWNLOAD_POLL_INTERVAL_S = 0
+        mm_module.DOWNLOAD_TIMEOUT_S = 5
+        self.mgr = ModelManager()
+        self.head = _make_supported_model(canonical_name="yolo11n")
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        mm_module.DOWNLOAD_POLL_INTERVAL_S = self._orig_poll
+        mm_module.DOWNLOAD_TIMEOUT_S = self._orig_timeout
+        mm_module.INSTALLED_MODELS_REGISTRY = self._orig_path
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        _reset_manager()
+
+    def _seed_job(self, job_id: str = "job-1") -> None:
+        self.mgr._jobs[job_id] = _make_running_job(job_id=job_id, model_name="yolo11n")
+
+    def test_completes_when_all_external_jobs_succeed(self) -> None:
+        self._seed_job()
+        client = _FakeHttpxClient(
+            post_response=_FakeResponse(json_body={"job_ids": ["ext-1"]}),
+            get_responses=[_FakeResponse(json_body={"status": "completed"})],
+        )
+        with (
+            patch("managers.model_manager.httpx.Client", return_value=client),
+            patch.object(self.mgr, "_finalize_success") as fin,
+        ):
+            self.mgr._execute_remote_download(
+                "job-1", "yolo11n", self.head, {"model_id": "yolo11n"}
+            )
+        fin.assert_called_once_with("job-1", "yolo11n", self.head)
+
+    def test_fails_when_post_returns_no_job_ids(self) -> None:
+        self._seed_job()
+        client = _FakeHttpxClient(
+            post_response=_FakeResponse(json_body={"job_ids": []})
+        )
+        with patch("managers.model_manager.httpx.Client", return_value=client):
+            self.mgr._execute_remote_download(
+                "job-1", "yolo11n", self.head, {"model_id": "yolo11n"}
+            )
+        job = self.mgr._jobs["job-1"]
+        self.assertEqual(job.state, InternalModelDownloadJobState.FAILED)
+        self.assertIn("no job ids", job.details[0])
+
+    def test_aggregates_errors_when_polling_reports_failed(self) -> None:
+        self._seed_job()
+        client = _FakeHttpxClient(
+            post_response=_FakeResponse(
+                json_body={"job_ids": ["ext-1", "ext-2"], "status": "queued"}
+            ),
+            get_responses=[
+                _FakeResponse(json_body={"status": "failed", "error": "boom-1"}),
+                _FakeResponse(json_body={"status": "completed"}),
+            ],
+        )
+        with patch("managers.model_manager.httpx.Client", return_value=client):
+            self.mgr._execute_remote_download(
+                "job-1", "yolo11n", self.head, {"model_id": "yolo11n"}
+            )
+        job = self.mgr._jobs["job-1"]
+        self.assertEqual(job.state, InternalModelDownloadJobState.FAILED)
+        self.assertIn("boom-1", job.details[0])
+
+    def test_treats_404_from_external_job_as_failure(self) -> None:
+        self._seed_job()
+        client = _FakeHttpxClient(
+            post_response=_FakeResponse(json_body={"job_ids": ["ext-1"]}),
+            get_responses=[_FakeResponse(status_code=404)],
+        )
+        with patch("managers.model_manager.httpx.Client", return_value=client):
+            self.mgr._execute_remote_download(
+                "job-1", "yolo11n", self.head, {"model_id": "yolo11n"}
+            )
+        job = self.mgr._jobs["job-1"]
+        self.assertEqual(job.state, InternalModelDownloadJobState.FAILED)
+        self.assertIn("not found", job.details[0])
+
+    def test_post_http_error_marks_job_failed(self) -> None:
+        self._seed_job()
+        client = _FakeHttpxClient(raise_on="post")
+        with patch("managers.model_manager.httpx.Client", return_value=client):
+            self.mgr._execute_remote_download(
+                "job-1", "yolo11n", self.head, {"model_id": "yolo11n"}
+            )
+        job = self.mgr._jobs["job-1"]
+        self.assertEqual(job.state, InternalModelDownloadJobState.FAILED)
+        self.assertIn("HTTP error", job.details[0])
+
+    def test_polling_timeout_marks_job_failed(self) -> None:
+        """When external jobs never reach a terminal state the worker times out."""
+        self._seed_job()
+        # Force the polling loop to run at least once, then expire the deadline.
+        mm_module.DOWNLOAD_TIMEOUT_S = 0.05
+        client = _FakeHttpxClient(
+            post_response=_FakeResponse(json_body={"job_ids": ["ext-1"]}),
+            # Always returns ``processing`` so the loop never finishes.
+            get_responses=[
+                _FakeResponse(json_body={"status": "processing"}) for _ in range(50)
+            ],
+        )
+        with patch("managers.model_manager.httpx.Client", return_value=client):
+            self.mgr._execute_remote_download(
+                "job-1", "yolo11n", self.head, {"model_id": "yolo11n"}
+            )
+        job = self.mgr._jobs["job-1"]
+        self.assertEqual(job.state, InternalModelDownloadJobState.FAILED)
+        self.assertIn("timed out", job.details[0])
+
+
+# ----------------------------------------------------------------------
+# OMZ worker — only the very-light branches
+# ----------------------------------------------------------------------
+
+
+class TestExecuteOmzDownload(unittest.TestCase):
+    """Light tests for the OMZ worker — we mock subprocess + filesystem."""
+
+    def setUp(self) -> None:
+        _reset_manager()
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._supported_cls = self._supported_patcher.start()
+        self._supported_cls.return_value.get_all_supported_models.return_value = []
+        self.mgr = ModelManager()
+        self.head = _make_supported_model(
+            canonical_name="age-gender-recognition-retail-0013", hub="omz"
+        )
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        _reset_manager()
+
+    def _seed_job(self, job_id: str = "job-1") -> None:
+        self.mgr._jobs[job_id] = _make_running_job(
+            job_id=job_id, model_name="age-gender-recognition-retail-0013"
+        )
+        self.mgr._jobs[job_id].source = InternalModelSource.OMZ
+
+    @patch("managers.model_manager.shutil.rmtree")
+    @patch("managers.model_manager.tempfile.mkdtemp", return_value="/tmp/scratch")
+    @patch("managers.model_manager.os.makedirs")
+    def test_happy_path_calls_finalize_success(self, _md, _mk, _rm) -> None:
+        self._seed_job()
+        with (
+            patch.object(self.mgr, "_run_subprocess") as run,
+            patch.object(self.mgr, "_materialize_omz_artifacts") as mat,
+            patch.object(self.mgr, "_finalize_success") as fin,
+        ):
+            self.mgr._execute_omz_download(
+                "job-1", "age-gender-recognition-retail-0013", self.head
+            )
+        self.assertEqual(run.call_count, 2)  # downloader + converter
+        mat.assert_called_once()
+        fin.assert_called_once_with(
+            "job-1", "age-gender-recognition-retail-0013", self.head
+        )
+
+    @patch("managers.model_manager.shutil.rmtree")
+    @patch("managers.model_manager.tempfile.mkdtemp", return_value="/tmp/scratch")
+    @patch("managers.model_manager.os.makedirs")
+    def test_called_process_error_marks_job_failed(self, _md, _mk, _rm) -> None:
+        self._seed_job()
+        err = subprocess.CalledProcessError(
+            returncode=2,
+            cmd=["omz_downloader", "--name", "x"],
+            output=None,
+            stderr="boom",
+        )
+        with patch.object(self.mgr, "_run_subprocess", side_effect=err):
+            self.mgr._execute_omz_download(
+                "job-1", "age-gender-recognition-retail-0013", self.head
+            )
+        job = self.mgr._jobs["job-1"]
+        self.assertEqual(job.state, InternalModelDownloadJobState.FAILED)
+        # ``details`` carries both the summary and the captured stderr.
+        joined = "\n".join(job.details)
+        self.assertIn("OMZ command failed", joined)
+        self.assertIn("boom", joined)
+
+    @patch("managers.model_manager.shutil.rmtree")
+    @patch("managers.model_manager.tempfile.mkdtemp", return_value="/tmp/scratch")
+    @patch("managers.model_manager.os.makedirs")
+    def test_missing_omz_binaries_marks_job_failed(self, _md, _mk, _rm) -> None:
+        self._seed_job()
+        with patch.object(
+            self.mgr,
+            "_run_subprocess",
+            side_effect=FileNotFoundError("omz_downloader"),
+        ):
+            self.mgr._execute_omz_download(
+                "job-1", "age-gender-recognition-retail-0013", self.head
+            )
+        job = self.mgr._jobs["job-1"]
+        self.assertEqual(job.state, InternalModelDownloadJobState.FAILED)
+        self.assertIn("openvino-dev", job.details[0])
+
+
+# ----------------------------------------------------------------------
+# upload_model — proxy to model-download
+# ----------------------------------------------------------------------
+
+
+class TestUploadModel(unittest.TestCase):
+    """Cover the ``upload_model`` proxy path."""
+
+    def setUp(self) -> None:
+        _reset_manager()
+        self._tmpdir = tempfile.mkdtemp(prefix="vippet-mm-upload-")
+        self._orig_path = mm_module.INSTALLED_MODELS_REGISTRY
+        mm_module.INSTALLED_MODELS_REGISTRY = os.path.join(
+            self._tmpdir, "installed_models.json"
+        )
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._supported_patcher.start()
+        # A real, readable file is needed because ``upload_model`` opens it.
+        self._payload = os.path.join(self._tmpdir, "model.zip")
+        with open(self._payload, "wb") as f:
+            f.write(b"PK\x03\x04 fake zip")
+        self.mgr = ModelManager()
+        self.spec = InternalModelUploadSpec(
+            model_name="my-detector",
+            category=InternalModelCategory.DETECTION,
+            file_path=self._payload,
+            original_filename="my-detector.zip",
+        )
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        mm_module.INSTALLED_MODELS_REGISTRY = self._orig_path
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        _reset_manager()
+
+    def test_upload_success_registers_model_and_returns_201(self) -> None:
+        client = _FakeHttpxClient(
+            post_response=_FakeResponse(
+                status_code=201,
+                json_body={"output_dir": "/models/output/custom/my-detector"},
+            )
+        )
+        with patch("managers.model_manager.httpx.Client", return_value=client):
+            model, status, msg = self.mgr.upload_model(self.spec)
+
+        self.assertEqual(status, 201)
+        assert model is not None
+        self.assertEqual(model.name, "my-detector")
+        self.assertEqual(model.source, InternalModelSource.CUSTOM)
+        self.assertEqual(model.install_status, InternalModelInstallStatus.INSTALLED)
+        self.assertIn("my-detector", self.mgr._registry)
+        self.assertEqual(
+            self.mgr._registry["my-detector"].precisions[0].model_path,
+            "/models/output/custom/my-detector",
+        )
+        self.assertIn("uploaded successfully", msg)
+
+    def test_upload_success_without_output_dir_uses_fallback_path(self) -> None:
+        """When model-download omits ``output_dir`` the manager falls back to MODELS_PATH."""
+        client = _FakeHttpxClient(
+            post_response=_FakeResponse(status_code=201, json_body={})
+        )
+        with patch("managers.model_manager.httpx.Client", return_value=client):
+            model, status, _msg = self.mgr.upload_model(self.spec)
+        self.assertEqual(status, 201)
+        assert model is not None
+        # Path is composed from MODELS_PATH + ``custom_uploaded_models``.
+        self.assertTrue(model.precisions[0].model_path.endswith("/my-detector"))
+
+    def test_upload_returns_502_on_http_error(self) -> None:
+        client = _FakeHttpxClient(raise_on="post")
+        with patch("managers.model_manager.httpx.Client", return_value=client):
+            model, status, msg = self.mgr.upload_model(self.spec)
+        self.assertIsNone(model)
+        self.assertEqual(status, 502)
+        self.assertIn("Upload failed", msg)
+
+    def test_upload_propagates_upstream_status_and_detail(self) -> None:
+        """A 4xx response from model-download is mirrored to the caller."""
+        client = _FakeHttpxClient(
+            post_response=_FakeResponse(
+                status_code=409,
+                json_body={"detail": "Model already exists"},
+            )
+        )
+        with patch("managers.model_manager.httpx.Client", return_value=client):
+            model, status, msg = self.mgr.upload_model(self.spec)
+        self.assertIsNone(model)
+        self.assertEqual(status, 409)
+        self.assertEqual(msg, "Model already exists")
+
+    def test_upload_extracts_detail_from_fastapi_validation_array(self) -> None:
+        """FastAPI-style ``detail: [{msg, ...}]`` payloads are summarised."""
+        client = _FakeHttpxClient(
+            post_response=_FakeResponse(
+                status_code=400,
+                json_body={
+                    "detail": [
+                        {"msg": "field required"},
+                        {"msg": "value error"},
+                    ]
+                },
+            )
+        )
+        with patch("managers.model_manager.httpx.Client", return_value=client):
+            _model, status, msg = self.mgr.upload_model(self.spec)
+        self.assertEqual(status, 400)
+        self.assertIn("field required", msg)
+        self.assertIn("value error", msg)
+
+
+# ----------------------------------------------------------------------
+# Temp-file helpers
+# ----------------------------------------------------------------------
+
+
+class TestTempfileHelpers(unittest.TestCase):
+    """Cover ``write_upload_to_tempfile`` and ``cleanup_tempfile``."""
+
+    def test_write_upload_to_tempfile_streams_and_returns_path(self) -> None:
+        import io
+
+        payload = b"hello world" * 100
+        upload = io.BytesIO(payload)
+        path = ModelManager.write_upload_to_tempfile(upload, "x.zip")
+        try:
+            self.assertTrue(os.path.isfile(path))
+            self.assertTrue(path.endswith(".zip"))
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), payload)
+        finally:
+            os.unlink(path)
+
+    def test_write_upload_to_tempfile_cleans_up_on_error(self) -> None:
+        """If copying fails the temp file is removed before re-raising."""
+
+        class BoomBinary:
+            def read(self, *_args: Any, **_kwargs: Any) -> bytes:
+                raise RuntimeError("boom")
+
+        path_holder: list[str] = []
+        real_mkstemp = tempfile.mkstemp
+
+        def _spy_mkstemp(*args: Any, **kwargs: Any) -> tuple[int, str]:
+            fd, p = real_mkstemp(*args, **kwargs)
+            path_holder.append(p)
+            return fd, p
+
+        with patch("managers.model_manager.tempfile.mkstemp", side_effect=_spy_mkstemp):
+            with self.assertRaises(RuntimeError):
+                ModelManager.write_upload_to_tempfile(BoomBinary(), "x.zip")  # type: ignore[arg-type]
+
+        self.assertTrue(path_holder, "spy must have captured the temp path")
+        self.assertFalse(
+            os.path.exists(path_holder[0]),
+            "temp file must be deleted on copy failure",
+        )
+
+    def test_cleanup_tempfile_handles_none_and_missing(self) -> None:
+        # Both paths are silent no-ops.
+        ModelManager.cleanup_tempfile(None)
+        ModelManager.cleanup_tempfile("/does/not/exist")
+
+    def test_cleanup_tempfile_removes_existing_file(self) -> None:
+        fd, path = tempfile.mkstemp(prefix="vippet-cleanup-")
+        os.close(fd)
+        self.assertTrue(os.path.isfile(path))
+        ModelManager.cleanup_tempfile(path)
+        self.assertFalse(os.path.exists(path))
+
+
+# ----------------------------------------------------------------------
+# Lifecycle helpers — _fail_job / _finalize_success
+# ----------------------------------------------------------------------
+
+
+class TestJobLifecycle(unittest.TestCase):
+    """Direct unit tests for ``_fail_job`` and ``_finalize_success``."""
+
+    def setUp(self) -> None:
+        _reset_manager()
+        self._tmpdir = tempfile.mkdtemp(prefix="vippet-mm-lifecycle-")
+        self._orig_path = mm_module.INSTALLED_MODELS_REGISTRY
+        mm_module.INSTALLED_MODELS_REGISTRY = os.path.join(
+            self._tmpdir, "installed_models.json"
+        )
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._supported_cls = self._supported_patcher.start()
+        self._supported_cls.return_value.get_all_supported_models.return_value = []
+        self.mgr = ModelManager()
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        mm_module.INSTALLED_MODELS_REGISTRY = self._orig_path
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        _reset_manager()
+
+    def test_fail_job_records_state_and_end_time(self) -> None:
+        job = _make_running_job(job_id="job-1", model_name="x")
+        self.mgr._jobs["job-1"] = job
+        self.mgr._fail_job("job-1", "stuff went wrong")
+        self.assertEqual(job.state, InternalModelDownloadJobState.FAILED)
+        self.assertIsNotNone(job.end_time)
+        self.assertEqual(job.details, ["stuff went wrong"])
+
+    def test_fail_job_with_custom_details_preserves_them(self) -> None:
+        job = _make_running_job(job_id="job-1")
+        self.mgr._jobs["job-1"] = job
+        self.mgr._fail_job("job-1", "short", details=["a", "b", "c"])
+        self.assertEqual(job.details, ["a", "b", "c"])
+
+    def test_fail_job_unknown_id_is_silent(self) -> None:
+        """Calling _fail_job for an unknown id is a no-op (not an error)."""
+        self.mgr._fail_job("ghost", "x")  # must not raise
+
+    def test_fail_job_drops_registry_entry_when_files_missing(self) -> None:
+        """A failed install with no on-disk files drops the stale record."""
+        self.mgr._registry["yolo11n"] = _InstalledModelRecord(
+            name="yolo11n",
+            display_name="x",
+            source=InternalModelSource.ULTRALYTICS,
+            category=None,
+            precisions=[
+                InternalModelPrecision(precision="FP16", model_path="/missing.xml")
+            ],
+        )
+        job = _make_running_job(job_id="job-1", model_name="yolo11n")
+        self.mgr._jobs["job-1"] = job
+        self.mgr._fail_job("job-1", "nope")
+        self.assertNotIn("yolo11n", self.mgr._registry)
+
+    def test_finalize_success_records_state_and_registry(self) -> None:
+        entry = _make_supported_model(
+            canonical_name="yolo11n",
+            canonical_display_name="YOLO 11n (FP16)",
+            precision="FP16",
+            model_path_full="/models/output/yolo11n/FP16/model.xml",
+        )
+        self._supported_cls.return_value.get_all_supported_models.return_value = [entry]
+        job = _make_running_job(job_id="job-1", model_name="yolo11n")
+        self.mgr._jobs["job-1"] = job
+
+        self.mgr._finalize_success("job-1", "yolo11n", entry)
+
+        self.assertEqual(job.state, InternalModelDownloadJobState.COMPLETED)
+        self.assertEqual(job.model_path, entry.model_path_full)
+        self.assertIn("yolo11n", self.mgr._registry)
+        # Display name has the precision suffix stripped.
+        self.assertEqual(self.mgr._registry["yolo11n"].display_name, "YOLO 11n")
+
+
+# ----------------------------------------------------------------------
+# DownloadRequestCache — lazy load + malformed YAML
+# ----------------------------------------------------------------------
+
+
+class TestDownloadRequestCache(unittest.TestCase):
+    """The cache is read-once; tests assert ``get`` semantics."""
+
+    def setUp(self) -> None:
+        _DownloadRequestCache._data = None
+
+    def tearDown(self) -> None:
+        _DownloadRequestCache._data = None
+
+    def test_get_returns_dict_for_known_name(self) -> None:
+        yaml_payload = (
+            "- name: yolo11n\n"
+            "  download_request:\n"
+            "    model_id: yolo11n\n"
+            "- name: weird\n"
+        )
+        with patch("builtins.open", mock_open(read_data=yaml_payload)):
+            value = _DownloadRequestCache.get("yolo11n")
+        self.assertEqual(value, {"model_id": "yolo11n"})
+
+    def test_get_returns_none_for_missing(self) -> None:
+        with patch("builtins.open", mock_open(read_data="- name: x\n")):
+            self.assertIsNone(_DownloadRequestCache.get("nope"))
+
+    def test_get_returns_none_for_entry_without_download_request(self) -> None:
+        with patch("builtins.open", mock_open(read_data="- name: x\n")):
+            self.assertIsNone(_DownloadRequestCache.get("x"))
+
+    def test_get_handles_yaml_load_error(self) -> None:
+        """A broken YAML must not raise — cache stays empty and lookups return None."""
+        with patch("builtins.open", side_effect=OSError("no such file")):
+            self.assertIsNone(_DownloadRequestCache.get("yolo11n"))
+        # Second call must not retry the broken open.
+        self.assertEqual(_DownloadRequestCache._data, {})
+
+    def test_get_caches_after_first_call(self) -> None:
+        yaml_payload = "- name: yolo11n\n  download_request: {model_id: yolo11n}\n"
+        with patch("builtins.open", mock_open(read_data=yaml_payload)) as m:
+            _DownloadRequestCache.get("yolo11n")
+            _DownloadRequestCache.get("yolo11n")
+        # Only the first call opened the YAML.
+        self.assertEqual(m.call_count, 1)
+
+
+# ----------------------------------------------------------------------
+# Singleton + simple accessors
+# ----------------------------------------------------------------------
+
+
+class TestSingletonAndJobAccessors(unittest.TestCase):
+    """Cover the trivial accessors and singleton identity."""
+
+    def setUp(self) -> None:
+        _reset_manager()
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._supported_patcher.start()
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        _reset_manager()
+
+    def test_singleton_returns_same_instance(self) -> None:
+        a = ModelManager()
+        b = ModelManager()
+        self.assertIs(a, b)
+
+    def test_get_all_jobs_returns_snapshot(self) -> None:
+        mgr = ModelManager()
+        job = _make_running_job(job_id="job-1")
+        mgr._jobs["job-1"] = job
+        jobs = mgr.get_all_jobs()
+        self.assertEqual([j.id for j in jobs], ["job-1"])
+
+    def test_get_job_returns_none_for_unknown(self) -> None:
+        mgr = ModelManager()
+        self.assertIsNone(mgr.get_job("nope"))
+
+    def test_get_job_summary_returns_none_for_unknown(self) -> None:
+        mgr = ModelManager()
+        self.assertIsNone(mgr.get_job_summary("nope"))
+
+    def test_get_job_summary_returns_summary(self) -> None:
+        mgr = ModelManager()
+        job = _make_running_job(job_id="job-1", model_name="yolo11n")
+        mgr._jobs["job-1"] = job
+        summary = mgr.get_job_summary("job-1")
+        assert summary is not None
+        self.assertEqual(summary.id, "job-1")
+        self.assertEqual(summary.model_name, "yolo11n")
+        self.assertEqual(summary.source, InternalModelSource.ULTRALYTICS)
+
+
+# ----------------------------------------------------------------------
+# _materialize_omz_artifacts — file-system layout normalisation
+# ----------------------------------------------------------------------
+
+
+class TestMaterializeOmzArtifacts(unittest.TestCase):
+    """End-to-end test for OMZ artefact placement using a temp scratch tree.
+
+    We build the directory layout that ``omz_converter`` is expected to
+    produce, then assert the manager moves the files to the canonical
+    ``MODELS_PATH/omz/<name>`` location and applies the per-model rule.
+    """
+
+    def setUp(self) -> None:
+        _reset_manager()
+        self._tmpdir = tempfile.mkdtemp(prefix="vippet-mm-omz-")
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._supported_patcher.start()
+        self.mgr = ModelManager()
+        self.mgr._jobs["job-1"] = _make_running_job(
+            job_id="job-1", model_name="face-detection-retail-0004"
+        )
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        _reset_manager()
+
+    def test_moves_artifacts_and_applies_rule_when_proc_missing(self) -> None:
+        """Files are moved verbatim; missing model_proc source is logged + ignored."""
+        scratch = os.path.join(self._tmpdir, "scratch")
+        target = os.path.join(self._tmpdir, "target")
+        # ``intel/<model>/FP32/`` layout produced by omz_converter.
+        src_dir = os.path.join(scratch, "intel", "face-detection-retail-0004")
+        os.makedirs(src_dir)
+        with open(os.path.join(src_dir, "model.xml"), "w") as f:
+            f.write("<xml/>")
+
+        # The rule references a model_proc source that does not exist in
+        # our scratch tree — manager must log a warning and continue.
+        self.mgr._materialize_omz_artifacts(
+            job_id="job-1",
+            model_name="face-detection-retail-0004",
+            tmp_dir=scratch,
+            target_dir=target,
+        )
+
+        self.assertTrue(
+            os.path.isfile(os.path.join(target, "model.xml")),
+            "model.xml should have been moved to the target dir",
+        )
+
+    def test_raises_when_no_output_directory_exists(self) -> None:
+        scratch = os.path.join(self._tmpdir, "scratch")
+        target = os.path.join(self._tmpdir, "target")
+        os.makedirs(scratch)  # empty — no intel/ or public/ children
+        with self.assertRaises(FileNotFoundError):
+            self.mgr._materialize_omz_artifacts(
+                job_id="job-1",
+                model_name="face-detection-retail-0004",
+                tmp_dir=scratch,
+                target_dir=target,
+            )
+
+    def test_falls_back_to_public_when_intel_missing(self) -> None:
+        """For ``mobilenet-v2-pytorch`` the manager scans ``public/`` first."""
+        scratch = os.path.join(self._tmpdir, "scratch")
+        target = os.path.join(self._tmpdir, "target")
+        src_dir = os.path.join(scratch, "public", "mobilenet-v2-pytorch")
+        os.makedirs(src_dir)
+        with open(os.path.join(src_dir, "model.xml"), "w") as f:
+            f.write("<xml/>")
+
+        self.mgr._materialize_omz_artifacts(
+            job_id="job-1",
+            model_name="mobilenet-v2-pytorch",
+            tmp_dir=scratch,
+            target_dir=target,
+        )
+        self.assertTrue(os.path.isfile(os.path.join(target, "model.xml")))
+
+
+# ----------------------------------------------------------------------
+# _inject_imagenet_labels — happy path + missing files
+# ----------------------------------------------------------------------
+
+
+class TestInjectImagenetLabels(unittest.TestCase):
+    """Light tests for ImageNet label injection used by ``mobilenet-v2-pytorch``."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.mkdtemp(prefix="vippet-mm-labels-")
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_happy_path_writes_labels_into_postproc(self) -> None:
+        labels_path = os.path.join(self._tmpdir, "labels.txt")
+        json_path = os.path.join(self._tmpdir, "proc.json")
+        with open(labels_path, "w") as f:
+            f.write("0 tench\n1 goldfish\n2 great_white_shark\n\n")
+        with open(json_path, "w") as f:
+            json.dump({"output_postproc": [{"labels": []}]}, f)
+
+        ModelManager._inject_imagenet_labels(
+            job_id="job-1",
+            model_name="mobilenet-v2-pytorch",
+            labels_path=labels_path,
+            json_path=json_path,
+        )
+        with open(json_path) as f:
+            data = json.load(f)
+        self.assertEqual(
+            data["output_postproc"][0]["labels"],
+            ["tench", "goldfish", "great_white_shark"],
+        )
+
+    def test_missing_labels_file_is_silent_noop(self) -> None:
+        json_path = os.path.join(self._tmpdir, "proc.json")
+        with open(json_path, "w") as f:
+            json.dump({"output_postproc": [{"labels": []}]}, f)
+        # Must not raise even though the labels file does not exist.
+        ModelManager._inject_imagenet_labels(
+            job_id="job-1",
+            model_name="mobilenet-v2-pytorch",
+            labels_path="/does/not/exist",
+            json_path=json_path,
+        )
+        # File untouched.
+        with open(json_path) as f:
+            data = json.load(f)
+        self.assertEqual(data["output_postproc"][0]["labels"], [])
+
+    def test_json_without_postproc_is_silent_noop(self) -> None:
+        labels_path = os.path.join(self._tmpdir, "labels.txt")
+        json_path = os.path.join(self._tmpdir, "proc.json")
+        with open(labels_path, "w") as f:
+            f.write("0 a\n1 b\n")
+        with open(json_path, "w") as f:
+            json.dump({}, f)
+        ModelManager._inject_imagenet_labels(
+            job_id="job-1",
+            model_name="mobilenet-v2-pytorch",
+            labels_path=labels_path,
+            json_path=json_path,
+        )
+        with open(json_path) as f:
+            data = json.load(f)
+        # No mutation of an empty payload.
+        self.assertEqual(data, {})
+
+
+# ----------------------------------------------------------------------
+# _run_subprocess — one success path, one failure path
+# ----------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Minimal ``subprocess.Popen`` stand-in with controllable rc/stdout/stderr."""
+
+    def __init__(
+        self,
+        *,
+        rc: int = 0,
+        stdout_lines: list[str] | None = None,
+        stderr_lines: list[str] | None = None,
+    ) -> None:
+        import io
+
+        self.returncode = rc
+        self.stdout = io.StringIO("\n".join(stdout_lines or []) + "\n")
+        self.stderr = io.StringIO("\n".join(stderr_lines or []) + "\n")
+        self._rc = rc
+
+    def wait(self) -> int:
+        return self._rc
+
+
+class TestRunSubprocess(unittest.TestCase):
+    """Lightweight tests for the subprocess helper used by the OMZ worker."""
+
+    def setUp(self) -> None:
+        _reset_manager()
+        self._supported_patcher = patch("managers.model_manager.SupportedModelsManager")
+        self._supported_patcher.start()
+        self.mgr = ModelManager()
+        self.mgr._jobs["job-1"] = _make_running_job(job_id="job-1")
+
+    def tearDown(self) -> None:
+        self._supported_patcher.stop()
+        _reset_manager()
+
+    def test_success_streams_stdout_into_progress_message(self) -> None:
+        fake = _FakeProc(
+            rc=0,
+            stdout_lines=["Downloading...", "Done"],
+            stderr_lines=[],
+        )
+        with patch("managers.model_manager.subprocess.Popen", return_value=fake):
+            self.mgr._run_subprocess("job-1", ["omz_downloader", "--name", "x"])
+        # Last non-empty stdout line was attached as progress_message.
+        self.assertEqual(self.mgr._jobs["job-1"].progress_message, "Done")
+
+    def test_nonzero_exit_raises_called_process_error(self) -> None:
+        fake = _FakeProc(rc=1, stdout_lines=["ok"], stderr_lines=["boom"])
+        with patch("managers.model_manager.subprocess.Popen", return_value=fake):
+            with self.assertRaises(subprocess.CalledProcessError) as cm:
+                self.mgr._run_subprocess("job-1", ["omz_downloader", "--name", "x"])
+        # stderr is forwarded so the caller can attach it to job details.
+        self.assertIn("boom", cm.exception.stderr or "")
+
+
+# ----------------------------------------------------------------------
+# Uploaded-model fallback (used by graph.py to resolve custom models)
+# ----------------------------------------------------------------------
+
+
+class TestUploadedModelLookups(unittest.TestCase):
+    """Tests for ``find_installed_uploaded_model_by_display_name`` and
+    ``find_uploaded_model_by_path`` — the helpers consumed by
+    ``graph.py`` when a model is not in ``supported_models.yaml``.
+    """
+
+    def setUp(self) -> None:
+        _reset_manager()
+        # Skip the registry file load: tests seed records directly.
+        with patch.object(ModelManager, "_load_registry", lambda self: None):
+            self.mgr = ModelManager()
+        # A temp directory acts as the "uploaded model" output dir.
+        self._tmp = tempfile.TemporaryDirectory()
+        self.upload_dir = self._tmp.name
+        self.xml_path = os.path.join(self.upload_dir, "custom.xml")
+        with open(self.xml_path, "w") as f:
+            f.write("<net/>")
+        with open(os.path.join(self.upload_dir, "custom.bin"), "wb") as f:
+            f.write(b"\x00")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+        _reset_manager()
+
+    def _seed_record(
+        self,
+        *,
+        name: str = "my-custom",
+        display_name: str | None = None,
+        path: str | None = None,
+    ) -> _InstalledModelRecord:
+        record = _InstalledModelRecord(
+            name=name,
+            display_name=display_name or name,
+            source=InternalModelSource.CUSTOM,
+            category=InternalModelCategory.DETECTION,
+            precisions=[
+                InternalModelPrecision(precision="", model_path=path or self.upload_dir)
+            ],
+        )
+        self.mgr._registry[record.name] = record
+        return record
+
+    # --- find_installed_uploaded_model_by_display_name --------------
+
+    def test_find_by_display_name_returns_adapter_for_directory(self) -> None:
+        self._seed_record(display_name="My Custom Model")
+        result = self.mgr.find_installed_uploaded_model_by_display_name(
+            "My Custom Model"
+        )
+        assert result is not None
+        # The adapter resolves the directory to the inner ``.xml``.
+        self.assertEqual(result.model_path_full, self.xml_path)
+        # Uploaded models never carry a model-proc.
+        self.assertEqual(result.model_proc_full, "")
+
+    def test_find_by_display_name_matches_by_name_too(self) -> None:
+        # The UI uses ``model_name`` as the dropdown value; uploaded
+        # records use the same string for ``name`` and ``display_name``.
+        self._seed_record(name="raw-name", display_name="raw-name")
+        result = self.mgr.find_installed_uploaded_model_by_display_name("raw-name")
+        self.assertIsNotNone(result)
+
+    def test_find_by_display_name_unknown_returns_none(self) -> None:
+        self._seed_record(display_name="Known")
+        self.assertIsNone(
+            self.mgr.find_installed_uploaded_model_by_display_name("Unknown")
+        )
+
+    def test_find_by_display_name_returns_none_when_files_missing(self) -> None:
+        # Registry points at a path that no longer exists on disk.
+        self._seed_record(display_name="Stale", path="/nonexistent/path/model_dir")
+        self.assertIsNone(
+            self.mgr.find_installed_uploaded_model_by_display_name("Stale")
+        )
+
+    def test_find_by_display_name_with_no_precisions_returns_none(self) -> None:
+        record = self._seed_record(display_name="NoPrec")
+        record.precisions = []
+        self.assertIsNone(
+            self.mgr.find_installed_uploaded_model_by_display_name("NoPrec")
+        )
+
+    # --- find_uploaded_model_by_path --------------------------------
+
+    def test_find_by_path_matches_registry_directory(self) -> None:
+        self._seed_record()
+        result = self.mgr.find_uploaded_model_by_path(self.upload_dir)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.name, "my-custom")
+
+    def test_find_by_path_matches_inner_xml(self) -> None:
+        # Pipeline strings reference the resolved ``.xml`` artefact, not
+        # the directory. The lookup must still succeed.
+        self._seed_record()
+        result = self.mgr.find_uploaded_model_by_path(self.xml_path)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.model_path_full, self.xml_path)
+
+    def test_find_by_path_ignores_model_proc_argument(self) -> None:
+        # Uploaded models have no model-proc; passing one must not break
+        # resolution.
+        self._seed_record()
+        result = self.mgr.find_uploaded_model_by_path(
+            self.xml_path, model_proc_path="/some/proc.json"
+        )
+        self.assertIsNotNone(result)
+
+    def test_find_by_path_unknown_returns_none(self) -> None:
+        self._seed_record()
+        self.assertIsNone(
+            self.mgr.find_uploaded_model_by_path("/totally/unrelated/path.xml")
+        )
+
+    def test_find_by_path_empty_registry_returns_none(self) -> None:
+        self.assertIsNone(self.mgr.find_uploaded_model_by_path(self.xml_path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds end-to-end test coverage for the new model management feature (download, upload, registry, pipeline integration), fixes a production bug in `graph.py` discovered during test planning, and makes the functional test suite robust against missing models on the host.
## Production code changes
### `vippet/graph.py` - uploaded (custom) models now flow through the simple/advanced graph round-trip
Three independent code paths in `graph.py` consulted only `SupportedModelsManager` (catalogue-backed by `supported_models.yaml`) when resolving models. Uploaded models live in `ModelManager._registry`, so every API call that touched them was silently broken end-to-end (UI lists the upload, `convert-to-advanced` rejects it). Added a `ModelManager` fallback in all three:
- `_model_path_to_display_name` - preserves the display name on ingestion of an advanced graph that references an uploaded model.
- `_model_display_name_to_path` - resolves an uploaded model's absolute `.xml` when converting simple → advanced.
- `_validate_models_supported_on_devices` - accepts uploaded models on every device (they carry no `unsupported_devices` metadata).
To keep the existing `SupportedModel` contract untouched, added a `_UploadedSupportedModel(SupportedModel)` adapter inside `ModelManager` that bypasses the `MODELS_PATH` join (uploaded paths are absolute) and resolves a registry directory to the first `.xml` it contains.
### `vippet/managers/model_manager.py` - public lookup methods
Added two lookups used by the new fallbacks:
- `find_installed_uploaded_model_by_display_name(display_name)`
- `find_uploaded_model_by_path(model_path, model_proc_path=None)`
Both return the adapter described above. `find_uploaded_model_by_path` accepts either the registry directory or any `.xml` inside it, mirroring how display-name resolution stores paths.
## Test coverage
### Unit tests
- `tests/unit/managers_tests/model_manager_test.py::TestUploadedModelLookups` - 10 tests covering the two new lookups: directory → `.xml` resolution, name-vs-display-name matching, missing-files handling, no-precisions handling, model-proc-path argument is ignored, empty registry edge case.
- `tests/unit/graph_test.py::TestUploadedModelFallback` - 4 tests covering both fallback paths in `graph.py` (path → display name, display name → path, behaviour when neither catalogue nor registry knows the model).
### Functional tests
Three new functional test files exercise the full HTTP surface for model management:
- `test_models_download.py` - `POST /models/download`, `GET /jobs/models/status`, `GET /jobs/models/{id}`, `GET /jobs/models/{id}/status`. Tolerates both code paths: the reference models (`face-detection-retail-0004`, `age-gender-recognition-retail-0013`) may already be installed (`409`) or freshly downloaded (`202` + polling to `COMPLETED`). All 4 model-job endpoints are always exercised so `test_z_api_coverage.py` stays green.
- `test_models_upload.py` - `POST /models/upload` with a session-scoped fixture that uploads custom copies of the two reference OMZ FP16 models under per-session unique names. Covers happy path, duplicate name → `409`, invalid category → `422`.
- `test_models_uploaded_pipeline.py` - end-to-end check for the `graph.py` fix: parametrized over every available variant of the `Age & Gender Recognition` pipeline; for each variant patches `gvadetect` / `gvaclassify` to point at the uploaded model copies, runs `convert-to-advanced`, submits a performance job, asserts `COMPLETED` with positive FPS. Without the production fix, `convert-to-advanced` would `400` on the unknown display name.
### Shared helpers
- `tests/functional/helpers/api_helpers.py` - added `start_model_download`, `fetch_model_jobs`, `get_model_job_summary`, `get_model_job_status`, `wait_for_model_download_completion`, `upload_model_file`, `find_model_in_list`.
- `tests/functional/conftest.py` - session-scoped `uploaded_model_names` fixture that uploads both reference models under `<source>-uploaded-<run_id>` aliases. Cleanup of uploaded model files is intentionally not performed: the files are created by the `model-download` microservice under `shared/models/output/custom_uploaded_models/` and the test runner has no host-side permission to delete them. A dedicated DELETE endpoint / janitor task is tracked separately.
## Pipeline-case discovery: model-aware skips
`tests/functional/helpers/pipeline_case_helpers.py` now also filters pipeline cases by **installed models**, not just available device families:
- New `missing_models_per_pipeline(session)` reverses the `used_by_pipelines` index exposed by `GET /models` and returns `{pipeline_id: {display_name, ...}}` of models the pipeline needs but that are not in state `INSTALLED`.
- New `wrap_cases_for_pytest(cases, missing)` wraps any pipeline case whose models are missing in `pytest.param(..., marks=pytest.mark.skip(reason=...))` with a precise reason (`Pipeline 'Defect Detection' requires model(s) that are not installed: ['Pallet Defect Detection (INT8)']. Install them through POST /models/download...`).
- New `skip_if_pipeline_models_missing(session, pipeline_id)` for tests with a hard-coded pipeline id (e.g. `test_pipeline_optimize_flow`).
- `discover_pipeline_cases_for_pytest()` and the two custom discover helpers in `test_performance_job_usb_camera.py` / `test_performance_metadata_flow.py` were migrated to the new helpers.
Effect on a CPU-only host without `pallet-defect-detection` installed: 10 hard failures in density / performance / file-output / live-stream / uploaded-artifact tests become 10 explicit SKIPs with the missing-model reason.
## Drive-by fixes
- `test_models_list.py::test_models_endpoint_returns_models` - accept user-uploaded models (`source == "custom"`): they may have an empty `precision` and a non-catalogue `category`. Structural invariants (`name`, `display_name`, `variants` list) still apply.
- `test_pipeline_optimize_flow.py::test_pipeline_optimize_flow[optimize-non-device-variant]` - skip when the variant's required device families (`gpu_npu` → `{GPU, NPU}`) are not advertised by the host, and skip when `smart-parking` has missing models.
- `tests/functional/pytest.ini` - added `addopts = -r fEsxX` so the final summary lists every FAILED, ERROR, SKIPPED, XFAIL and XPASS test with its short reason. SKIPs appear above FAILs, making it easy to see at a glance which pipelines were not exercised and why.
