### PR TITLE
Bong5/grafana prometheus enabling

### DIFF
--- a/tools/npu-monitor-tool/README.md
+++ b/tools/npu-monitor-tool/README.md
@@ -21,6 +21,11 @@ to track and analyze NPU performance.
 
 Disclaimer: The utilization percentage is a calculated metric, based on the difference in NPU busy timestamps when the inference starts and ends on NPU. It does not represent an exact hardware-level measurement. Hence, this metric is an approximation of workload and not a precise hardware utilization figure.
 
+### Prometheus/Grafana Dashboard
+
+[requirements-exporter.txt](./requirements-exporter.txt) is Python dependencies for the Prometheus exporter,
+which is not required for running npu-monitor-tool.py. Please read [docs/npu-metrics-exporter](docs/npu-metrics-exporter.md) for more details.
+
 ### Supported Platforms
 
 The tool supports the following Intel CPU generations with integrated NPU:

--- a/tools/npu-monitor-tool/docs/grafana-npu-dashboard.json
+++ b/tools/npu-monitor-tool/docs/grafana-npu-dashboard.json
@@ -1,0 +1,798 @@
+{
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.6.1"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1647584693304,
+  "links": [],
+  "panels": [
+    {
+      "title": "NPU Dashboard",
+      "type": "row",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": null,
+      "panels": [],
+      "collapsed": false
+    },
+    {
+      "title": "NPU Temperature",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "npu_monitor_temperature{}",
+          "interval": "",
+          "legendFormat": "NPU: {{dev_id}}",
+          "refId": "S"
+        }
+      ],
+            "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "id": null,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "title": "NPU Power",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 16
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "npu_monitor_power{}",
+          "interval": "",
+          "legendFormat": "NPU: {{dev_id}}",
+          "refId": "S"
+        }
+      ],
+            "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "id": null,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "title": "DPU Frequency",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "npu_monitor_freq_hz{}",
+          "interval": "",
+          "legendFormat": "NPU: {{dev_id}}",
+          "refId": "S"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "rothz"
+        },
+        "overrides": []
+      },
+      "id": null,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "title": "DPU Frequency",
+      "type": "gauge",
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 20,
+        "y": 16
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "npu_monitor_freq_hz{}",
+          "interval": "",
+          "legendFormat": "NPU: {{dev_id}}",
+          "refId": "S"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1500
+              },
+              {
+                "color": "red",
+                "value": 2000
+              }
+            ]
+          },
+          "unit": "rothz"
+        },
+        "overrides": []
+      },
+      "id": null,
+      "interval": "5s",
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.1.0"
+    },
+    {
+      "title": "NPU Utilization",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 23
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "npu_util{} / 100",
+          "interval": "",
+          "legendFormat": "NPU: {{dev_id}}",
+          "refId": "S"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "id": null,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "title": "NPU Tile Config",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 2,
+        "x": 6,
+        "y": 23
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "npu_tile_config",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+            "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "id": 14,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.1"
+    },
+    {
+      "title": "NPU Memory Utilization",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 23
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "npu_memory_util{} * (1024 * 1024)",
+          "interval": "",
+          "legendFormat": "NPU: {{dev_id}}",
+          "refId": "S"
+        }
+      ],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "id": null,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    },
+    {
+      "title": "NPU Memory Bandwidth",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 23
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "npu_memory_bandwidth{} * (1024 * 1024)",
+          "interval": "",
+          "legendFormat": "NPU: {{dev_id}}",
+          "refId": "S"
+        }
+      ],
+            "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "id": null,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [
+    "npumon"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "dut1132-pvc-dua",
+          "value": "dut1132-pvc-dua"
+        },
+              "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+        "definition": "label_values(instance)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Node",
+        "multi": false,
+        "name": "Node",
+        "options": [],
+        "query": {
+          "query": "label_values(instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "NPU Dashboard",
+  "uid": "7VxcZDPnl",
+  "version": 1
+}

