### PR TITLE
[ViPPET] Remove gst plugins

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -23,12 +23,6 @@ USER root
 # Set environment variable to non-interactive mode (avoids some prompts)
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install necessary dependencies
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # Set GStreamer plugin path
 ENV GST_PLUGIN_PATH=$GST_PLUGIN_PATH/usr/lib/x86_64-linux-gnu/gstreamer-1.0/
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -25,7 +25,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install necessary dependencies
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends gstreamer1.0-plugins-ugly yq v4l-utils && \
+    apt-get install --yes --no-install-recommends yq v4l-utils && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/age-and-gender-recognition.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/age-and-gender-recognition.yaml
@@ -39,7 +39,7 @@ variants:
       queue !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -76,7 +76,7 @@ variants:
       queue !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -115,7 +115,7 @@ variants:
       queue !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -151,7 +151,7 @@ variants:
       queue !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -188,7 +188,7 @@ variants:
       queue !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/goods-detection-and-classification.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/goods-detection-and-classification.yaml
@@ -38,7 +38,7 @@ variants:
         reclassify-interval=1 !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -74,7 +74,7 @@ variants:
         reclassify-interval=1 !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -112,7 +112,7 @@ variants:
         reclassify-interval=1 !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -146,7 +146,7 @@ variants:
         reclassify-interval=1 !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -181,7 +181,7 @@ variants:
         reclassify-interval=1 !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/goods-detection.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/goods-detection.yaml
@@ -21,7 +21,7 @@ variants:
         nireq=2 !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -40,7 +40,7 @@ variants:
         nireq=2 !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -61,7 +61,7 @@ variants:
         nireq=2 !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
@@ -79,7 +79,7 @@ variants:
         nireq=4 !
       gvafpscounter starting-frame=100 !
       gvawatermark !
-      gvametaconvert !
+      gvametaconvert add-empty-results=true !
       queue !
       gvametapublish file-format=json-lines file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/human-pose.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/human-pose.yaml
@@ -29,7 +29,7 @@ variants:
       gvafpscounter starting-frame=100 !
       gvawatermark !
       queue !
-      gvametaconvert timestamp-utc=true json-indent=-1 !
+      gvametaconvert add-empty-results=true timestamp-utc=true json-indent=-1 !
       gvametapublish method=file file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
   - name: GPU
@@ -52,7 +52,7 @@ variants:
       gvafpscounter starting-frame=100 !
       gvawatermark !
       queue !
-      gvametaconvert timestamp-utc=true json-indent=-1 !
+      gvametaconvert add-empty-results=true timestamp-utc=true json-indent=-1 !
       gvametapublish method=file file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
   - name: NPU
@@ -74,6 +74,6 @@ variants:
       gvafpscounter starting-frame=100 !
       gvawatermark !
       queue !
-      gvametaconvert timestamp-utc=true json-indent=-1 !
+      gvametaconvert add-empty-results=true timestamp-utc=true json-indent=-1 !
       gvametapublish method=file file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/license-plate-recognition.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/license-plate-recognition.yaml
@@ -37,7 +37,7 @@ variants:
         reclassify-interval=1 !
       queue !
       gvawatermark !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       fakesink name=default_output_sink
   - name: GPU
@@ -71,7 +71,7 @@ variants:
         reclassify-interval=1 !
       queue !
       gvawatermark !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       fakesink name=default_output_sink
   - name: GPU (WSL)
@@ -107,7 +107,7 @@ variants:
         reclassify-interval=1 !
       queue !
       gvawatermark !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       fakesink name=default_output_sink
   - name: GPU_NPU
@@ -140,6 +140,6 @@ variants:
         reclassify-interval=1 !
       queue !
       gvawatermark !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       fakesink name=default_output_sink

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/motion-detection.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/motion-detection.yaml
@@ -17,7 +17,7 @@ variants:
         pre-process-backend=opencv
         inference-region=roi-list
         model-instance-id=detect-cpu !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-format=json-lines file-path=/dev/null !
       gvafpscounter starting-frame=100 !
       gvawatermark !
@@ -34,7 +34,7 @@ variants:
         pre-process-backend=va-surface-sharing
         inference-region=roi-list
         model-instance-id=detect-gpu !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-format=json-lines file-path=/dev/null !
       gvafpscounter starting-frame=100 !
       gvawatermark !
@@ -53,7 +53,7 @@ variants:
         pre-process-backend=opencv
         inference-region=roi-list
         model-instance-id=detect-gpu !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-format=json-lines file-path=/dev/null !
       gvafpscounter starting-frame=100 !
       gvawatermark !
