### PR TITLE
[ViPPET] Make build-from-source work on release-1.2.0 (docs + qmassa pin)

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
@@ -6,7 +6,11 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN cargo install --locked qmassa
+# Install qmassa directly from its GitHub repository by tag instead of from
+# crates.io. The version is pinned so the build keeps working on this image's
+# Rust toolchain (rust:1.87); installing from a git tag also avoids build
+# failures if a crates.io version is ever yanked by the upstream maintainer.
+RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag v1.0.0
 
 FROM docker.io/library/telegraf:1.35.3 AS collector
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/how-to-build-source.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/how-to-build-source.md
@@ -25,7 +25,7 @@ This guide assumes basic familiarity with Git commands, Python virtual environme
 1. **Clone the Repository**:
    - Run:
      ```bash
-     git clone https://github.com/open-edge-platform/edge-ai-libraries.git
+     git clone https://github.com/open-edge-platform/edge-ai-libraries.git -b release-1.2.0
      cd ./edge-ai-libraries/tools/visual-pipeline-and-platform-evaluation-tool
      ```
 


### PR DESCRIPTION
## Summary
Fix the build-from-source flow on the `release-1.2.0` branch.
Two small changes are needed for users to actually be able to build and run this release from source by following the documentation.
## Changes
### 1. Docs: clone the correct release branch
`docs/user-guide/how-to-build-source.md` instructed the user to clone the repository without specifying a branch, which leaves the user on `main`.
A user following the docs would therefore build the development version of the code instead of the released version they intended to install.
**Before:**
```bash
git clone https://github.com/open-edge-platform/edge-ai-libraries.git
```
**After:**
```bash
git clone https://github.com/open-edge-platform/edge-ai-libraries.git -b release-1.2.0
```
### 2. Collector Dockerfile: pin `qmassa` and install it from a git tag
`collector/Dockerfile` installed `qmassa` from crates.io without pinning a version, on top of a `rust:1.87` base image.
Because no version was specified, the build pulled the latest `qmassa`, which now requires Rust >= 1.88 and therefore fails to compile on `rust:1.87`.
This means the collector image could not be built at all from this branch anymore.
**Before:**
```dockerfile
RUN cargo install --locked qmassa
```
**After:**
```dockerfile
RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag v1.0.0
```
`v1.0.0` is a `qmassa` version that compiles on the `rust:1.87` toolchain used by this image, so the build is restored without touching the base image.
## Why install from a git tag instead of crates.io
A crate published on crates.io can be *yanked* by its maintainer at any time.
A yanked version is not deleted, but `cargo` refuses to install it for new builds, which breaks every `cargo install` that pins that exact version.
Installing directly from the GitHub repository by tag is not subject to the yanking mechanism: as long as the git tag exists in the repository, the build will succeed.
This makes the collector image build resilient to future yanks and removes an external single point of failure from our build process.