--- a/tools/npu-monitor-tool/docs/npu-metrics-exporter.md
+++ b/tools/npu-monitor-tool/docs/npu-metrics-exporter.md
@@ -1,0 +1,108 @@
+# Overview
+
+NPU metrics exporter (npu-metrics-exporter.py) supports Prometheus data pull
+model that stores time-series NPU metrics in its built-in database.
+
+## Software Dependencies
+
+```bash
+pip install -r requirements-exporter.txt
+```
+
+
+## Start NPU Metrics Exporter
+```bash
+sudo env "PATH=$PATH" gunicorn -w 1 -b localhost:8000 npu-metrics-exporter:app
+```
+* __-w 1__: Start 1 working thread to service NPU metrics Restful server
+* __-b localhost:8000__: Set 0.0.0.0 if want to allow any IP address.
+  * Change __Port=8000__ according to your platform port allocation.
+
+## Quick Test
+```bash
+$ curl http://localhost:8000/metrics
+# HELP npu_monitor_temperature NPU Temperature [°C]
+# TYPE npu_monitor_temperature gauge
+npu_monitor_temperature{dev_id="0xad1d"} 35.0
+# HELP npu_monitor_freq_hz DPU Frequency [Hz]
+# TYPE npu_monitor_freq_hz gauge
+npu_monitor_freq_hz{dev_id="0xad1d"} 1200.0000000000002
+# HELP npu_memory_util NPU Memory Utilization [MB]
+# TYPE npu_memory_util gauge
+npu_memory_util{dev_id="0xad1d"} 292.140625
+# HELP npu_memory_bandwidth NPU DDR Average Bandwidth [MB/s]
+# TYPE npu_memory_bandwidth gauge
+npu_memory_bandwidth{dev_id="0xad1d"} 9929.940412290676
+# HELP npu_util NPU Utilization [%]
+# TYPE npu_util gauge
+npu_util{dev_id="0xad1d"} 80.0
+# HELP npu_monitor_power NPU Power Consumption [Watts]
+# TYPE npu_monitor_power gauge
+npu_monitor_power{dev_id="0xad1d"} 1.6932698651519054
+# HELP npu_tile_config NPU Tile Configuration
+# TYPE npu_tile_config gauge
+npu_tile_config{dev_id="0xad1d"} 2.0
+```
+
+# Prometheus
+```bash
+# Download and unpack the most recent Prometheus release
+VERSION=3.11.0
+$ wget https://github.com/prometheus/prometheus/releases/download/v${VERSION}/prometheus-${VERSION}.linux-amd64.tar.gz
+$ tar -xvf prometheus-${VERSION}.linux-amd64.tar.gz
+$ cd prometheus-${VERSION}.linux-amd64
+
+# Configure Prometheus configuration for NPU Metrics
+$ nano prometheus.yml
+---
+scrape_configs:
+  - job_name: "NPU Metrics Exporter"
+    scheme: http
+    static_configs:
+      - targets: ['localhost:8000']
+---
+
+# Start Prometheus
+$ ./prometheus --config.file=./prometheus.yml
+```
+
+# Grafana Dashboard for NPU metrics
+## Installation
+```bash
+# https://grafana.com/docs/grafana/latest/setup-grafana/installation/debian/
+$ sudo mkdir -p /etc/apt/keyrings/
+$ wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/grafana.gpg > /dev/null
+$ echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+$ sudo apt-get update
+$ sudo apt-get install grafana
+
+# Add proxy setting in /etc/default/grafana-server
+$ sudo cat << EOF > /etc/default/grafana-server
+HTTP_PROXY=http://<PROXY_SERVER>:<PORT>
+HTTPS_PROXY=http://<PROXY_SERVER>:<PORT>
+NO_PROXY=localhost,127.0.0.1
+EOF
+
+# Enable and start Grafana server
+$ sudo systemctl enable grafana-server
+$ sudo systemctl restart grafana-server
+$ sudo systemctl status grafana-server
+```
+
+## Open Grafana Webpage
+- Connect to Grafana Server using http://localhost:3000
+- Use initial login/password  = admin/admin
+- Update Grafana server with new password
+
+## Create Data-source for Prometheus
+- From Grafana left navigation menu, select 'Connections/Data Sources'.
+  Under "Add data source", search for "Prometheus" and select it.
+- In the "Prometheus/Settings" tab:
+  - Name = Prometheus Data Feeder
+  - Prometheus server URL = http://localhost:9090
+- Then, scroll to the bottom, click 'Save & test'.
+- Confirm that above "Prometheus Data Feeder" is listed (created) under Data sources,
+  when you select Grafana left navigation 'Connections/Data Sources' menu again.
+
+## Create New Dashboard for NPU metrics
+Import sample NPU metrics dashboard in [grafana-npu-dashboard.json](grafana-npu-dashboard.json)

