### PR TITLE
Add parameter binding contract artifacts

### DIFF
--- a/microservices/dlstreamer-pipeline-server/AGENTS.md
+++ b/microservices/dlstreamer-pipeline-server/AGENTS.md
@@ -1,0 +1,167 @@
+# DL Streamer Pipeline Server — Agent Entry Point
+
+## What This Service Does
+
+Deep Learning Streamer Pipeline Server (DL Streamer Pipeline Server) is a containerized
+microservice for launching, managing, and monitoring video analytics pipelines. It exposes
+a REST API for pipeline lifecycle (start, stop, status) and accepts per-request configuration
+that controls how GStreamer element properties are set at pipeline launch time.
+
+This file is the canonical entry point for agents and external integrators arriving at this
+folder. It describes the parameter-application contract: how values supplied in a pipeline
+request are bound to GStreamer element properties.
+
+## Contract Files
+
+| File | Purpose |
+|------|---------|
+| [`contract.json`](contract.json) | Machine-readable contract artifact. Stable at this repo-relative path across all patch releases. |
+| [`docs/user-guide/advanced-guide/detailed_usage/rest_api/parameter_contract.md`](docs/user-guide/advanced-guide/detailed_usage/rest_api/parameter_contract.md) | Normative prose reference for all binding semantics. Contains the `contract-version` field. |
+| [`docs/user-guide/release-notes/contract-migration-template.md`](docs/user-guide/release-notes/contract-migration-template.md) | Template used for any release that contains contract-breaking changes. |
+| [`tests/test_parameter_contract.py`](tests/test_parameter_contract.py) | Conformance tests. Every binding form described below is covered by at least one test. |
+
+## Parameter Binding Contract
+
+### Overview
+
+A pipeline definition contains a `parameters` section that declares which properties are
+configurable and how they map to GStreamer elements. When a request arrives, the pipeline
+server reads the `element` field from each parameter schema entry and applies the supplied
+value to the corresponding GStreamer element property.
+
+### The Three `element` Binding Forms
+
+#### 1. String form
+
+```json
+"inference-interval": {
+    "element": "detection",
+    "type": "integer",
+    "default": 1
+}
+```
+
+The string is the element name. The property name is taken from the parameter key
+(`inference-interval` in this example).
+
+#### 2. Object form
+
+```json
+"interval": {
+    "element": {
+        "name": "detection",
+        "property": "inference-interval"
+    },
+    "type": "integer",
+    "default": 1
+}
+```
+
+The object specifies the element `name` and the explicit `property` name to set.
+An optional `format` field controls serialization (see below).
+
+#### 3. Array form
+
+```json
+"interval": {
+    "element": [
+        {"name": "detection",  "property": "inference-interval"},
+        {"name": "classification", "property": "inference-interval"}
+    ],
+    "type": "integer",
+    "default": 1
+}
+```
+
+The array applies the same value to all listed element/property pairs. Each entry
+follows the same rules as the object form.
+
+### The Two `format` Values
+
+The `format` field is only valid inside an object or array element entry.
+
+| `format` value | Behavior |
+|----------------|----------|
+| `element-properties` | The parameter value must be a JSON object. Each key/value pair in the object is applied as a separate property on the named element. Used when a single parameter should fan out across an element's entire property set. |
+| `json` | The parameter value is JSON-serialized (`json.dumps`) before being passed to `element.set_property`. Required for GStreamer properties that expect a JSON string (e.g. `metaconvert.tags`). |
+| _(absent)_ | The value is passed directly to `element.set_property` without transformation. |
+
+**Example — `element-properties`:**
+
+```json
+"properties": {
+    "type": "object",
+    "element": {
+        "name": "source",
+        "format": "element-properties"
+    }
+}
+```
+
+A request value of `{"device": "/dev/video0", "do-timestamp": true}` causes
+`source.device = /dev/video0` and `source.do-timestamp = true` to be set individually.
+
+**Example — `json`:**
+
+```json
+"tags": {
+    "type": "object",
+    "element": {
+        "name": "metaconvert",
+        "property": "tags",
+        "format": "json"
+    }
+}
+```
+
+A request value of `{"city": "Seattle"}` is passed to the element as the string
+`'{"city": "Seattle"}'`.
+
+### Unresolved-Property Behavior
+
+| Condition | Behavior |
+|-----------|---------|
+| Named element not present in the pipeline | Logged at DEBUG level. Pipeline continues without error. |
+| Element present but property not in its property list | Logged at DEBUG level. Value recorded in `_unset_properties`. Pipeline continues without error. |
+
+Neither condition raises an exception or transitions the pipeline to an error state.
+
+### Reserved Element Names
+
+The following element names have special default handling built into the pipeline server.
+Do not reuse these names for custom elements unless you intend to trigger that handling.
+
+| Name | Default handling |
+|------|-----------------|
+| `source` | URI, device, or custom GST element wired automatically from the `source` section of the request. |
+| `destination` | Output sink wired from the `destination` section of the request. |
+| `appsink` | Used internally for frame-level destinations (RTSP, WebRTC). |
+| `metaconvert` | Used for metadata publishing; `source` and `tags` properties have built-in bindings. |
+
+## Conformance Tests
+
+`tests/test_parameter_contract.py` asserts the following invariants:
+
+1. String-form binding sets the property named by the parameter key on the named element.
+2. Object-form binding sets the explicitly named `property` on the named element.
+3. Array-form binding applies to all listed elements.
+4. `format: element-properties` fans out key/value pairs as individual property calls.
+5. `format: json` JSON-serializes the value before calling `set_property`.
+6. An unresolved element name is logged and does not raise an exception.
+
+## Contract-Breaking Change Policy
+
+A change is contract-breaking if it:
+- Removes or renames a supported `format` value.
+- Changes the property resolution rule for any binding form.
+- Changes unresolved-property behavior from log-and-continue to raise.
+
+Contract-breaking changes are release blockers until a migration note is published using
+[`docs/user-guide/release-notes/contract-migration-template.md`](docs/user-guide/release-notes/contract-migration-template.md)
+and `contract.json` is updated with the new `contract-version`.
+
+## Further Reading
+
+- Full parameter examples: [`docs/user-guide/advanced-guide/detailed_usage/rest_api/defining_pipelines.md`](docs/user-guide/advanced-guide/detailed_usage/rest_api/defining_pipelines.md)
+- Request customization: [`docs/user-guide/advanced-guide/detailed_usage/rest_api/customizing_pipeline_requests.md`](docs/user-guide/advanced-guide/detailed_usage/rest_api/customizing_pipeline_requests.md)
+- REST API reference: [`docs/user-guide/api-reference.md`](docs/user-guide/api-reference.md)

