### PR TITLE
Metrics manager security hardening

### DIFF
--- a/microservices/metrics-manager/Dockerfile
+++ b/microservices/metrics-manager/Dockerfile
@@ -61,11 +61,9 @@ RUN cargo install --locked qmmd@0.2.0
 # -----------------------------------------------------------------------------
 # Built from source (instead of the upstream .deb) to patch known CVEs in
 # bundled Go dependencies:
-#   - github.com/rclone/rclone  1.69.3 → 1.73.5  (CVE-2026-41176, CVE-2026-41179)
-#   - github.com/go-git/go-billy/v5 5.6.0 → 5.9.0 (CVE-2026-44973, CVE-2026-44740)
 # Using golang:1.26 (1.26.3+) also resolves stdlib CVEs fixed in Go 1.26.3.
 # Digest pinned for reproducible builds — decoupled from Docker Hub tag updates.
-FROM golang:1.26@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS telegraf-builder
+FROM golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479 AS telegraf-builder
 
 ARG TELEGRAF_VERSION=1.38.4
 
@@ -99,6 +97,10 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go get github.com/rclone/rclone@v1.73.5 && \
     go get github.com/go-git/go-billy/v5@v5.9.0 && \
     go mod tidy
+# NOTE: CVE-2026-34040 (HIGH) and CVE-2026-33997 (MEDIUM) in github.com/docker/docker
+# cannot be patched yet — fix requires v29.3.1 which does not exist in the Go
+# module proxy (latest: v28.5.2+incompatible). Transitive Telegraf dependency.
+# Revisit when moby/moby v29.3.1 is published to the Go module registry.
 
 # fs.LogOutput was removed from rclone/fs in rclone 1.71+; the remotefile
 # plugin used it only for trace logging so dropping the assignment is safe.
@@ -185,9 +187,6 @@ CMD ["python", "-m", "pytest", "tests/", "-v", "--tb=short"]
 # -----------------------------------------------------------------------------
 FROM python:3.12-slim AS production
 
-# Telegraf version - pinned for reproducible builds
-ARG TELEGRAF_VERSION=1.38.4
-
 # Proxy settings (passed from docker-compose build args)
 ARG http_proxy
 ARG HTTP_PROXY
@@ -215,7 +214,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install supervisor via pip to avoid pulling Debian's python3.13 (CVE-2026-7210).
 # perl-base is not needed at runtime; purging it removes several known CVEs.
 RUN pip install --no-cache-dir pip==26.1 supervisor==4.3.0 && \
-    dpkg --purge --force-remove-essential perl-base && \
+    (dpkg -s perl-base >/dev/null 2>&1 && dpkg --purge --force-remove-essential perl-base || true) && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/microservices/metrics-manager/Dockerfile
+++ b/microservices/metrics-manager/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Copyright (C) 2025-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
@@ -52,11 +53,73 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN cargo install --locked qmassa@1.3.1
-RUN cargo install --locked qmmd@0.1.1
+RUN cargo install --locked qmassa@2.1.0
+RUN cargo install --locked qmmd@0.2.0
 
 # -----------------------------------------------------------------------------
-# Stage 2: Build Python dependencies
+# Stage 2: Build Telegraf from source with patched dependencies
+# -----------------------------------------------------------------------------
+# Built from source (instead of the upstream .deb) to patch known CVEs in
+# bundled Go dependencies:
+#   - github.com/rclone/rclone  1.69.3 → 1.73.5  (CVE-2026-41176, CVE-2026-41179)
+#   - github.com/go-git/go-billy/v5 5.6.0 → 5.9.0 (CVE-2026-44973, CVE-2026-44740)
+# Using golang:1.26 (1.26.3+) also resolves stdlib CVEs fixed in Go 1.26.3.
+# Digest pinned for reproducible builds — decoupled from Docker Hub tag updates.
+FROM golang:1.26@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS telegraf-builder
+
+ARG TELEGRAF_VERSION=1.38.4
+
+ARG http_proxy
+ARG HTTP_PROXY
+ARG https_proxy
+ARG HTTPS_PROXY
+ARG no_proxy
+ARG NO_PROXY
+
+ENV http_proxy=${http_proxy} \
+    HTTP_PROXY=${HTTP_PROXY} \
+    https_proxy=${https_proxy} \
+    HTTPS_PROXY=${HTTPS_PROXY} \
+    no_proxy=${no_proxy} \
+    NO_PROXY=${NO_PROXY}
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends git libudev-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --branch v${TELEGRAF_VERSION} \
+    https://github.com/influxdata/telegraf /telegraf
+
+WORKDIR /telegraf
+
+# Cache Go module downloads across builds to avoid re-fetching on every run.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go get github.com/rclone/rclone@v1.73.5 && \
+    go get github.com/go-git/go-billy/v5@v5.9.0 && \
+    go mod tidy
+
+# fs.LogOutput was removed from rclone/fs in rclone 1.71+; the remotefile
+# plugin used it only for trace logging so dropping the assignment is safe.
+# The outer `if` is a no-op if a future Telegraf release already adapts to
+# the new API; the inner grep catches a block size change at build time.
+RUN if grep -q 'fs\.LogOutput = func' plugins/outputs/remotefile/remotefile.go; then \
+        sed -i '/fs\.LogOutput = func/,+2d' plugins/outputs/remotefile/remotefile.go; \
+        if grep -q 'fs\.LogOutput' plugins/outputs/remotefile/remotefile.go; then \
+            echo "ERROR: sed patch incomplete — fs.LogOutput block may have changed size in this Telegraf version" >&2; \
+            exit 1; \
+        fi; \
+    fi
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build \
+        -ldflags="-s -w -X github.com/influxdata/telegraf/internal.Version=${TELEGRAF_VERSION}" \
+        -o /usr/bin/telegraf ./cmd/telegraf
+
+# -----------------------------------------------------------------------------
+# Stage 3: Build Python dependencies
 # -----------------------------------------------------------------------------
 FROM python:3.12-slim AS python-builder
 