--- a/tools/npu-monitor-tool/npu-metrics-exporter.py
+++ b/tools/npu-monitor-tool/npu-metrics-exporter.py
@@ -1,0 +1,342 @@
+#!/usr/bin/python3
+
+# Copyright 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=line-too-long,missing-module-docstring,invalid-name,too-many-locals,too-many-statements
+
+import traceback
+import time
+import os
+import sys
+import logging as LOG
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+from flask import Flask, Response
+from enum import Enum, unique
+from prometheus_client import (
+    CollectorRegistry,
+    Gauge,
+    generate_latest
+)
+
+KB = 1024
+
+def load_npu_monitor():
+    """Dynamically load monitor classes from standalone npu-monitor-tool.py."""
+    module_path = Path(__file__).resolve().parent / 'npu-monitor-tool.py'
+    spec = spec_from_file_location('npu_monitor_tool', module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f'Unable to load monitor module from {module_path}')
+
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.NpuMonitor
+
+NpuMonitor = load_npu_monitor()
+
+# NPU Monitor
+npu_mon = NpuMonitor()
+pu = npu_mon.get_pmt_telemetry()
+if pu is None:
+    print('Failed to setup NPU monitor')
+    sys.exit(1)
+
+pciid = npu_mon.read_pciid()
+
+# Prometheus data source registry
+registries = {}
+metrics_owner = f'npu'
+registry, metrics = registries.setdefault(
+                        metrics_owner, (CollectorRegistry(), {}))
+
+# Get initial value for interval-related metrics (utilization and power)
+curr_time_ms = 0
+prev_time_ms = time.time_ns() // 1_000_000
+prev_busy_time = npu_mon.read_busy_time()
+pu.update_buffer()
+prev_energy = pu.get_npu_energy()
+prev_mem_bandwidth_mb = pu.get_noc_bandwidth()
+prev_mem_bandwidth_ts = time.monotonic()
+
+@unique
+class PromMetric(Enum):
+    npu_monitor_temperature = ('npu_monitor_temperature', 'NPU Temperature [°C]') # nopep8
+    npu_monitor_freq_hz = ('npu_monitor_freq_hz', 'DPU Frequency [Hz]') # nopep8
+    npu_memory_util = ('npu_memory_util', 'NPU Memory Utilization [MB]') # nopep8
+    npu_memory_bandwidth =('npu_memory_bandwidth', 'NPU DDR Average Bandwidth [MB/s]') # nopep8
+    npu_util = ('npu_util', 'NPU Utilization [%]') # nopep8
+    npu_monitor_power = ('npu_monitor_power', 'NPU Power Consumption [Watts]') # nopep8
+    npu_tile_config = ('npu_tile_config', 'NPU Tile Configuration') # nopep8
+
+    def __new__(cls, name, desc=None, ext_labelnames=[]):
+        obj = object.__new__(cls)
+        obj._value_ = name
+        obj.desc = f'{name}_desc' if desc is None else desc
+        obj.ext_labelnames = ext_labelnames
+        return obj
+
+class Metric:
+    def __init__(self, prom_metric: PromMetric) -> None:
+        self.prom_metric = prom_metric
+
+metrics_map = {
+    'NPU_TEMPERATURE': Metric(PromMetric.npu_monitor_temperature),
+    'NPU_FREQUENCY': Metric(PromMetric.npu_monitor_freq_hz),
+    'NPU_MEM_UTIL': Metric(PromMetric.npu_memory_util),
+    'NPU_MEM_BANDWIDTH': Metric(PromMetric.npu_memory_bandwidth),
+    'NPU_UTIL': Metric(PromMetric.npu_util),
+    'NPU_POWER': Metric(PromMetric.npu_monitor_power),
+    'NPU_TILE_CFG':  Metric(PromMetric.npu_tile_config),
+}
+
+def process_npu_temperature():
+    metric = metrics_map['NPU_TEMPERATURE']
+    metric_name = metric.prom_metric.name
+    metric_desc = metric.prom_metric.desc
+    all_labelnames = ['dev_id']
+    all_labelvalues = [f'{pciid}']
+
+    val = pu.get_npu_temperature()
+    if metric_name not in metrics:
+        metrics[metric_name] = Gauge(metric_name, metric_desc,
+                                    labelnames=all_labelnames,
+                                    registry=registry)
+        metrics[metric_name].labels(*all_labelvalues).set(val)
+    else:
+        metrics[metric_name].labels(*all_labelvalues).set(val)
+
+def process_npu_frequency():
+    metric = metrics_map['NPU_FREQUENCY']
+    metric_name = metric.prom_metric.name
+    metric_desc = metric.prom_metric.desc
+    all_labelnames = ['dev_id']
+    all_labelvalues = [f'{pciid}']
+
+    val = pu.get_display_freq_hz()
+    if metric_name not in metrics:
+        metrics[metric_name] = Gauge(metric_name, metric_desc,
+                                    labelnames=all_labelnames,
+                                    registry=registry)
+        metrics[metric_name].labels(*all_labelvalues).set(val)
+    else:
+        metrics[metric_name].labels(*all_labelvalues).set(val)
+
+def process_npu_mem_util():
+    metric = metrics_map['NPU_MEM_UTIL']
+    metric_name = metric.prom_metric.name
+    metric_desc = metric.prom_metric.desc
+    all_labelnames = ['dev_id']
+    all_labelvalues = [f'{pciid}']
+
+    mem_util = npu_mon.read_mem_util()
+    try:
+        mem_util_mb = int(mem_util) / KB / KB
+    except (TypeError, ValueError) as err:
+        LOG.warning('Failed to parse memory utilization: %s', err)
+        mem_util_mb = 0
+
+    if metric_name not in metrics:
+        metrics[metric_name] = Gauge(metric_name, metric_desc,
+                                    labelnames=all_labelnames,
+                                    registry=registry)
+        metrics[metric_name].labels(*all_labelvalues).set(mem_util_mb)
+    else:
+        metrics[metric_name].labels(*all_labelvalues).set(mem_util_mb)
+
+def process_npu_mem_bandwidth():
+    global prev_mem_bandwidth_mb
+    global prev_mem_bandwidth_ts
+
+    metric = metrics_map['NPU_MEM_BANDWIDTH']
+    metric_name = metric.prom_metric.name
+    metric_desc = metric.prom_metric.desc
+    all_labelnames = ['dev_id']
+    all_labelvalues = [f'{pciid}']
+
+    try:
+        curr_mem_bandwidth_mb = pu.get_noc_bandwidth()
+    except (TypeError, ValueError) as err:
+        LOG.warning('Failed to parse memory bandwidth: %s', err)
+        curr_mem_bandwidth_mb = 0
+
+    curr_mem_bandwidth_ts = time.monotonic()
+    delta_ts = curr_mem_bandwidth_ts - prev_mem_bandwidth_ts
+
+    if prev_mem_bandwidth_mb is None or curr_mem_bandwidth_mb is None or delta_ts <= 0:
+        bandwidth_mbps = 0.0
+    else:
+        delta_mem_bandwidth_mb = curr_mem_bandwidth_mb - prev_mem_bandwidth_mb
+        bandwidth_mbps = max(0.0, delta_mem_bandwidth_mb / delta_ts)
+
+    prev_mem_bandwidth_mb = curr_mem_bandwidth_mb
+    prev_mem_bandwidth_ts = curr_mem_bandwidth_ts
+
+    if metric_name not in metrics:
+        metrics[metric_name] = Gauge(metric_name, metric_desc,
+                                    labelnames=all_labelnames,
+                                    registry=registry)
+        metrics[metric_name].labels(*all_labelvalues).set(bandwidth_mbps)
+    else:
+        metrics[metric_name].labels(*all_labelvalues).set(bandwidth_mbps)
+
+def process_npu_utilization():
+    global curr_time_ms
+    global prev_time_ms
+    global prev_busy_time
+
+    metric = metrics_map['NPU_UTIL']
+    metric_name = metric.prom_metric.name
+    metric_desc = metric.prom_metric.desc
+    all_labelnames = ['dev_id']
+    all_labelvalues = [f'{pciid}']
+
+    curr_busy_time = npu_mon.read_busy_time()
+    if prev_busy_time is None or curr_busy_time is None:
+        utilization = 0
+    else:
+        # delta is in micro-seconds, interval is in milli-seconds
+        delta_busy_time = curr_busy_time - prev_busy_time
+        interval_us = (curr_time_ms - prev_time_ms) * 1000
+        if interval_us <= 0:
+            utilization = 0
+        else:
+            utilization = min(100, int(100 * delta_busy_time / interval_us))
+
+        prev_busy_time = curr_busy_time
+
+    if metric_name not in metrics:
+        metrics[metric_name] = Gauge(metric_name, metric_desc,
+                                    labelnames=all_labelnames,
+                                    registry=registry)
+        metrics[metric_name].labels(*all_labelvalues).set(utilization)
+    else:
+        metrics[metric_name].labels(*all_labelvalues).set(utilization)
+
+def process_npu_power():
+    global curr_time_ms
+    global prev_time_ms
+    global prev_energy
+
+    metric = metrics_map['NPU_POWER']
+    metric_name = metric.prom_metric.name
+    metric_desc = metric.prom_metric.desc
+    all_labelnames = ['dev_id']
+    all_labelvalues = [f'{pciid}']
+
+    curr_energy = pu.get_npu_energy()
+    if prev_energy is None or curr_energy is None:
+        power = 0
+    else:
+        interval_ms = curr_time_ms - prev_time_ms
+        if interval_ms <= 0:
+            power = 0
+        else:
+            power = (curr_energy - prev_energy) / (interval_ms * 1e-3)
+
+        prev_energy = curr_energy
+
+    if metric_name not in metrics:
+        metrics[metric_name] = Gauge(metric_name, metric_desc,
+                                    labelnames=all_labelnames,
+                                    registry=registry)
+        metrics[metric_name].labels(*all_labelvalues).set(power)
+    else:
+        metrics[metric_name].labels(*all_labelvalues).set(power)
+
+def process_npu_tile_config():
+    metric = metrics_map['NPU_TILE_CFG']
+    metric_name = metric.prom_metric.name
+    metric_desc = metric.prom_metric.desc
+    all_labelnames = ['dev_id']
+    all_labelvalues = [f'{pciid}']
+    val = pu.get_tile_config()
+    if metric_name not in metrics:
+        metrics[metric_name] = Gauge(metric_name, metric_desc,
+                                    labelnames=all_labelnames,
+                                    registry=registry)
+        metrics[metric_name].labels(*all_labelvalues).set(val)
+    else:
+        metrics[metric_name].labels(*all_labelvalues).set(val)
+
+def tidy_response(resp):
+    resp_str = resp.decode('UTF-8')
+    tidy_resp = []
+    is_comment = False
+    for line in resp_str.splitlines():
+        if not line.startswith('#'):
+            if line not in tidy_resp:
+                tidy_resp.append(line)
+                is_comment = False
+        else:
+            if is_comment == False:
+                tidy_resp.append('\n' + line)
+                is_comment = True
+            else:
+                tidy_resp.append(line)
+
+    return '\n'.join(tidy_resp)
+
+def get_metrics():
+    global curr_time_ms
+    global prev_time_ms
+
+    try:
+        curr_time_ms = time.time_ns() // 1_000_000
+        pu.update_buffer()
+
+        process_npu_temperature()
+        process_npu_frequency()
+        process_npu_mem_util()
+        process_npu_mem_bandwidth()
+        process_npu_utilization()
+        process_npu_power()
+        process_npu_tile_config()
+
+        prev_time_ms = curr_time_ms
+
+        resp = generate_latest(registry)
+        return tidy_response(resp)
+
+    except Exception as e:
+        traceback.print_exc()
+        return "#nodata: due to unexpected failure", 500
+
+def export_metrics():
+    result = get_metrics()
+
+    # Handle (body, status) or just body
+    if isinstance(result, tuple):
+        body, status = result
+        body = body + '\n'
+    else:
+        body, status = result + '\n', 200
+
+    return Response(body, status=status, content_type='text/plain')
+
+def hello_world():
+    body = "NPU telemetry source for Prometheus\n"
+    status = 200
+    return Response(body, status=status, content_type='text/plain')
+
+app = Flask(__name__)
+
+app.add_url_rule(
+    '/', view_func=hello_world, methods=['GET'])
+
+app.add_url_rule(
+    '/metrics', view_func=export_metrics, methods=['GET'])
+