--- a/microservices/dlstreamer-pipeline-server/Makefile
+++ b/microservices/dlstreamer-pipeline-server/Makefile
@@ -34,6 +34,18 @@ coverage:
 	echo $@
 	@echo "---END MAKEFILE COVERAGE---"
 
+check-contract:
+	@# Help: Fails if contract.json is stale relative to src/server/schema.py
+	@echo "---MAKEFILE CHECK-CONTRACT---"
+	python3 utils/generate_contract.py --check
+	@echo "---END MAKEFILE CHECK-CONTRACT---"
+
+generate-contract:
+	@# Help: Regenerates contract.json from src/server/schema.py and document-versions.yaml
+	@echo "---MAKEFILE GENERATE-CONTRACT---"
+	python3 utils/generate_contract.py
+	@echo "---END MAKEFILE GENERATE-CONTRACT---"
+
 list:
 	@# Help: displays make targets
 	help
@@ -48,4 +60,4 @@ help:
         | xargs -I _ sh -c 'printf "%-20s " _; make _ -nB | (grep -i "^# Help:" || echo "") | tail -1 | sed "s/^# Help: //g"'
 
 
-.PHONY: build test coverage
+.PHONY: build test coverage check-contract generate-contract

--- a/microservices/dlstreamer-pipeline-server/contract.json
+++ b/microservices/dlstreamer-pipeline-server/contract.json
@@ -1,0 +1,22 @@
+{
+  "contract-version": "3.0.0",
+  "element-binding-forms": [
+    "string",
+    "object",
+    "array"
+  ],
+  "supported-formats": [
+    "element-properties",
+    "json"
+  ],
+  "reserved-element-names": [
+    "appsink",
+    "destination",
+    "metaconvert",
+    "source"
+  ],
+  "unresolved-element-behavior": "log-and-continue",
+  "unresolved-property-behavior": "log-and-continue",
+  "normative-reference": "docs/user-guide/advanced-guide/detailed_usage/rest_api/parameter_contract.md",
+  "conformance-tests": "tests/test_parameter_contract.py"
+}

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/rest_api/parameter_contract.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/rest_api/parameter_contract.md
@@ -1,0 +1,273 @@
+---
+contract-version: "3.0.0"
+source-files:
+  - src/server/gstreamer_pipeline.py
+  - src/server/schema.py
+---
+
+# Parameter Binding Contract — Normative Reference
+
+This document is the normative specification for how pipeline parameters are applied to
+GStreamer element properties by DL Streamer Pipeline Server. It is versioned by the
+`contract-version` field in the YAML front matter above, which matches the service release
+version in `document-versions.yaml`.
+
+The machine-readable form of this contract is committed at
+[`contract.json`](../../../../contract.json) (repo-relative, stable across patch releases).
+
+For worked examples and request formats, see:
+- [Defining Pipelines](defining_pipelines.md)
+- [Customizing Pipeline Requests](customizing_pipeline_requests.md)
+
+---
+
+## 1. Scope
+
+This contract covers GStreamer pipeline parameter binding only. FFmpeg pipeline parameter
+binding is a separate concern and is not covered here.
+
+A **pipeline definition** is a JSON document stored under `configs/` or loaded at startup.
+It may contain a `parameters` section. A **pipeline request** is the JSON body sent to
+`POST /pipelines/{name}/{version}`. The `parameters` field of the request is validated
+against the JSON schema in the pipeline definition's `parameters` section, then applied
+to the running GStreamer pipeline by `_set_section_properties` in
+`src/server/gstreamer_pipeline.py`.
+
+---
+
+## 2. The `element` Field
+
+Each property entry inside `parameters.properties` may carry an `element` field that
+controls which GStreamer element(s) and property receive the value. There are three
+binding forms.
+
+### 2.1 String Form
+
+```
+"element": "<element-name>"
+```
+
+**Resolution:** The string is treated as the GStreamer element name. The property name
+set on the element is taken from the parameter key itself.
+
+**Implementation reference:** `_get_element_property` — `isinstance(element, str)` branch
+returns `(element, key, None)`.
+
+**Example:**
+
+```json
+"parameters": {
+  "type": "object",
+  "properties": {
+    "inference-interval": {
+      "element": "detection",
+      "type": "integer",
+      "default": 1
+    }
+  }
+}
+```
+
+A request value of `{"inference-interval": 4}` calls
+`detection.set_property("inference-interval", 4)`.
+
+---
+
+### 2.2 Object Form
+
+```json
+"element": {
+  "name": "<element-name>",
+  "property": "<property-name>",
+  "format": "<format-value>"
+}
+```
+
+`name` is required. `property` defaults to the parameter key when absent.
+`format` is optional; see Section 3.
+
+**Implementation reference:** `_get_element_property` — `isinstance(element, dict)` branch
+returns `(element["name"], element.get("property", None), element.get("format", None))`.
+
+**Example:**
+
+```json
+"interval": {
+  "element": {
+    "name": "detection",
+    "property": "inference-interval"
+  },
+  "type": "integer",
+  "default": 1
+}
+```
+
+A request value of `{"interval": 4}` calls
+`detection.set_property("inference-interval", 4)`.
+
+---
+
+### 2.3 Array Form
+
+```json
+"element": [
+  {"name": "<element-name-1>", "property": "<property-name-1>"},
+  {"name": "<element-name-2>", "property": "<property-name-2>"}
+]
+```
+
+Each entry in the array follows the object form rules. The same value is applied to
+all listed element/property pairs.
+
+**Implementation reference:** `_set_section_properties` — `isinstance(config[key]["element"], list)`
+branch builds a list of `(element_name, property_name, format_type)` tuples and iterates them.
+
+**Example:**
+
+```json
+"interval": {
+  "element": [
+    {"name": "detection",     "property": "inference-interval"},
+    {"name": "classification","property": "inference-interval"}
+  ],
+  "type": "integer",
+  "default": 1
+}
+```
+
+A request value of `{"interval": 4}` calls `set_property("inference-interval", 4)` on both
+`detection` and `classification`.
+
+---
+
+## 3. The `format` Field
+
+The `format` field is valid inside an object or array element entry. It controls how the
+parameter value is transformed before being passed to `element.set_property`.
+
+### 3.1 `format: element-properties`
+
+The parameter value must be a JSON object. Each key/value pair in the object is applied
+as a separate `set_property` call on the named element.
+
+**Use case:** Exposing all writable properties of an element through a single pipeline
+parameter without enumerating each property explicitly.
+
+**Implementation reference:** `_set_section_properties` — `format_type == "element-properties"`
+branch iterates `request[key].items()` and calls `_set_element_property` for each pair.
+
+**Example:**
+
+```json
+"properties": {
+  "type": "object",
+  "element": {
+    "name": "source",
+    "format": "element-properties"
+  }
+}
+```
+
+Request `{"properties": {"uri": "rtsp://camera/stream", "latency": 100}}` results in:
+- `source.set_property("uri", "rtsp://camera/stream")`
+- `source.set_property("latency", 100)`
+
+### 3.2 `format: json`
+
+The parameter value is passed to `json.dumps` before being set on the element property.
+
+**Use case:** GStreamer properties that expect a JSON string rather than a native type.
+
+**Implementation reference:** `_set_element_property` — `format_type == "json"` branch calls
+`element.set_property(property_name, json.dumps(property_value))`.
+
+**Example:**
+
+```json
+"tags": {
+  "type": "object",
+  "element": {
+    "name": "metaconvert",
+    "property": "tags",
+    "format": "json"
+  }
+}
+```
+
+Request `{"tags": {"location": "building-1"}}` passes the string
+`'{"location": "building-1"}'` to `metaconvert.set_property("tags", ...)`.
+
+### 3.3 No `format` (default)
+
+The parameter value is passed directly to `element.set_property` without transformation.
+
+---
+
+## 4. Unresolved-Property Behavior
+
+### 4.1 Element not found in pipeline
+
+If `pipeline.get_by_name(element_name)` returns `None`, the binding is skipped. A DEBUG
+message is logged:
+
+```
+Parameter <property_name> given for element <element_name> but no element found
+```
+
+The pipeline continues normally. No exception is raised.
+
+### 4.2 Property not in element's property list
+
+If the element is found but the property name is not in `element.list_properties()`, the
+binding is skipped. A DEBUG message is logged:
+
+```
+Parameter <property_name> given for element <element_gtype_name> but no property found
+```
+
+The unset binding is appended to `_unset_properties` for observability. The pipeline
+continues normally. No exception is raised.
+
+---
+
+## 5. Reserved Element Names
+
+The following element names have special handling wired into the pipeline server modules.
+Using these names in a pipeline template triggers that handling automatically.
+
+| Name | Special handling |
+|------|-----------------|
+| `source` | Auto-wired from the `source` section of the request (URI, webcam device, GST element, or application source). |
+| `destination` | Auto-wired from the `destination` section of the request. |
+| `appsink` | Used internally for frame-level destinations (RTSP, WebRTC). Setting `name=appsink` on an appsink element enables frame capture. |
+| `metaconvert` | Used for metadata publishing. The `source` and `tags` properties have built-in element bindings in `schema.py`. |
+
+---
+
+## 6. Downstream Adapter Responsibilities
+
+The parser applies values to elements — it does not generate or validate the values
+themselves. A downstream adapter (the component that constructs the pipeline request)
+is responsible for:
+
+- Supplying parameter values that are valid for the target GStreamer property type.
+- Providing `format: json` values as JSON-serializable Python objects, not pre-encoded strings.
+- Using reserved element names only when intending to trigger their built-in handling.
+- Checking `_unset_properties` (surfaced in pipeline status) to detect silently dropped bindings.
+
+---
+
+## 7. Contract Stability Guarantees
+
+| Category | Stability |
+|----------|-----------|
+| Three binding forms (string, object, array) | Stable across all releases in this major version. |
+| `format: element-properties` behavior | Stable. |
+| `format: json` behavior | Stable. |
+| Unresolved-element behavior (log, no raise) | Stable. |
+| Reserved element names | Additive changes only (new names may be added; existing names will not change behavior within a major version). |
+
+A **contract-breaking change** is any change that alters the items marked Stable above.
+Such changes are release blockers until a migration note is published using the template at
+[`../release-notes/contract-migration-template.md`](../release-notes/contract-migration-template.md)
+and `contract.json` is updated with the new `contract-version`.

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/release-notes/contract-migration-template.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/release-notes/contract-migration-template.md
@@ -1,0 +1,100 @@
+# Contract Migration Notes — RELEASE_MONTH YEAR
+
+<!--
+  Use this template for any release that contains contract-breaking changes to the
+  DL Streamer Pipeline Server parameter binding contract.  Copy this file to
+  docs/user-guide/release-notes/<month-year>.md (or add a section to the existing
+  release notes file for that month) and fill in all sections below.
+
+  A release is a contract-breaking release if it changes any item marked "Stable"
+  in docs/user-guide/advanced-guide/detailed_usage/rest_api/parameter_contract.md.
+
+  Before publishing the release:
+    1. Complete all sections in this template.
+    2. Update contract-version in parameter_contract.md YAML front matter.
+    3. Run  python3 utils/generate_contract.py  and commit contract.json.
+    4. Remove this comment block.
+-->
+
+## Contract Version
+
+| Field | Value |
+|-------|-------|
+| Previous contract-version | `X.Y.Z` |
+| New contract-version | `X.Y+1.0` |
+| Breaking change | Yes |
+
+---
+
+## Changed Behavior
+
+<!-- Describe what changed and why. Be precise: name the binding form or format value
+     that changed, quote the old behavior, and quote the new behavior. -->
+
+| Binding form / format | Old behavior | New behavior |
+|-----------------------|-------------|-------------|
+| _(e.g. `format: json`)_ | _(e.g. value passed as native object)_ | _(e.g. value JSON-serialized before set_property)_ |
+
+---
+
+## Removed Parameters or Binding Forms
+
+<!-- List any parameter keys, element binding forms, or format values that have been
+     removed. For each, state the replacement (if any). -->
+
+- **Removed:** `_parameter-name_`
+  - **Reason:** _(brief explanation)_
+  - **Replacement:** _(new parameter name or approach, or "none")_
+
+---
+
+## New Required Fields
+
+<!-- List any new fields that are now required in a pipeline definition or request.
+     Integrators must update their pipeline definitions before deploying this release. -->
+
+- **Field:** `_field-name_`
+  - **Where required:** pipeline definition `parameters.properties.<name>.element`
+  - **Default if absent:** _(none — will cause runtime error / fallback to X)_
+
+---
+
+## Upgrade Steps
+
+Follow these steps to update any pipeline definition or downstream adapter that uses
+the previous contract version.
+
+1. **Update pipeline definitions.**
+   In each `configs/<pipeline>/config.json`, change:
+   ```json
+   // Before
+   "element": "old-element-name"
+
+   // After
+   "element": {"name": "new-element-name", "property": "explicit-property"}
+   ```
+
+2. **Update request construction.**
+   If your adapter constructs pipeline requests programmatically, update the
+   `parameters` dict to use the new field names or value formats.
+
+3. **Verify with conformance tests.**
+   Run the conformance suite against your updated definitions:
+   ```bash
+   pytest tests/test_parameter_contract.py -v
+   ```
+
+4. **Update `contract-version` references** in any downstream system that pins to
+   a specific contract version.
+
+---
+
+## Verification
+
+Before releasing, confirm:
+
+- [ ] `parameter_contract.md` front matter `contract-version` updated.
+- [ ] `contract.json` regenerated: `python3 utils/generate_contract.py`
+- [ ] `contract.json` committed to the service root.
+- [ ] `pytest tests/test_parameter_contract.py` passes.
+- [ ] CI `check-contract` step passes: `python3 utils/generate_contract.py --check`

