### PR TITLE
time-series-analytics: Changed the python-multipart version

### DIFF
--- a/microservices/time-series-analytics/requirements.txt
+++ b/microservices/time-series-analytics/requirements.txt
@@ -7,6 +7,6 @@ influxdb==5.3.2
 tomlkit==0.14.0
 protobuf==7.34.0
 dpctl==0.21.1
-python-multipart==0.0.27
+python-multipart==0.0.32
 setuptools==82.0.1
 packaging==26.0

--- a/microservices/time-series-analytics/third-party-programs.txt
+++ b/microservices/time-series-analytics/third-party-programs.txt
@@ -28,7 +28,7 @@ License-Identifier: MIT License
 License-Identifier: Apache License 2.0
 dpctl==0.21.1
 pyOpenSSL==26.2.0
-python-multipart==0.0.27
+python-multipart==0.0.32
 scikit-learn-intelex==2025.11.0
 sortedcontainers==2.4.0
 aiofiles==25.1.0


### PR DESCRIPTION



### Description

Chnages:
1. In requirements.txt: python-multipart version from 0.0.27 to 0.0.32

Fixes # (issue)

### Any Newly Introduced Dependencies

NO

### How Has This Been Tested?

YES

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