--- a/tools/npu-monitor-tool/npu-monitor-tool.py
+++ b/tools/npu-monitor-tool/npu-monitor-tool.py
@@ -248,7 +248,12 @@ class PmtTelemetry:
         return int_part + float_part
 
     def get_noc_bandwidth(self) -> float:
-        """Get NoC (Network on Chip) bandwidth in MB/s."""
+        """Get NoC (Network on Chip) bandwidth in MB.
+
+        The PMT register reports a monotonically increasing counter (scaled in milli-MB), not an
+        instantaneous rate. Convert to a bandwidth rate by taking a delta between two reads and
+        dividing by elapsed time in seconds.
+        """
         val = sum([self.read(reg1, 31, 0) for reg1 in self.regs.get('VPU_MEMORY_BW',[])])
         return val / 1e3
 
@@ -392,6 +397,7 @@ def main(): # pylint: disable=too-many-branches
     prev_energy = pu.get_npu_energy()
     interval = args.interval if args.interval else DEFAULT_INTERVAL_MS
     prev_bandwidth = pu.get_noc_bandwidth()
+    prev_bandwidth_ts = time_module.monotonic()
 
     csv_file = None
     csv_file_path = None
@@ -461,12 +467,21 @@ def main(): # pylint: disable=too-many-branches
             temp = pu.get_npu_temperature()
 
             curr_bandwidth = pu.get_noc_bandwidth()