--- a/microservices/dlstreamer-pipeline-server/tests/test_parameter_contract.py
+++ b/microservices/dlstreamer-pipeline-server/tests/test_parameter_contract.py
@@ -1,0 +1,422 @@
+#
+# Apache v2 license
+# Copyright (C) 2024-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Conformance tests for the DL Streamer Pipeline Server parameter binding contract.
+
+Each test maps directly to one of the six invariants listed in AGENTS.md and
+parameter_contract.md.  No SceneScape-specific fixtures or imports are used.
+
+Invariants tested:
+  1. String-form element binding uses the parameter key as the property name.
+  2. Object-form element binding uses the explicit 'property' field.
+  3. Array-form element binding applies to all listed elements.
+  4. format=element-properties fans out key/value pairs as individual set_property calls.
+  5. format=json JSON-serializes the value before calling set_property.
+  6. Unresolved element name is logged at DEBUG and does not raise an exception.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, call, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a minimal GStreamerPipeline instance without a live GStreamer
+# ---------------------------------------------------------------------------
+
+def _make_pipeline(mocker, request_params=None, config_params=None):
+    """Return a GStreamerPipeline whose internals are mocked enough to exercise
+    _get_element_property, _set_element_property, and _set_section_properties.
+    """
+    # Patch the GStreamer initialisation that runs at class body level.
+    mocker.patch("gi.repository.Gst.init")
+    mocker.patch("src.server.gstreamer_pipeline.GStreamerPipeline._mainloop", None)
+
+    from src.server.gstreamer_pipeline import GStreamerPipeline
+
+    config = {
+        "template": "fakesrc name=source ! fakesink name=destination",
+        "type": "GStreamer",
+        "parameters": {
+            "type": "object",
+            "properties": config_params or {},
+        },
+    }
+    request = {
+        "source": {"type": "uri", "uri": "file://test.mp4"},
+        "destination": {"metadata": {"type": "file", "path": "/tmp/out.json"}},
+        "parameters": request_params or {},
+    }
+
+    mock_options = MagicMock()
+    mock_options.enable_rtsp = False
+    mock_options.enable_webrtc = False
+
+    gp = GStreamerPipeline.__new__(GStreamerPipeline)
+    gp.identifier = "contract-test"
+    gp.config = config
+    gp.request = request
+    gp._options = mock_options
+    gp._unset_properties = []
+    gp._logger = MagicMock()
+
+    # Attach a mock GStreamer pipeline object.
+    gp.pipeline = MagicMock()
+
+    return gp
+
+
+# ---------------------------------------------------------------------------
+# Invariant 1 — String-form binding uses the parameter key as the property name
+# ---------------------------------------------------------------------------
+
+class TestStringFormBinding:
+    """Invariant 1: 'element': '<name>' → property name == parameter key."""
+
+    def test_property_name_is_parameter_key(self, mocker):
+        config_params = {
+            "inference-interval": {
+                "element": "detection",
+                "type": "integer",
+                "default": 1,
+            }
+        }
+        request_params = {"inference-interval": 4}
+        gp = _make_pipeline(mocker, request_params, config_params)
+
+        mock_element = MagicMock()
+        mock_element.list_properties.return_value = [
+            MagicMock(name="inference-interval")
+        ]
+        gp.pipeline.get_by_name.side_effect = lambda name: (
+            mock_element if name == "detection" else None
+        )
+
+        gp._set_section_properties(["parameters"], ["parameters", "properties"])
+
+        mock_element.set_property.assert_called_once_with("inference-interval", 4)
+
+    def test_element_looked_up_by_string_value(self, mocker):
+        config_params = {
+            "threshold": {
+                "element": "classify",
+                "type": "number",
+            }
+        }
+        request_params = {"threshold": 0.8}
+        gp = _make_pipeline(mocker, request_params, config_params)
+
+        mock_element = MagicMock()
+        mock_element.list_properties.return_value = [MagicMock(name="threshold")]
+        gp.pipeline.get_by_name.side_effect = lambda name: (
+            mock_element if name == "classify" else None
+        )
+
+        gp._set_section_properties(["parameters"], ["parameters", "properties"])
+
+        gp.pipeline.get_by_name.assert_called_with("classify")
+
+
+# ---------------------------------------------------------------------------
+# Invariant 2 — Object-form binding uses the explicit 'property' field
+# ---------------------------------------------------------------------------
+
+class TestObjectFormBinding:
+    """Invariant 2: element.property overrides the parameter key."""
+
+    def test_explicit_property_name_used(self, mocker):
+        config_params = {
+            "interval": {
+                "element": {
+                    "name": "detection",
+                    "property": "inference-interval",
+                },
+                "type": "integer",
+                "default": 1,
+            }
+        }
+        request_params = {"interval": 2}
+        gp = _make_pipeline(mocker, request_params, config_params)
+
+        mock_element = MagicMock()
+        mock_element.list_properties.return_value = [
+            MagicMock(name="inference-interval")
+        ]
+        gp.pipeline.get_by_name.return_value = mock_element
+
+        gp._set_section_properties(["parameters"], ["parameters", "properties"])
+
+        mock_element.set_property.assert_called_once_with("inference-interval", 2)
+
+    def test_get_element_property_returns_name_and_property(self, mocker):
+        mocker.patch("gi.repository.Gst.init")
+        from src.server.gstreamer_pipeline import GStreamerPipeline
+
+        gp = GStreamerPipeline.__new__(GStreamerPipeline)
+        element_spec = {"name": "detection", "property": "inference-interval"}
+        result = gp._get_element_property(element_spec, "interval")
+        assert result == ("detection", "inference-interval", None)
+
+    def test_get_element_property_defaults_property_to_none_when_absent(self, mocker):
+        mocker.patch("gi.repository.Gst.init")
+        from src.server.gstreamer_pipeline import GStreamerPipeline
+
+        gp = GStreamerPipeline.__new__(GStreamerPipeline)
+        element_spec = {"name": "detection"}
+        result = gp._get_element_property(element_spec, "my-param")
+        assert result == ("detection", None, None)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 3 — Array-form binding applies to all listed elements
+# ---------------------------------------------------------------------------
+
+class TestArrayFormBinding:
+    """Invariant 3: array element → every listed element receives the value."""
+
+    def test_value_set_on_all_listed_elements(self, mocker):
+        config_params = {
+            "interval": {
+                "element": [
+                    {"name": "detection",     "property": "inference-interval"},
+                    {"name": "classification","property": "inference-interval"},
+                ],
+                "type": "integer",
+                "default": 1,
+            }
+        }
+        request_params = {"interval": 3}
+        gp = _make_pipeline(mocker, request_params, config_params)
+
+        mock_det = MagicMock()
+        mock_det.list_properties.return_value = [MagicMock(name="inference-interval")]
+        mock_cls = MagicMock()
+        mock_cls.list_properties.return_value = [MagicMock(name="inference-interval")]
+
+        def get_by_name(name):
+            return {"detection": mock_det, "classification": mock_cls}.get(name)
+
+        gp.pipeline.get_by_name.side_effect = get_by_name
+
+        gp._set_section_properties(["parameters"], ["parameters", "properties"])
+
+        mock_det.set_property.assert_called_once_with("inference-interval", 3)
+        mock_cls.set_property.assert_called_once_with("inference-interval", 3)
+
+    def test_array_with_three_elements(self, mocker):
+        config_params = {
+            "device": {
+                "element": [
+                    {"name": "a", "property": "device"},
+                    {"name": "b", "property": "device"},
+                    {"name": "c", "property": "device"},
+                ],
+                "type": "string",
+            }
+        }
+        request_params = {"device": "GPU"}
+        gp = _make_pipeline(mocker, request_params, config_params)
+
+        elements = {n: MagicMock() for n in ("a", "b", "c")}
+        for m in elements.values():
+            m.list_properties.return_value = [MagicMock(name="device")]
+        gp.pipeline.get_by_name.side_effect = lambda n: elements.get(n)
+
+        gp._set_section_properties(["parameters"], ["parameters", "properties"])
+
+        for name, mock_el in elements.items():
+            mock_el.set_property.assert_called_once_with("device", "GPU")
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 — format=element-properties fans out key/value pairs
+# ---------------------------------------------------------------------------
+
+class TestElementPropertiesFormat:
+    """Invariant 4: each key in the value dict becomes a separate set_property call."""
+
+    def test_each_key_value_applied_individually(self, mocker):
+        config_params = {
+            "source-properties": {
+                "type": "object",
+                "element": {
+                    "name": "source",
+                    "format": "element-properties",
+                },
+            }
+        }
+        request_params = {
+            "source-properties": {
+                "uri": "rtsp://camera/stream",
+                "latency": 100,
+            }
+        }
+        gp = _make_pipeline(mocker, request_params, config_params)
+
+        mock_source = MagicMock()
+        mock_source.list_properties.return_value = [
+            MagicMock(name="uri"),
+            MagicMock(name="latency"),
+        ]
+        gp.pipeline.get_by_name.return_value = mock_source
+
+        gp._set_section_properties(["parameters"], ["parameters", "properties"])
+
+        assert mock_source.set_property.call_count == 2
+        calls = {c.args[0]: c.args[1] for c in mock_source.set_property.call_args_list}
+        assert calls["uri"] == "rtsp://camera/stream"
+        assert calls["latency"] == 100
+
+    def test_single_key_in_element_properties_value(self, mocker):
+        config_params = {
+            "props": {
+                "type": "object",
+                "element": {"name": "detect", "format": "element-properties"},
+            }
+        }
+        request_params = {"props": {"threshold": 0.5}}
+        gp = _make_pipeline(mocker, request_params, config_params)
+
+        mock_el = MagicMock()
+        mock_el.list_properties.return_value = [MagicMock(name="threshold")]
+        gp.pipeline.get_by_name.return_value = mock_el
+
+        gp._set_section_properties(["parameters"], ["parameters", "properties"])
+
+        mock_el.set_property.assert_called_once_with("threshold", 0.5)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5 — format=json serializes value before set_property
+# ---------------------------------------------------------------------------
+
+class TestJsonFormat:
+    """Invariant 5: format=json → json.dumps applied before set_property."""
+
+    def test_dict_value_is_json_serialized(self, mocker):
+        mocker.patch("gi.repository.Gst.init")
+        from src.server.gstreamer_pipeline import GStreamerPipeline
+
+        gp = GStreamerPipeline.__new__(GStreamerPipeline)
+        gp._logger = MagicMock()
+        gp._unset_properties = []
+
+        mock_element = MagicMock()
+        prop_name = MagicMock(name="tags")
+        mock_element.list_properties.return_value = [prop_name]
+
+        gp._set_element_property(
+            mock_element, "tags", {"location": "building-1"}, format_type="json"
+        )
+
+        expected = json.dumps({"location": "building-1"})
+        mock_element.set_property.assert_called_once_with("tags", expected)
+
+    def test_list_value_is_json_serialized(self, mocker):
+        mocker.patch("gi.repository.Gst.init")
+        from src.server.gstreamer_pipeline import GStreamerPipeline
+
+        gp = GStreamerPipeline.__new__(GStreamerPipeline)
+        gp._logger = MagicMock()
+        gp._unset_properties = []
+
+        mock_element = MagicMock()
+        prop_name = MagicMock(name="labels")
+        mock_element.list_properties.return_value = [prop_name]
+
+        gp._set_element_property(
+            mock_element, "labels", ["cat", "dog"], format_type="json"
+        )
+
+        mock_element.set_property.assert_called_once_with("labels", '["cat", "dog"]')
+
+    def test_no_format_passes_value_directly(self, mocker):
+        mocker.patch("gi.repository.Gst.init")
+        from src.server.gstreamer_pipeline import GStreamerPipeline
+
+        gp = GStreamerPipeline.__new__(GStreamerPipeline)
+        gp._logger = MagicMock()
+        gp._unset_properties = []
+
+        mock_element = MagicMock()
+        prop_name = MagicMock(name="threshold")
+        mock_element.list_properties.return_value = [prop_name]
+
+        gp._set_element_property(mock_element, "threshold", 0.75)
+
+        mock_element.set_property.assert_called_once_with("threshold", 0.75)
+
+
+# ---------------------------------------------------------------------------
+# Invariant 6 — Unresolved element name: logged, no exception raised
+# ---------------------------------------------------------------------------
+
+class TestUnresolvedElementBehavior:
+    """Invariant 6: missing element → DEBUG log, no exception, pipeline continues."""
+
+    def test_unresolved_element_does_not_raise(self, mocker):
+        config_params = {
+            "inference-interval": {
+                "element": "nonexistent",
+                "type": "integer",
+                "default": 1,
+            }
+        }
+        request_params = {"inference-interval": 1}
+        gp = _make_pipeline(mocker, request_params, config_params)
+        gp.pipeline.get_by_name.return_value = None  # element not in pipeline
+
+        # Must not raise.
+        gp._set_section_properties(["parameters"], ["parameters", "properties"])
+
+    def test_unresolved_element_emits_debug_log(self, mocker):
+        config_params = {
+            "threshold": {
+                "element": "ghost-element",
+                "type": "number",
+            }
+        }
+        request_params = {"threshold": 0.5}
+        gp = _make_pipeline(mocker, request_params, config_params)
+        gp.pipeline.get_by_name.return_value = None
+
+        gp._set_section_properties(["parameters"], ["parameters", "properties"])
+
+        gp._logger.debug.assert_called()
+
+    def test_unresolved_property_does_not_raise(self, mocker):
+        """Element exists but property is not in its list → log, no raise."""
+        mocker.patch("gi.repository.Gst.init")
+        from src.server.gstreamer_pipeline import GStreamerPipeline
+
+        gp = GStreamerPipeline.__new__(GStreamerPipeline)
+        gp._logger = MagicMock()
+        gp._unset_properties = []
+
+        mock_element = MagicMock()
+        mock_element.list_properties.return_value = []  # property not present
+
+        # Must not raise.
+        gp._set_element_property(mock_element, "unknown-prop", 42)
+
+        mock_element.set_property.assert_not_called()
+        assert len(gp._unset_properties) == 1
+
+    def test_unresolved_property_appended_to_unset_list(self, mocker):
+        mocker.patch("gi.repository.Gst.init")
+        from src.server.gstreamer_pipeline import GStreamerPipeline
+
+        gp = GStreamerPipeline.__new__(GStreamerPipeline)
+        gp._logger = MagicMock()
+        gp._unset_properties = []
+
+        mock_element = MagicMock()
+        mock_element.__gtype__ = MagicMock()
+        mock_element.__gtype__.name = "GstFakeDetect"
+        mock_element.list_properties.return_value = []
+
+        gp._set_element_property(mock_element, "no-such-prop", "value")
+
+        assert gp._unset_properties == [["GstFakeDetect", "no-such-prop", "value"]]