@@ -70,7 +70,7 @@ variants:
         pre-process-backend=opencv
         inference-region=roi-list
         model-instance-id=detect-npu !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-format=json-lines file-path=/dev/null !
       gvafpscounter starting-frame=100 !
       gvawatermark !

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/segmentation.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/segmentation.yaml
@@ -19,6 +19,7 @@ variants:
       gvafpscounter starting-frame=100 !
       videoconvert !
       video/x-raw,format=I420 !
+      gvametaconvert add-empty-results=true !
       gvametapublish method=file file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false
   - name: GPU
@@ -31,5 +32,6 @@ variants:
       queue !
       gvawatermark !
       gvafpscounter starting-frame=100 !
+      gvametaconvert add-empty-results=true !
       gvametapublish method=file file-path=/dev/null !
       fakesink name=default_output_sink sync=false async=false

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/smart-nvr.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/smart-nvr.yaml
@@ -42,7 +42,7 @@ variants:
         reclassify-interval=1 !
       queue !
       gvawatermark !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       videoscale !
       video/x-raw,width=320,height=240 !
@@ -85,7 +85,7 @@ variants:
         reclassify-interval=1 !
       queue !
       gvawatermark !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       vapostproc !
       video/x-raw(memory:VAMemory),width=320,height=240 !
@@ -128,7 +128,7 @@ variants:
         reclassify-interval=1 !
       queue !
       gvawatermark !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       videoscale !
       video/x-raw,width=320,height=240 !
@@ -170,7 +170,7 @@ variants:
         reclassify-interval=1 !
       queue !
       gvawatermark !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       vapostproc !
       video/x-raw(memory:VAMemory),width=320,height=240 !
@@ -212,7 +212,7 @@ variants:
         reclassify-interval=1 !
       queue !
       gvawatermark !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       vapostproc !
       video/x-raw(memory:VAMemory),width=320,height=240 !
@@ -254,7 +254,7 @@ variants:
         reclassify-interval=1 !
       queue !
       gvawatermark !
-      gvametaconvert format=json !
+      gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       vapostproc !
       video/x-raw(memory:VAMemory),width=320,height=240 !

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_density_job_flow.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_density_job_flow.py
@@ -58,7 +58,7 @@ def _build_density_payload(case: PipelineCase) -> JsonDict:
             }
         ],
         "execution_config": {
-            "max_runtime": "5",
+            "max_runtime": "20",
             "output_mode": "disabled",
         },
     }
@@ -136,7 +136,7 @@ def test_start_density_job_with_nonexistent_variant_returns_400(
                 "stream_rate": 10,
             }
         ],
-        "execution_config": {"max_runtime": "5", "output_mode": "disabled"},
+        "execution_config": {"max_runtime": "20", "output_mode": "disabled"},
     }
 
     response = http_client.post(f"{BASE_URL}/tests/density", json=payload, timeout=30)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_pipeline_optimize_flow.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_pipeline_optimize_flow.py
@@ -45,7 +45,7 @@ OPTIMIZATION_CASES = [
     ),
     (
         "optimize-non-device-variant",
-        "gpu_npu",
+        "gpu-npu",
         {
             "type": "optimize",
             "parameters": {"search_duration": 10, "sample_duration": 3},


### PR DESCRIPTION
# Summary
Cleans up unused GStreamer plugin packages from Docker images, fixes a wrong variant id in a functional test, and stabilizes flaky metadata / density functional tests.
## Changes
### Remove unused GStreamer plugin packages
- `vippet/Dockerfile`: drop `gstreamer1.0-plugins-ugly`.
- `video_generator/Dockerfile`: drop the install step for `gstreamer1.0-plugins-bad` and `gstreamer1.0-plugins-ugly`. These packages are no longer used by any ViPPET pipeline and only bloated the images.
### Fix variant id in pipeline optimize test
- `test_pipeline_optimize_flow.py`: `gpu_npu` → `gpu-npu` to match the actual pipeline definition.
### Make metadata-mode tests deterministic
Added `add-empty-results=true` to every `gvametaconvert` that did not already have it (age-and-gender, goods-detection, goods-detection-and-classification, human-pose, license-plate-recognition, motion-detection, segmentation,
smart-nvr). In `segmentation.yaml` also added the missing `gvametaconvert` before `gvametapublish` so file-mode metadata is actually produced.
Without this flag, `gvametaconvert` skips frames with no inference results, so on short videos / high thresholds `gvametapublish` produced empty `.jsonl` files and `test_performance_metadata_file_mode_job` was flaky.
### Increase density test `max_runtime`
- `test_density_job_flow.py`: `max_runtime` 5 s → 20 s.
Heavier GPU pipelines did not always reach `gvafpscounter starting-frame=100` within 5 s due to GPU warm-up, which caused jobs to finish cleanly but with no FPS reported and be marked `FAILED`.
## Validation
- `make test-full` runs cleanly; previously flaky metadata and density cases now pass consistently.
- No API or schema changes; no client regeneration needed.