+            curr_bandwidth_ts = time_module.monotonic()
             bandwidth_delta = curr_bandwidth - prev_bandwidth
-            if curr_bandwidth > MB_TO_GB:
-                bandwidth = bandwidth_delta / MB_TO_GB
+            dt_s = curr_bandwidth_ts - prev_bandwidth_ts
+
+            # Guard against clock quirks and counter resets/wrap.
+            if dt_s <= 0:
+                bandwidth_mbps = 0.0
+            else:
+                bandwidth_mbps = max(0.0, bandwidth_delta / dt_s)
+
+            if bandwidth_mbps > MB_TO_GB:
+                bandwidth = bandwidth_mbps / MB_TO_GB
                 bw_unit = 'GB/s'
             else:
-                bandwidth = bandwidth_delta
+                bandwidth = bandwidth_mbps
                 bw_unit = 'MB/s'
 
             if csv_file:
@@ -487,6 +502,7 @@ def main(): # pylint: disable=too-many-branches
             print( '+-----------------------------------------------------------------------------------------------+')
             prev_busy_time = curr_busy_time
             prev_bandwidth = curr_bandwidth
+            prev_bandwidth_ts = curr_bandwidth_ts
 
             if not args.interval:
                 break

--- a/tools/npu-monitor-tool/npu-monitor-tool.py
+++ b/tools/npu-monitor-tool/npu-monitor-tool.py
@@ -252,6 +252,93 @@ class PmtTelemetry:
         val = sum([self.read(reg1, 31, 0) for reg1 in self.regs.get('VPU_MEMORY_BW',[])])
         return val / 1e3
 
