### PR TITLE
[metrics-manager] Install qmassa and qmmd from GitHub tags instead of crates.io (release-2026.1.0)

### DIFF
--- a/microservices/metrics-manager/Dockerfile
+++ b/microservices/metrics-manager/Dockerfile
@@ -52,8 +52,18 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN cargo install --locked qmassa@1.3.1
-RUN cargo install --locked qmmd@0.1.1
+# Install qmassa and qmmd directly from their upstream GitHub repository by
+# tag instead of from crates.io. Both binaries live in the same Cargo
+# workspace (https://github.com/ulissesf/qmassa) but are tagged independently
+# in the upstream repo (`v1.3.1` for qmassa is the older single-workspace tag
+# scheme, `qmmd-v0.1.1` is the newer per-binary scheme), so each binary is
+# installed with its own tag and the package name is passed positionally so
+# only that workspace member is built.
+# The --locked flag is kept, so the build stays fully reproducible. This
+# avoids build failures if a pinned crates.io version is ever yanked from
+# the registry by the upstream maintainer.
+RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag qmmd-v0.1.1 qmmd
+RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag v1.3.1 qmassa
 
 # -----------------------------------------------------------------------------
 # Stage 2: Build Python dependencies


### PR DESCRIPTION
## Summary
Switch the `qmassa` and `qmmd` installs in the `metrics-manager` Dockerfile from crates.io installs to git-tag installs from the upstream GitHub repository.
Both binaries live in the same Cargo workspace but are tagged independently in the upstream repo, so each binary is installed with its own tag.
The package name is passed positionally so only that workspace member is built.
The `--locked` flag is kept, so the build stays fully reproducible.
## Change
**Before:**
```dockerfile
RUN cargo install --locked qmassa@1.3.1
RUN cargo install --locked qmmd@0.1.1
```
**After:**
```dockerfile
RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag qmmd-v0.1.1 qmmd
RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag v1.3.1 qmassa
```
The `qmassa` tag (`v1.3.1`) follows the older single-workspace tag scheme used by the upstream repository at the time of that release; the `qmmd` tag (`qmmd-v0.1.1`) follows the newer per-binary scheme.
Both refer to the same upstream repository.
## Why this change
A crate published on crates.io can be *yanked* by its maintainer at any time.
A yanked version is not deleted, but `cargo` refuses to install it for new builds, which breaks every `cargo install` that pins that exact version.
This has already happened for `qmassa` in the past and required manual intervention from the upstream maintainer to recover.
Installing directly from the GitHub repository by tag is not subject to the yanking mechanism: as long as the git tag exists in the repository, the build will succeed.
This makes the `metrics-manager` image build resilient to future yanks and removes an external single point of failure from our build process, without changing the installed binaries or their runtime behavior.