@@ -118,13 +181,12 @@ COPY Dockerfile ./
 CMD ["python", "-m", "pytest", "tests/", "-v", "--tb=short"]
 
 # -----------------------------------------------------------------------------
-# Stage 4: Final image (Python 3.12 base with Telegraf)
-# Using Python base for venv compatibility, Telegraf installed via .deb
+# Stage 4: Final image
 # -----------------------------------------------------------------------------
 FROM python:3.12-slim AS production
 
 # Telegraf version - pinned for reproducible builds
-ARG TELEGRAF_VERSION=1.37.3
+ARG TELEGRAF_VERSION=1.38.4
 
 # Proxy settings (passed from docker-compose build args)
 ARG http_proxy
@@ -141,23 +203,24 @@ ENV http_proxy=${http_proxy} \
     no_proxy=${no_proxy} \
     NO_PROXY=${NO_PROXY}
 
-# Copy qmassa binary from the build stage
+# Copy qmassa and qmmd binaries from Rust build stage
 COPY --from=qmassa-builder /usr/local/cargo/bin/qmassa /usr/local/bin/qmassa
 COPY --from=qmassa-builder /usr/local/cargo/bin/qmmd /usr/local/bin/qmmd
 
+# Copy Telegraf binary (built from source with patched dependencies)
+COPY --from=telegraf-builder /usr/bin/telegraf /usr/bin/telegraf
+
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Telegraf (pinned version via direct .deb download), supervisor, and curl
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends \
-        supervisor \
-        curl && \
-    # Download and install Telegraf .deb directly (pinned version, no GPG issues)
-    curl -fsSL "https://dl.influxdata.com/telegraf/releases/telegraf_${TELEGRAF_VERSION}-1_amd64.deb" -o /tmp/telegraf.deb && \
-    dpkg -i /tmp/telegraf.deb && \
-    rm /tmp/telegraf.deb && \
+# Install supervisor via pip to avoid pulling Debian's python3.13 (CVE-2026-7210).
+# perl-base is not needed at runtime; purging it removes several known CVEs.
+RUN pip install --no-cache-dir pip==26.1 supervisor==4.3.0 && \
+    dpkg --purge --force-remove-essential perl-base && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Create Telegraf config directories
+RUN mkdir -p /etc/telegraf /etc/telegraf/telegraf.d /var/log/telegraf
 
 # Clear proxy from final image (not needed at runtime, set via environment)
 ENV http_proxy= \
@@ -219,7 +282,7 @@ LABEL org.opencontainers.image.title="metrics-manager" \
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:9090/health || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:9090/health', timeout=8)" || exit 1
 
 # Use supervisor to manage both Telegraf and Python service
 CMD ["/entrypoint.sh"]

--- a/microservices/metrics-manager/entrypoint.sh
+++ b/microservices/metrics-manager/entrypoint.sh
@@ -31,4 +31,4 @@ echo "       - Telegraf Prometheus port: ${TELEGRAF_PORT:-9273}"
 echo "       - Custom metrics directory: ${CUSTOM_METRICS_DIR:-/app/custom-metrics}"
 
 # Start supervisor to manage all processes
-exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+exec supervisord -c /etc/supervisor/supervisord.conf

--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -194,9 +194,9 @@ services:
       no_proxy: ${no_proxy}
     restart: on-failure:5
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9090/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9090/health', timeout=8)"]
       interval: 10s
-      timeout: 5s
+      timeout: 10s
       retries: 3
       start_period: 15s
   mediamtx:


### PR DESCRIPTION
### Description

- Build Telegraf 1.38.4 from source instead of upstream .deb to patch CVEs in bundled Go dependencies:
  - rclone 1.69.3 → 1.73.5 (CVE-2026-41176, CVE-2026-41179 CRITICAL)
  - go-billy/v5 5.6.0 → 5.9.0 (CVE-2026-44973, CVE-2026-44740)
  - Compile with Go 1.26.3 to resolve stdlib CVEs (CVE-2026-33811 et al.)
- Install supervisor via pip instead of apt to avoid pulling Debian python3.13 (CVE-2026-7210 CRITICAL)
- Purge perl-base post-install (not needed at runtime)
- Replace curl in HEALTHCHECK with Python urllib (removes curl CVEs)
- Upgrade pip to 26.1 (CVE-2025-8869, CVE-2026-3219, CVE-2026-6357)
- Upgrade qmassa 1.3.1 → 2.1.0, qmmd 0.1.1 → 0.2.0
- Upgrade Telegraf 1.37.3 → 1.38.4
- Add BuildKit cache mounts for Go modules (faster incremental builds)
- Pin golang base image by digest for reproducible CI builds
- Add version ldflags so telegraf --version reports correctly
- Enable # syntax=docker/dockerfile:1 for BuildKit features

### How Has This Been Tested?

seflreview was performed along with manual tests.

### Checklist:

- [ x] I agree to use the APACHE-2.0 license for my code changes.
- [ x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ x] I have not included any company confidential information, trade secret, password or security token. 
- [x ] I have performed a self-review of my code.