+class NpuMonitor:
+    def __init__(self):
+        # get ID based on 0000 prefix from /sys/bus/pci/drivers/intel_vpu/
+        self.dev_path = "/sys/bus/pci/drivers/intel_vpu/"
+        self.debugfs = "/sys/kernel/debug/accel/"
+        self.npu_busy = None
+        if self.core_setup() == True:
+            self.pu = PmtTelemetry()
+        else:
+            self.pu = None
+
+    def get_pmt_telemetry(self) -> Optional[PmtTelemetry]:
+        return self.pu
+
+    def core_setup(self) -> bool:
+        if not os.path.exists(self.dev_path):
+            LOG.error("Intel NPU driver 'intel_vpu' seems not to be loaded.\n")
+            return False
+
+        for entry in os.listdir(self.dev_path):
+            if entry.startswith("0000:"):
+                self.dev_path = os.path.join(self.dev_path, entry)
+                self.debugfs = os.path.join(self.debugfs, entry)
+                break
+
+        if os.path.exists(os.path.join(self.dev_path, "npu_busy_time_us")):
+            self.npu_busy_path = os.path.join(self.dev_path, "npu_busy_time_us")
+        else:
+            self.npu_busy_path = None
+
+        if os.path.exists(os.path.join(self.dev_path, "npu_memory_utilization")):
+            self.mem_util_path = os.path.join(self.dev_path, "npu_memory_utilization")
+        else:
+            self.mem_util_path = None
+
+        if os.path.exists(os.path.join(self.dev_path, "device")):
+            self.pciid_path = os.path.join(self.dev_path, "device")
+        else:
+            self.pciid_path = None
+
+        if os.path.exists(os.path.join(self.debugfs, "fw_version")):
+            self.fw_version_path = os.path.join(self.debugfs, "fw_version")
+        else:
+            self.fw_version_path = None
+
+        return True
+
+    def read_fw_version(self) -> Optional[str]:
+        if self.fw_version_path is None:
+            return None
+        try:
+            return fdump(self.fw_version_path)
+        except (ValueError, RuntimeError) as err:
+            LOG.warning('Failed to read NPU firmware version: %s', err)
+            return None
+
+    def read_driver_version(self) -> str:
+        ver_str = run_command('modinfo -F version intel_vpu').stdout.strip()
+        return ver_str.split()[0] if ver_str else 'unknown'
+
+    def read_pciid(self) -> Optional[str]:
+        if self.pciid_path is None:
+            return None
+        try:
+            return fdump(self.pciid_path)
+        except (ValueError, RuntimeError):
+            LOG.warning('Failed to read PCI ID: %s', err)
+            return None
+
+    def read_busy_time(self) -> Optional[int]:
+        if self.npu_busy_path is None:
+            return None
+        try:
+            return int(fdump(self.npu_busy_path))
+        except (ValueError, RuntimeError) as err:
+            LOG.warning('Failed to read busy time: %s', err)
+            return None
+
+    def read_mem_util(self) -> Optional[str]:
+        if self.mem_util_path is None:
+            return None
+        try:
+            return fdump(self.mem_util_path)
+        except (ValueError, RuntimeError) as err:
+            LOG.warning('Failed to read memory utilization: %s', err)
+            return None
+
 def logging_setup(args) -> None:
     """Configure colored logging output."""
     log_format = '%(levelname)s: %(message)s'
