### PR TITLE
[metrics-manager] Install qmassa and qmmd from GitHub tags instead of crates.io

### DIFF
--- a/microservices/metrics-manager/Dockerfile
+++ b/microservices/metrics-manager/Dockerfile
@@ -53,8 +53,17 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN cargo install --locked qmassa@2.1.0
-RUN cargo install --locked qmmd@0.2.0
+# Install qmassa and qmmd directly from their upstream GitHub repository by
+# tag instead of from crates.io. qmassa and qmmd live in the same Cargo
+# workspace (https://github.com/ulissesf/qmassa) but are tagged independently
+# (`qmassa-vX.Y.Z`, `qmmd-vX.Y.Z`), so each binary is installed with its own
+# per-binary tag. `--bin` limits each install to the matching binary so the
+# other workspace member is not rebuilt unnecessarily.
+# The --locked flag is kept, so the build stays fully reproducible. This
+# avoids build failures if a pinned crates.io version is ever yanked from
+# the registry by the upstream maintainer.
+RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag qmmd-v0.2.0 qmmd
+RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag qmassa-v2.1.0 qmassa
 
 # -----------------------------------------------------------------------------
 # Stage 2: Build Telegraf from source with patched dependencies


### PR DESCRIPTION
## Summary
Switch the `qmassa` and `qmmd` installs in the `metrics-manager` Dockerfile from crates.io installs to git-tag installs from the upstream GitHub repository.
The upstream tags binaries independently (`qmassa-vX.Y.Z`, `qmmd-vX.Y.Z`), so each binary is installed with its own per-binary tag.
The `--locked` flag is kept, so the build stays fully reproducible.
## Change
**Before:**
```dockerfile
RUN cargo install --locked qmassa@2.1.0
RUN cargo install --locked qmmd@0.2.0
```
**After:**
```dockerfile
RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag qmmd-v0.2.0 qmmd
RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag qmassa-v2.1.0 qmassa
```
## Why this change
A crate published on crates.io can be *yanked* by its maintainer at any time.
A yanked version is not deleted, but `cargo` refuses to install it for new builds, which breaks every `cargo install` that pins that exact version.
This has already happened for `qmassa` in the past and required manual intervention from the upstream maintainer to recover.
Installing directly from the GitHub repository by tag is not subject to the yanking mechanism: as long as the git tag exists in the repository, the build will succeed.
This makes the `metrics-manager` image build resilient to future yanks and removes an external single point of failure from our build process, without changing the installed binaries or their runtime behavior.
