### PR TITLE
[ViPPET] Restore full install on release-2026.0.0 (docs + qmassa + PDD model)

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/collector/Dockerfile
@@ -26,8 +26,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install qmassa
-RUN cargo install --locked qmassa@1.2.1
+# Install qmassa directly from its GitHub repository by tag instead of from
+# crates.io. This avoids build failures if the pinned crates.io version is
+# ever yanked from the registry by the upstream maintainer.
+RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag v1.2.1
 
 # Final image for the collector
 FROM docker.io/library/telegraf:1.38.1 AS collector

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/build-from-source.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/build-from-source.md
@@ -31,7 +31,7 @@ This guide assumes basic familiarity with Git commands and terminal usage. For m
 1. **Clone the repository**:
 
    ```bash
-   git clone https://github.com/open-edge-platform/edge-ai-libraries.git
+   git clone https://github.com/open-edge-platform/edge-ai-libraries.git -b release-2026.0.0
    cd ./edge-ai-libraries/tools/visual-pipeline-and-platform-evaluation-tool
    ```
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/models/model_manager.sh
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/models/model_manager.sh
@@ -82,7 +82,31 @@ function cleanup_and_exit {
 download_public_models() {
     local models="$1"
     echo "Installing public models: $models"
-    if ! bash /opt/intel/dlstreamer/samples/download_public_models.sh "$models" "${QUANTIZE_DATASET}"; then
+
+    # Workaround for the Pallet Defect Detection (PDD) model.
+    #
+    # The upstream DLStreamer script `download_public_models.sh` fetches the
+    # PDD archive from the `main` branch of the `edge-ai-resources` repository.
+    # The archive layout on `main` was changed and is no longer compatible with
+    # the unzip/move logic in this version of the DLStreamer script, which
+    # makes the PDD download fail.
+    #
+    # As a workaround we pin the PDD archive URL to the last commit in
+    # `edge-ai-resources` whose layout is still compatible with this script.
+    # We do this on a writable copy of the script (the original location
+    # under /opt is treated as read-only) and run the patched copy.
+    local upstream_script="/opt/intel/dlstreamer/samples/download_public_models.sh"
+    local patched_script="$MODEL_MANAGER_TMP_DIR/download_public_models.sh"
+    local pdd_pinned_commit="06bb0d621cb14a1791672552a538beddddcc4066"
+
+    mkdir -p "$MODEL_MANAGER_TMP_DIR"
+    cp "$upstream_script" "$patched_script"
+    sed -i \
+        -e "s|edge-ai-resources/raw/main/models/INT8/pallet_defect_detection.zip|edge-ai-resources/raw/${pdd_pinned_commit}/models/INT8/pallet_defect_detection.zip|g" \
+        -e "s|raw.githubusercontent.com/open-edge-platform/edge-ai-resources/main/models/INT8/pallet_defect_detection.zip|raw.githubusercontent.com/open-edge-platform/edge-ai-resources/${pdd_pinned_commit}/models/INT8/pallet_defect_detection.zip|g" \
+        "$patched_script"
+
+    if ! bash "$patched_script" "$models" "${QUANTIZE_DATASET}"; then
         echo "Error: Failed to download public models: $models"
         cleanup_and_exit 14
     fi


### PR DESCRIPTION

## Summary
Fix the install flow on the `release-2026.0.0` branch.
Three small changes are needed for users to actually be able to install and run this release end-to-end by following the documentation.
## Changes
### 1. Docs: clone the correct release branch
`docs/user-guide/get-started/build-from-source.md` instructed the user to clone the repository without specifying a branch, which leaves the user on `main`.
A user following the docs would therefore build the development version of the code instead of the released version they intended to install.
**Before:**
```bash
git clone https://github.com/open-edge-platform/edge-ai-libraries.git
```
**After:**
```bash
git clone https://github.com/open-edge-platform/edge-ai-libraries.git -b release-2026.0.0
```
### 2. Collector Dockerfile: install `qmassa` from a git tag
`collector/Dockerfile` installed `qmassa` from crates.io with a pinned version.
A crate published on crates.io can be *yanked* by its maintainer at any time, in which case `cargo` refuses to install that version and every `cargo install` pinning it stops working.
Installing the same pinned version directly from the upstream GitHub repository by tag is not subject to the yanking mechanism, so the build keeps working as long as the git tag exists.
**Before:**
```dockerfile
RUN cargo install --locked qmassa@1.2.1
```
**After:**
```dockerfile
RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag v1.2.1
```
The installed `qmassa` version and its runtime behavior do not change.
### 3. Model manager: fix download of the Pallet Defect Detection (PDD) model
The PDD model is downloaded by the DLStreamer helper script `download_public_models.sh` (shipped inside the model-manager base image) from the `main` branch of the `edge-ai-resources` repository.
The archive layout on `main` was later changed and is no longer compatible with the unzip/move logic in this version of the DLStreamer script, which makes the PDD download fail.
Because PDD is one of the default-selected models in `supported_models.yaml`, a regular user who does not change the model selection will hit this failure and the install of the model manager will not complete.
The fix is applied entirely in our own `models/model_manager.sh`, so it covers both installation methods (Quick Deploy with prebuilt images and Build from Source), because in both cases this script is fetched from the release branch and mounted into the model-manager container at runtime.
What we do:
1. Copy the DLStreamer script from the read-only image location to a writable temporary directory.
2. Patch the PDD archive URL in the copy with `sed`, pinning it from `edge-ai-resources/.../main/...` to the last commit whose archive layout is still compatible with this version of the DLStreamer script (`b943adcf240e22c5c2942a59909982ee2f103f92`).
3. Run the patched copy instead of the original.
Nothing else in the DLStreamer script is modified, so the behavior for the other 19 public models is unchanged.
The pinned commit URL keeps working as long as that commit exists in the `edge-ai-resources` repository, which is a stronger guarantee than relying on a moving `main` branch.
This workaround can be removed in a future release as soon as the model-manager base image switches to a DLStreamer version that contains the upstream PDD download fix.