@@ -289,54 +376,22 @@ def main(): # pylint: disable=too-many-branches
 
     logging_setup(args)
 
-    # get ID based on 0000 prefix from /sys/bus/pci/drivers/intel_vpu/
-    dev_path = "/sys/bus/pci/drivers/intel_vpu/"
-    debugfs = "/sys/kernel/debug/accel/"
-    pu = PmtTelemetry()
-    if not os.path.exists(dev_path):
+    npu_mon = NpuMonitor()
+    pu = npu_mon.get_pmt_telemetry()
+    if pu is None:
         print("Intel NPU driver 'intel_vpu' seems not to be loaded.\n")
         parser.print_help()
         sys.exit(1)
 
-    for entry in os.listdir(dev_path):
-        if entry.startswith("0000:"):
-            dev_path = os.path.join(dev_path, entry)
-            debugfs = os.path.join(debugfs, entry)
-            break
-
-    npu_busy = None
-    if os.path.exists(os.path.join(dev_path, "npu_busy_time_us")):
-        npu_busy = os.path.join(dev_path, "npu_busy_time_us")
-
-    def read_busy_time():
-        if npu_busy is None:
-            return None
-        try:
-            return int(fdump(npu_busy))
-        except (ValueError, RuntimeError) as err:
-            LOG.warning('Failed to read busy time: %s', err)
-            return None
-
-    try:
-        pciid = fdump(os.path.join(dev_path, "device"))
-        fw_version = fdump(os.path.join(debugfs, "fw_version"))
-    except RuntimeError as err:
-        LOG.error('Failed to read device metadata: %s', err)
-        sys.exit(1)
-
-    ver_str = run_command('modinfo -F version intel_vpu').stdout.strip()
-    driver_version = ver_str.split()[0] if ver_str else 'unknown'
+    pciid = npu_mon.read_pciid() or 'unknown'
+    fw_version = npu_mon.read_fw_version() or 'unknown'
+    driver_version = npu_mon.read_driver_version()
 
     pu.update_buffer()
-    prev_busy_time = read_busy_time()
+    prev_busy_time = npu_mon.read_busy_time()
     prev_energy = pu.get_npu_energy()
     interval = args.interval if args.interval else DEFAULT_INTERVAL_MS
     prev_bandwidth = pu.get_noc_bandwidth()
-
-    # Memory utilization sysfs isn't exposed on N-1 platforms (e.g., MTL/ARL).
-    # Only PTL and later platforms should attempt to read it.
-    mem_util_supported = (pu.cpu_gen is not None) and (pu.cpu_gen >= CpuGen.PTL)
-    mem_util_path = os.path.join(dev_path, "npu_memory_utilization")
 
     csv_file = None
     csv_file_path = None
@@ -357,7 +412,7 @@ def main(): # pylint: disable=too-many-branches
 
         while True:
             sleep(interval * 1e-3)
-            curr_busy_time = read_busy_time()
+            curr_busy_time = npu_mon.read_busy_time()
             if (args.interval or args.csv) and CLEAR_CMD:
                 subprocess.run([CLEAR_CMD], check=False) # nosec B603
 
@@ -374,28 +429,25 @@ def main(): # pylint: disable=too-many-branches
                 else:
                     utilization = min(100, int(100 * delta_us / interval_us))
 
-            mem_util_mb = -1.0
-            mem_util_str = f'{"N/A":>31} [--]'
-            if mem_util_supported:
-                if os.path.exists(mem_util_path):
-                    mem_util_raw = fdump(mem_util_path)
-                    # from bytes to MB
-                    try:
-                        mem_util_mb = float(int(mem_util_raw)) / KB / KB
-                    except (TypeError, ValueError) as err:
-                        LOG.warning('Failed to parse memory utilization: %s', err)
-                        mem_util_mb = -1.0
+            mem_util_raw = npu_mon.read_mem_util()
+            # from bytes to MB
+            try:
+                mem_util_mb = float(int(mem_util_raw)) / KB / KB
+            except (TypeError, ValueError) as err:
+                LOG.warning('Failed to parse memory utilization: %s', err)
+                mem_util_mb = -1.0
 
