### PR TITLE
[ViPPET] Install qmassa from GitHub tag instead of crates.io (2025.2)

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
@@ -26,8 +26,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install qmassa
-RUN cargo install --locked qmassa@1.1.0
+# Install qmassa directly from its GitHub repository by tag instead of from
+# crates.io. This avoids build failures if the pinned crates.io version is
+# ever yanked from the registry by the upstream maintainer.
+RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag v1.1.0
 
 # Final image for the collector
 FROM docker.io/library/telegraf:1.36.3 AS collector


### PR DESCRIPTION
## Summary
Switch the `qmassa` installation in the collector Dockerfile from a crates.io install to a git-tag install from the upstream GitHub repository.
The pinned version (`v1.1.0`) and the `--locked` flag are kept, so the build stays fully reproducible.
## Change
**Before:**
```dockerfile
RUN cargo install --locked qmassa@1.1.0
```
**After:**
```dockerfile
RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag v1.1.0
```
## Why this change
A crate published on crates.io can be *yanked* by its maintainer at any time.
A yanked version is not deleted, but `cargo` refuses to install it for new builds, which breaks every `cargo install` that pins that exact version.
This has already happened to the `qmassa` version used here and required manual intervention from the upstream maintainer to recover.
Installing directly from the GitHub repository by tag is not subject to the yanking mechanism: as long as the git tag exists in the repository, the build will succeed.
This makes the collector image build resilient to future yanks and removes an external single point of failure from our build process, without changing the installed `qmassa` version or its behavior at runtime.
