### PR TITLE
[ViPPET] Bump onnx to >=1.21.0 in OMZ venv to fix CVE-2026-27489

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/setup_env.sh
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/setup_env.sh
@@ -3,7 +3,7 @@
 # This script automatically detects the available device (NPU, GPU, or CPU)
 # and writes COMPOSE_PROFILES, RENDER_GROUP_ID, and DOCKER_TAG to the .env file.
 
-VERSION=2026.0.0
+VERSION=2026.1.0
 COMPOSE_PROFILES=""
 RENDER_GROUP_ID=""
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -63,7 +63,15 @@ RUN \
     pip3 install --disable-pip-version-check --no-cache-dir -r requirements.txt && \
     python3 -m venv $OMZ_VIRTUAL_ENV && \
     $OMZ_VIRTUAL_ENV/bin/pip install --disable-pip-version-check --no-cache-dir \
-        -r requirements-omz.txt
+        -r requirements-omz.txt && \
+    # Security override: bump ``onnx`` past the cap that ``openvino-dev``
+    # 2024.6.0 (archived upstream) inherited. Fixes CVE-2026-27489 (HIGH),
+    # CVE-2026-28500 and CVE-2026-34446. ``--upgrade`` + explicit version
+    # is required because the resolver would otherwise honor the cap, and
+    # we deliberately keep transitive deps intact (no --no-deps) so onnx's
+    # own runtime requirements (protobuf, numpy) are satisfied.
+    $OMZ_VIRTUAL_ENV/bin/pip install --disable-pip-version-check --no-cache-dir \
+        --upgrade "onnx>=1.21.0"
 
 # Copy the Python scripts and configuration files into the container
 COPY --chown=dlstreamer:dlstreamer \

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/requirements-omz.txt
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/requirements-omz.txt
@@ -15,3 +15,14 @@
 openvino-dev[onnx]==2024.6.0
 torch==2.8.0
 torchvision==0.23.0
+
+# Security override:
+# ``openvino-dev[onnx]==2024.6.0`` transitively pins ``onnx<=1.17.0``,
+# which is affected by CVE-2026-27489 (HIGH, path traversal) and
+# CVE-2026-28500 / CVE-2026-34446. Upstream ``openvino-dev`` is archived
+# and will not be re-released, so we override the pin manually.
+# Installed in a second pip step in the Dockerfile with ``--upgrade``
+# because the resolver would otherwise refuse to violate the cap.
+# The ONNX file format is backward-compatible, so 1.21.x is a safe
+# drop-in for ``omz_converter`` which only uses ``onnx`` as a model
+# reader/writer.


### PR DESCRIPTION
## Summary

Trivy reports a HIGH severity vulnerability `CVE-2026-27489` (ONNX path traversal / information disclosure) plus two related MEDIUM CVEs (`CVE-2026-28500`, `CVE-2026-34446`) on `onnx==1.17.0` installed in the secondary virtualenv at `/home/dlstreamer/.omz-venv`.

`onnx 1.17.0` is pulled in transitively by `openvino-dev[onnx]==2024.6.0`, which we still need because `2024.6.0` is the last `openvino-dev` release shipping `omz_downloader` and `omz_converter`. The package is archived upstream and will not be re-released, so the cap on `onnx` will never be lifted at the source.

## Changes

- `vippet/requirements-omz.txt`: document why `onnx` must be overridden manually (the resolver would otherwise honor the upstream cap).
- `vippet/Dockerfile`: add a second `pip install --upgrade "onnx>=1.21.0"` step inside `$OMZ_VIRTUAL_ENV` right after `requirements-omz.txt` is installed. This overwrites the vulnerable `onnx 1.17.0` (and its `METADATA`) without touching openvino-dev` itself. Transitive deps are left intact (no `--no-deps`) so `protobuf` / `numpy` stay consistent.
- `setup_env.sh`: bump `VERSION` from `2026.0.0` to `2026.1.0` for new release.