-                    if mem_util_mb >= 0:
-                        if mem_util_mb > MB_TO_GB:
-                            mem_util = mem_util_mb / MB_TO_GB
-                            mem_util_unit = 'GB'
-                        else:
-                            mem_util = mem_util_mb
-                            mem_util_unit = 'MB'
-                        mem_util_str = f'{mem_util:>31.2f} [{mem_util_unit}]'
+            if mem_util_mb >= 0:
+                if mem_util_mb > MB_TO_GB:
+                    mem_util = mem_util_mb / MB_TO_GB
+                    mem_util_unit = 'GB'
                 else:
-                    LOG.debug('Memory utilization sysfs node not found at %s', mem_util_path)
+                    mem_util = mem_util_mb
+                    mem_util_unit = 'MB'
+                mem_util_str = f'{mem_util:>31.2f} [{mem_util_unit}]'
+            else:
+                LOG.debug('Memory utilization sysfs node not found.')
+                mem_util_str = f'{"N/A":>31} [--]'
 
             pu.update_buffer()
 

--- a/tools/npu-monitor-tool/requirements-exporter.txt
+++ b/tools/npu-monitor-tool/requirements-exporter.txt
@@ -1,0 +1,3 @@
+flask
+prometheus_client
+gunicorn


### PR DESCRIPTION
### Description

This is a rework of previously PR request about enabling npu-monitoring-tool for Grafana/Prometheus below:
https://github.com/open-edge-platform/edge-ai-libraries/pull/2110 (which should be dropped now)

This PR has 4 patches:

1/4 to 3/4: is about refactoring npu-monitoring-tool.py to add a abstraction layer (class NpuMonitor) that will be used for npu-metrics-exporter.py. Unlike previous implementation, this PR keeps the npu-monitoring-tool.py as stand-alone. It also makes rename requirements.txt to requirements-exporter.txt to be more explicit.

4/4: is a fixes related to NPU memory bandwidth calculation that varied according to polling interval earlier.

### Any Newly Introduced Dependencies

Below dependencies are required for Prometheus exporter only:
- flask
- prometheus_client
- gunicorn

### How Has This Been Tested?

The refactored npu-monitor-tool.py has been tested under CLI:
```bash
+-----------------------------------------------------------------------------------------------+
| INTEL NPU Device: 0xad1d | version:                                                     1.0.0 |
| Firmware version: 20260305*MTL_CLIENT_SILICON-NVR+NN-deployment*dbda783919b77553afe5576a59881 |
| bca37fb6d7b*dbda783919b77553afe5576a59881bca37fb6d7b*dbda783919b                              |
+===============================================================================================+
|       Power Usage        |      DPU Freq        | NPU DDR Average Bandwidth |    Tile Conf    |
|                0.056 [W] |               0 [Hz] |               0.00 [MB/s] |               0 |
+===============================================================================================+
|       NPU Temperature    |       NPU Utilization       |      Memory Usage                    |
|                  30 [°C] |                          0% |                           65.54 [MB] |
+-----------------------------------------------------------------------------------------------+
```

The newly introduced Prometheus exporter is tested using curl command:-
```bash
# HELP npu_monitor_temperature NPU Temperature [°C]
# TYPE npu_monitor_temperature gauge
npu_monitor_temperature{dev_id="0xad1d"} 29.0

# HELP npu_monitor_freq_hz DPU Frequency [Hz]
# TYPE npu_monitor_freq_hz gauge
npu_monitor_freq_hz{dev_id="0xad1d"} 0.0

# HELP npu_memory_util NPU Memory Utilization [MB]
# TYPE npu_memory_util gauge
npu_memory_util{dev_id="0xad1d"} 65.5390625

# HELP npu_memory_bandwidth NPU DDR Average Bandwidth [MB/s]
# TYPE npu_memory_bandwidth gauge
npu_memory_bandwidth{dev_id="0xad1d"} 0.0

# HELP npu_util NPU Utilization [%]
# TYPE npu_util gauge
npu_util{dev_id="0xad1d"} 0.0

# HELP npu_monitor_power NPU Power Consumption [Watts]
# TYPE npu_monitor_power gauge
npu_monitor_power{dev_id="0xad1d"} 0.055789629830113256

# HELP npu_tile_config NPU Tile Configuration
# TYPE npu_tile_config gauge
npu_tile_config{dev_id="0xad1d"} 0.0
```
 
### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

