### PR TITLE
[ViPPET] Fix clean target

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
@@ -140,11 +140,14 @@ shell-videogenerator: ## Open shell in videogenerator container
 stop: ## Stop the docker compose services
 	docker compose down model-download metrics-manager videogenerator mediamtx vippet-ui vippet onvif-discovery
 
-clean: clean-model-download clean-output-videos ## Clean all build artifacts
-	rm -rf shared/models/output/ shared/onvif/onvif_cameras.json shared/videos/input shared/videos/video-generator
+clean: clean-model-download clean-models clean-output-videos ## Clean all build artifacts
+	rm -rf shared/onvif/onvif_cameras.json shared/videos/input shared/videos/video-generator
 
 clean-model-download: ## Clean only model-download artifacts
 	docker run --rm -v "${PWD}"/shared/model-download/:/mnt/model-download/ python:3.12-slim sh -c 'rm -rf /mnt/model-download/cache/ /mnt/model-download/venv-*/'
+
+clean-models: ## Clean only models
+	docker run --rm -v "${PWD}"/shared/models/:/mnt/models/ python:3.12-slim sh -c 'rm -rf /mnt/models/output/'
 
 clean-output-videos: ## Clean only output videos
 	rm -rf shared/videos/output/*

--- a/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
@@ -144,8 +144,7 @@ clean: clean-model-download clean-output-videos ## Clean all build artifacts
 	rm -rf shared/models/output/ shared/onvif/onvif_cameras.json shared/videos/input shared/videos/video-generator
 
 clean-model-download: ## Clean only model-download artifacts
-	docker run --rm -v shared/model-download/:/mnt/model-download/ python:3.12-slim sh -c 'rm -r /mnt/model-download/cache/ /mnt/model-download/venv-*/'
-	rm -r shared/model-download/
+	docker run --rm -v "${PWD}"/shared/model-download/:/mnt/model-download/ python:3.12-slim sh -c 'rm -rf /mnt/model-download/cache/ /mnt/model-download/venv-*/'
 
 clean-output-videos: ## Clean only output videos
 	rm -rf shared/videos/output/*


### PR DESCRIPTION
- Use absolute host path in `clean-model-download` target to fix below issue when cleaning model-download artifacts.

  ```
  $ make clean-model-download
  docker run --rm -v shared/model-download/:/mnt/model-download/ python:3.12-slim sh -c 'rm -r /mnt/model-download/cache/ /mnt/model-download/venv-*/'
  docker: Error response from daemon: create shared/model-download/: "shared/model-download/" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path

  Run 'docker run --help' for more information
  make: *** [Makefile:147: clean-model-download] Error 125
  ```

  Fixes #2314

- Add `-f` flag to `rm` command in `clean-model-download` target to remove empty directories without error.

  Fixes #2314

- Prevent `model-download` directory from being removed in `clean-model-download` target.

  Fixes #2314

- Add `clean-models` target to workaround permission denied issue when cleaning models.