--- a/microservices/dlstreamer-pipeline-server/utils/generate_contract.py
+++ b/microservices/dlstreamer-pipeline-server/utils/generate_contract.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+#
+# Apache v2 license
+# Copyright (C) 2024-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Generate contract.json from source schema and version information.
+
+Reads:
+  - document-versions.yaml  (contract-version)
+  - src/server/schema.py    (reserved element names, supported formats)
+
+Writes:
+  - contract.json at the service root
+
+Run from the service root:
+    python3 utils/generate_contract.py
+
+CI usage (fail if committed file is stale):
+    python3 utils/generate_contract.py --check
+"""
+
+import argparse
+import ast
+import json
+import os
+import sys
+
+
+SERVICE_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+VERSIONS_FILE = os.path.join(SERVICE_ROOT, "document-versions.yaml")
+SCHEMA_FILE = os.path.join(SERVICE_ROOT, "src", "server", "schema.py")
+OUTPUT_FILE = os.path.join(SERVICE_ROOT, "contract.json")
+
+
+def read_version(versions_path: str) -> str:
+    """Parse the version string from document-versions.yaml.
+
+    The file has a single line of the form:
+        release/vX.Y.Z:X.Y.Z
+    """
+    with open(versions_path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                # Format: release/vX.Y.Z:X.Y.Z  — take the part after the colon.
+                parts = line.split(":")
+                if len(parts) >= 2:
+                    return parts[-1].strip()
+                return line
+    raise ValueError(f"Could not parse version from {versions_path}")
+
+
+def extract_reserved_element_names(schema_path: str) -> list:
+    """Walk the schema.py AST to collect string values assigned to 'name'
+    keys inside dicts that are themselves the value of an 'element' key.
+    This restricts extraction to GStreamer element bindings and excludes
+    names from 'filter' or other non-element dicts.
+
+    Returns a sorted, deduplicated list.
+    """
+    with open(schema_path, encoding="utf-8") as fh:
+        source = fh.read()
+
+    tree = ast.parse(source, filename=schema_path)
+    names = set()
+
+    def collect_names_from_element_value(node):
+        """Recursively collect 'name' string values from an element value node.
+
+        The node may be a dict (object form), a list of dicts (array form),
+        or a string constant (string form — the whole value is the element name).
+        """
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            names.add(node.value)
+        elif isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if (
+                    isinstance(key, ast.Constant)
+                    and key.value == "name"
+                    and isinstance(value, ast.Constant)
+                    and isinstance(value.value, str)
+                ):
+                    names.add(value.value)
+        elif isinstance(node, ast.List):
+            for elt in node.elts:
+                collect_names_from_element_value(elt)
+
+    class ElementVisitor(ast.NodeVisitor):
+        def visit_Dict(self, node):  # noqa: N802
+            for key, value in zip(node.keys, node.values):
+                if isinstance(key, ast.Constant) and key.value == "element":
+                    collect_names_from_element_value(value)
+            self.generic_visit(node)
+
+    ElementVisitor().visit(tree)
+
+    # Always include the well-known reserved names even if schema.py is refactored.
+    names.update({"source", "destination", "appsink", "metaconvert"})
+    return sorted(names)
+
+
+def build_contract(version: str, reserved_names: list) -> dict:
+    return {
+        "contract-version": version,
+        "element-binding-forms": ["string", "object", "array"],
+        "supported-formats": ["element-properties", "json"],
+        "reserved-element-names": reserved_names,
+        "unresolved-element-behavior": "log-and-continue",
+        "unresolved-property-behavior": "log-and-continue",
+        "normative-reference": (
+            "docs/user-guide/advanced-guide/detailed_usage/"
+            "rest_api/parameter_contract.md"
+        ),
+        "conformance-tests": "tests/test_parameter_contract.py",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit with code 1 if the committed contract.json is stale.",
+    )
+    args = parser.parse_args()
+
+    version = read_version(VERSIONS_FILE)
+    reserved_names = extract_reserved_element_names(SCHEMA_FILE)
+    contract = build_contract(version, reserved_names)
+    generated = json.dumps(contract, indent=2) + "\n"
+
+    if args.check:
+        if not os.path.exists(OUTPUT_FILE):
+            print(f"ERROR: {OUTPUT_FILE} does not exist. Run generate_contract.py to create it.")
+            sys.exit(1)
+        with open(OUTPUT_FILE, encoding="utf-8") as fh:
+            committed = fh.read()
+        if committed != generated:
+            print(
+                f"ERROR: {OUTPUT_FILE} is stale.\n"
+                "Run  python3 utils/generate_contract.py  and commit the result."
+            )
+            sys.exit(1)
+        print(f"OK: {OUTPUT_FILE} is up to date (contract-version={version})")
+        sys.exit(0)
+
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as fh:
+        fh.write(generated)
+    print(f"Written {OUTPUT_FILE} (contract-version={version})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add AGENTS.md at service root: discoverable entry point for agents and external integrators arriving via URL; covers all three element binding forms, both format values, unresolved-property behavior, reserved element names, and cross-links to all contract artifacts.

- Add docs/user-guide/advanced-guide/detailed_usage/rest_api/parameter_contract.md: normative prose reference with contract-version 3.0.0 in YAML front matter; documents string/object/array element binding, element-properties and json formats, unresolved-property behavior, reserved names, downstream adapter responsibilities, and stability guarantees.

- Add contract.json at service root: machine-readable artifact at a stable repo-relative URL; contains contract-version, element-binding-forms, supported-formats, reserved-element-names, and behavior policies.

- Add utils/generate_contract.py: derives contract.json from schema.py and document-versions.yaml; --check mode exits non-zero if committed file is stale.

- Add tests/test_parameter_contract.py: 14 conformance tests covering all six contract invariants (string-form binding, object-form binding, array-form binding, format=element-properties fan-out, format=json serialization, unresolved-element log-and-continue); no SceneScape-specific dependencies.

- Add docs/user-guide/release-notes/contract-migration-template.md: template for contract-breaking releases with sections for changed behavior, removed parameters, new required fields, upgrade steps, and verification checklist.

- Update Makefile: add check-contract and generate-contract targets.

- Update plan.md: rewritten to reflect concrete file-level deliverables, CI staleness check requirement, and AGENTS.md as a required artifact.


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

