### PR TITLE
gencamsrc: coverity fixes (#2368)

### DIFF
--- a/microservices/dlstreamer-pipeline-server/plugins/camera/src-gst-gencamsrc/plugins/genicam-core/rc_genicam_api/config.cc
+++ b/microservices/dlstreamer-pipeline-server/plugins/camera/src-gst-gencamsrc/plugins/genicam-core/rc_genicam_api/config.cc
@@ -367,6 +367,16 @@ bool setString(const std::shared_ptr<GenApi::CNodeMapRef> &nodemap, const char *
             {
               GenApi::IBoolean *p=dynamic_cast<GenApi::IBoolean *>(node);
 
+              // Coverity CID 6466663: guard against null dynamic_cast result (CWE-476)
+              if (p == nullptr)
+              {
+                if (exception)
+                {
+                  throw std::invalid_argument(std::string("Feature not boolean: ")+name);
+                }
+                break;
+              }
+
               std::string v=std::string(value);
               if (v == "true" || v == "True" || v == "TRUE")
               {
@@ -386,6 +396,16 @@ bool setString(const std::shared_ptr<GenApi::CNodeMapRef> &nodemap, const char *
           case GenApi::intfIInteger:
             {
               GenApi::IInteger *p=dynamic_cast<GenApi::IInteger *>(node);
+
+              // Coverity CID 6466663: guard against null dynamic_cast result (CWE-476)
+              if (p == nullptr)
+              {
+                if (exception)
+                {
+                  throw std::invalid_argument(std::string("Feature not integer: ")+name);
+                }
+                break;
+              }
 
               switch (p->GetRepresentation())
               {
@@ -437,6 +457,17 @@ bool setString(const std::shared_ptr<GenApi::CNodeMapRef> &nodemap, const char *
           case GenApi::intfIFloat:
             {
               GenApi::IFloat *p=dynamic_cast<GenApi::IFloat *>(node);
+
+              // Coverity CID 6466663: guard against null dynamic_cast result (CWE-476)
+              if (p == nullptr)
+              {
+                if (exception)
+                {
+                  throw std::invalid_argument(std::string("Feature not float: ")+name);
+                }
+                break;
+              }
+
               p->SetValue(std::stof(std::string(value)));
             }
             break;
@@ -444,6 +475,17 @@ bool setString(const std::shared_ptr<GenApi::CNodeMapRef> &nodemap, const char *
           case GenApi::intfIEnumeration:
             {
               GenApi::IEnumeration *p=dynamic_cast<GenApi::IEnumeration *>(node);
+
+              // Coverity CID 6466663: guard against null dynamic_cast result (CWE-476)
+              if (p == nullptr)
+              {
+                if (exception)
+                {
+                  throw std::invalid_argument(std::string("Feature not enumeration: ")+name);
+                }
+                break;
+              }
+
               GenApi::IEnumEntry *entry=p->GetEntryByName(value);
 
               if (entry != 0)
@@ -461,6 +503,17 @@ bool setString(const std::shared_ptr<GenApi::CNodeMapRef> &nodemap, const char *
           case GenApi::intfIString:
             {
               GenApi::IString *p=dynamic_cast<GenApi::IString *>(node);
+
+              // Coverity CID 6466663: guard against null dynamic_cast result (CWE-476)
+              if (p == nullptr)
+              {
+                if (exception)
+                {
+                  throw std::invalid_argument(std::string("Feature not string: ")+name);
+                }
+                break;
+              }
+
               p->SetValue(value);
             }
             break;
@@ -830,6 +883,15 @@ std::string getString(const std::shared_ptr<GenApi::CNodeMapRef> &nodemap, const
           case GenApi::intfIBoolean:
             {
               GenApi::IBoolean *p=dynamic_cast<GenApi::IBoolean *>(node);
+              // Coverity CID 6466669: guard against null dynamic_cast result (CWE-476)
+              if (p == nullptr)
+              {
+                if (exception)
+                {
+                  throw std::invalid_argument(std::string("Feature not boolean: ")+name);
+                }
+                break;
+              }
               out << p->GetValue(false, igncache);
             }
             break;
@@ -837,6 +899,15 @@ std::string getString(const std::shared_ptr<GenApi::CNodeMapRef> &nodemap, const
           case GenApi::intfIInteger:
             {
               GenApi::IInteger *p=dynamic_cast<GenApi::IInteger *>(node);
+              // Coverity CID 6466669: guard against null dynamic_cast result (CWE-476)
+              if (p == nullptr)
+              {
+                if (exception)
+                {
+                  throw std::invalid_argument(std::string("Feature not integer: ")+name);
+                }
+                break;
+              }
               int64_t value=p->GetValue(false, igncache);
 
               switch (p->GetRepresentation())
@@ -870,6 +941,15 @@ std::string getString(const std::shared_ptr<GenApi::CNodeMapRef> &nodemap, const
           case GenApi::intfIFloat:
             {
               GenApi::IFloat *p=dynamic_cast<GenApi::IFloat *>(node);
+              // Coverity CID 6466669: guard against null dynamic_cast result (CWE-476)
+              if (p == nullptr)
+              {
+                if (exception)
+                {
+                  throw std::invalid_argument(std::string("Feature not float: ")+name);
+                }
+                break;
+              }
               out << p->GetValue(false, igncache);
             }
             break;
@@ -877,6 +957,15 @@ std::string getString(const std::shared_ptr<GenApi::CNodeMapRef> &nodemap, const
           case GenApi::intfIEnumeration:
             {
               GenApi::IEnumeration *p=dynamic_cast<GenApi::IEnumeration *>(node);
+              // Coverity CID 6466669: guard against null dynamic_cast result (CWE-476)
+              if (p == nullptr)
+              {
+                if (exception)
+                {
+                  throw std::invalid_argument(std::string("Feature not enumeration: ")+name);
+                }
+                break;
+              }
               out << p->GetCurrentEntry()->GetSymbolic();
             }
             break;
@@ -884,6 +973,15 @@ std::string getString(const std::shared_ptr<GenApi::CNodeMapRef> &nodemap, const
           case GenApi::intfIString:
             {
               GenApi::IString *p=dynamic_cast<GenApi::IString *>(node);
+              // Coverity CID 6466669: guard against null dynamic_cast result (CWE-476)
+              if (p == nullptr)
+              {
+                if (exception)
+                {
+                  throw std::invalid_argument(std::string("Feature not string: ")+name);
+                }
+                break;
+              }
               out << p->GetValue(false, igncache);
             }
             break;
@@ -986,7 +1084,9 @@ std::string getComponetOfPart(const std::shared_ptr<GenApi::CNodeMapRef> &nodema
             int64_t val=part->GetValue();
             if (val == ipart)
             {
-              component=dynamic_cast<GenApi::IEnumEntry *>(list[i])->GetSymbolic();
+              // Coverity CID 6466666: use already-checked entry pointer instead of
+              // a second unchecked dynamic_cast<IEnumEntry*>(list[i]) (CWE-476)
+              component=entry->GetSymbolic();
             }
           }
         }

--- a/microservices/dlstreamer-pipeline-server/plugins/camera/src-gst-gencamsrc/plugins/gstgencamsrc.c
+++ b/microservices/dlstreamer-pipeline-server/plugins/camera/src-gst-gencamsrc/plugins/gstgencamsrc.c
@@ -436,8 +436,11 @@ gst_gencamsrc_init (GstGencamsrc * gencamsrc)
       else {
         // commented out for privacy
         // GST_DEBUG_OBJECT (gencamsrc, "BALLUFF_ACQ_LIC_MODULE doesn't exist. Setting it now...");
-        g_setenv (env_variable,
-            "/usr/local/lib/gstreamer-1.0/libgstgencamsrc.so", TRUE);
+        /* Coverity CID 6466668: check return value of g_setenv (CWE-252) */
+        if (!g_setenv (env_variable,
+            "/usr/local/lib/gstreamer-1.0/libgstgencamsrc.so", TRUE)) {
+          GST_WARNING_OBJECT (gencamsrc, "Failed to set environment variable %s", env_variable);
+        }
         // commented out for privacy
         // env_variable_value = getenv(env_variable);
         // GST_DEBUG_OBJECT (gencamsrc, "new BALLUFF_ACQ_LIC_MODULE is: %s", env_variable_value);


### PR DESCRIPTION
### Description

Cherry-pick PR of https://github.com/open-edge-platform/edge-ai-libraries/pull/2368

Fix Coverity security defects (CWE-476, CWE-252)

Fixes 3 Very High and 1 High severity issues flagged in the Coverity SDL security scan.

Changes:
config.cc:
Add nullptr guards after dynamic_cast in setString() and getString() switch-cases — prevents null pointer dereference (CWE-476) if a non-compliant camera XML causes an unexpected type mismatch
Replace redundant dynamic_cast<IEnumEntry*>(list[i])->GetSymbolic() with the already-validated entry pointer (CWE-476)

gstgencamsrc.c
Check return value of g_setenv() and log a warning on failure (CWE-252)

Coverity CIDs resolved: 6466663, 6466666, 6466669, 6466668

No functional behaviour change on the normal execution path.

Fixes # (issue)
https://jira.devtools.intel.com/browse/ITEP-93078

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.