### PR TITLE
[ViPPET] Automatically strip `gvawatermark` when no rendered video output is needed

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/developer-guide/architecture/vippet-be.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/developer-guide/architecture/vippet-be.md
@@ -98,6 +98,31 @@ simplified view (`pipeline_graph_simple`) used by the visual editor. `vippet/gra
 GStreamer description and the graph form, and applies the `SIMPLE_VIEW_VISIBLE_ELEMENTS` /
 `SIMPLE_VIEW_INVISIBLE_ELEMENTS` filtering rules that decide which elements appear in the simplified canvas.
 
+### Automatic Graph Transformations
+
+`PipelineManager.build_pipeline_command()` does not run the variant graph as-is. For every stream it
+applies a small set of deterministic transformations defined in `vippet/graph.py`, so the same graph can
+be reused across different output modes without changes to the YAML or the saved user definition:
+
+- **Intermediate sink rewriting** (`prepare_intermediate_output_sinks`) — gives every non-fakesink
+  terminal a unique, stream-scoped file location under the job output directory.
+- **Main output placeholder** (`prepare_main_output_placeholder`) — when `output_mode` is `file` or
+  `live_stream`, the default `fakesink name=default_output_sink` is converted to an
+  `OUTPUT_PLACEHOLDER` node. It is replaced later by the encoder + filesink (for `file`) or by the
+  encoder + rtspclientsink (for `live_stream`) subpipeline built by `video_encoder`.
+- **Metadata file injection** (`inject_metadata_file_paths`) — when `metadata_mode=file`, every
+  `gvametapublish` node gets a unique file path under the job metadata directory.
+- **Automatic `gvawatermark` stripping** (`strip_watermark_if_all_sinks_are_fake`) — removes every
+  `gvawatermark` node when the only terminals left are fakesinks, i.e. there is no rendered video
+  output that would consume the overlay. The watermark is preserved whenever an `OUTPUT_PLACEHOLDER`
+  is present (`output_mode=file` or `live_stream`) or any non-fakesink terminal exists in the graph
+  (for example a `splitmuxsink` in NVR-style pipelines that records the stream itself). This keeps
+  the default `output_mode=disabled` measurement free of the overlay-rendering cost without
+  affecting live view, file output, or pipelines that persist the video.
+- **Unique element names and source/sink identifiers** (`unify_all_element_names`,
+  `apply_stream_identifiers`) — assigns deterministic, stream-unique names to every element so the
+  latency tracer can correlate its rows back to a specific source/sink pair.
+
 ### Job and Metrics Flow
 
 Tests, optimization runs, and validation runs are tracked as jobs. Each job has a status (`PENDING`,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
@@ -1077,26 +1077,38 @@ class Graph:
 
     def strip_watermark_if_all_sinks_are_fake(self) -> "Graph":
         """
-        Remove all gvawatermark nodes if every sink in the graph is a fakesink.
+        Remove all gvawatermark nodes when every sink in the graph is a fakesink.
 
-        If the graph contains at least one OUTPUT_PLACEHOLDER node, it means
-        non-fakesink outputs will be added later, so the graph is returned
-        unchanged.
+        This is an opt-in optimization for execution paths that do not need
+        a rendered video output. When the only sinks present are fakesink
+        elements, no overlay is ever consumed, so the gvawatermark elements
+        only add CPU/GPU cost without any visible effect.
 
-        When all sink nodes (nodes whose type ends with "sink") are fakesink,
-        gvawatermark elements serve no purpose because there is no real video
-        output to render overlays on. Removing them avoids unnecessary
-        processing overhead.
-
-        For each removed gvawatermark node, incoming and outgoing edges are
-        reconnected so that the predecessor connects directly to the successor.
+        Behavior:
+            - If any node is an OUTPUT_PLACEHOLDER, the graph is returned
+              unchanged. The placeholder marks the spot where a real video
+              sink (filesink for output_mode=file, rtspclientsink for
+              output_mode=live_stream) will be injected later by
+              PipelineManager, so the watermark must be kept.
+            - If there are no sink nodes at all, the graph is returned
+              unchanged.
+            - If at least one sink is NOT a fakesink (for example
+              splitmuxsink used as an intermediate recorder in NVR-style
+              pipelines), the graph is returned unchanged. Pipelines that
+              persist or display the stream are expected to keep the
+              overlay.
+            - Otherwise, every gvawatermark node is removed and its
+              incoming and outgoing edges are reconnected so each
+              predecessor is wired directly to each successor (fan-in and
+              fan-out preserved).
 
         Returns:
-            Graph: New Graph instance with gvawatermark nodes removed, or self
-                if conditions are not met.
+            Graph: New Graph instance with gvawatermark nodes removed, or
+                self when the conditions above are not met.
 
         Note:
-            This creates a deep copy of the graph to avoid modifying the original.
+            When a modification is needed a deep copy of the graph is
+            created, so the original instance is never mutated.
         """
         # Early exit: if any OUTPUT_PLACEHOLDER exists, real sinks will be
         # added later, so keep gvawatermark nodes intact.
@@ -1131,6 +1143,18 @@ class Graph:
 
         modified_graph = copy.deepcopy(self)
 
+        # Compute the next available edge ID once, before the removal loop.
+        # New reconnection edges keep counting from this value, which keeps
+        # IDs unique across the whole operation and avoids an O(N*E) rescan
+        # inside the per-watermark loop.
+        max_edge_id = 0
+        for e in modified_graph.edges:
+            try:
+                max_edge_id = max(max_edge_id, int(e.id))
+            except ValueError:
+                pass
+        next_edge_id = max_edge_id + 1
+
         for wm_id in watermark_ids:
             # Find incoming edges (edges targeting this watermark node)
             incoming_edges = [e for e in modified_graph.edges if e.target == wm_id]
@@ -1150,15 +1174,6 @@ class Graph:
             ]
 
             # Reconnect: create edges from each source to each target
-            # Find max edge ID for generating new unique IDs
-            max_edge_id = 0
-            for e in modified_graph.edges:
-                try:
-                    max_edge_id = max(max_edge_id, int(e.id))
-                except ValueError:
-                    pass
-
-            next_edge_id = max_edge_id + 1
 
             for src in source_ids:
                 for tgt in target_ids:

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/pipeline_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/pipeline_manager.py
@@ -688,7 +688,19 @@ class PipelineManager:
                     if paths:
                         metadata_file_paths[pipeline_id] = paths
 
-                # Remove gvawatermark nodes when all sinks are fakesink (no real video output)
+                # Drop gvawatermark elements when the pipeline has no real
+                # video output to render onto. This is decided per stream
+                # by Graph.strip_watermark_if_all_sinks_are_fake():
+                #   * output_mode=disabled and the pipeline only has
+                #     fakesink terminals -> gvawatermark is stripped to
+                #     save the overlay rendering cost.
+                #   * output_mode=file or live_stream installs an
+                #     OUTPUT_PLACEHOLDER above, so the call is a no-op and
+                #     the overlay is kept (the user will see it).
+                #   * Pipelines with intermediate non-fakesink terminals
+                #     (e.g. splitmuxsink in NVR-style pipelines) keep
+                #     gvawatermark, because the recorded file is itself a
+                #     visible output for the user.
                 graph_instance = graph_instance.strip_watermark_if_all_sinks_are_fake()
 
                 # Assign explicit, unique element names to the main-branch

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_watermark_optimization.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_watermark_optimization.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Functional tests for automatic gvawatermark handling.
+
+These tests submit performance jobs end-to-end and check that the chosen
+output mode does not break execution for two complementary built-in
+pipelines. They intentionally do NOT iterate over every pipeline or
+every device variant: the broad coverage already lives in
+``test_performance_job_flow.py``. The goal here is to exercise both
+branches of :meth:`Graph.strip_watermark_if_all_sinks_are_fake`
+end-to-end on real graphs that include ``gvadetect`` and ``gvaclassify``.
+
+Pipelines used:
+  * ``license-plate-recognition`` -- has a single ``gvawatermark`` and a
+    single ``fakesink`` as terminal. In ``output_mode="disabled"`` the
+    optimization MUST strip the watermark before the graph is launched.
+    This test verifies the modified graph still runs successfully.
+  * ``smart-nvr`` -- the most complex predefined pipeline. It has
+    multiple ``gvawatermark`` nodes and an intermediate ``splitmuxsink``
+    next to the main ``fakesink``. The strip path MUST be a no-op here.
+    The test verifies the unchanged graph still runs successfully in
+    ``output_mode="disabled"``.
+
+The API does not expose the generated GStreamer command string, so the
+tests can only assert end-to-end success (job state, FPS, output paths).
+Together with the unit tests in
+``vippet/tests/unit/managers_tests/pipeline_manager_watermark_test.py``
+this confirms that the optimization neither breaks pipeline connectivity
+when it fires, nor accidentally fires on graphs that need the overlay.
+"""
+
+import logging
+
+import pytest
+import requests
+
+from helpers.api_helpers import (
+    JsonDict,
+    run_job_with_retry,
+    start_performance_job,
+    wait_for_job_completion,
+)
+from helpers.config import BASE_URL
+
+logger = logging.getLogger(__name__)
+
+# Pipeline that exercises the strip path:
+#   - single gvawatermark
+#   - gvadetect + gvaclassify in the chain
+#   - single fakesink as terminal -> watermark is removed in disabled mode
+STRIP_PIPELINE_ID: str = "license-plate-recognition"
+STRIP_VARIANT_ID: str = "cpu"
+
+# Pipeline that exercises the preservation path:
+#   - multiple gvawatermark nodes (one per tee branch)
+#   - intermediate splitmuxsink (non-fakesink) plus fakesink as main sink
+#     -> watermark must stay even with output_mode=disabled
+SMART_NVR_PIPELINE_ID: str = "smart-nvr"
+SMART_NVR_VARIANT_ID: str = "cpu"
+
+# Seconds to wait before retrying a failed job
+RETRY_DELAY_SECONDS: float = 5.0
+
+
+def _build_payload(
+    pipeline_id: str,
+    variant_id: str,
+    output_mode: str,
+    streams: int = 1,
+) -> JsonDict:
+    return {
+        "pipeline_performance_specs": [
+            {
+                "pipeline": {
+                    "source": "variant",
+                    "pipeline_id": pipeline_id,
+                    "variant_id": variant_id,
+                },
+                "streams": streams,
+            }
+        ],
+        "execution_config": {
+            "output_mode": output_mode,
+        },
+    }
+
+
+def _attempt_job(session: requests.Session, payload: JsonDict) -> JsonDict:
+    job_id = start_performance_job(session, payload)
+    status_url = f"{BASE_URL}/jobs/tests/performance/{job_id}/status"
+    return wait_for_job_completion(session, status_url)
+
+
+@pytest.mark.full
+def test_license_plate_recognition_with_output_disabled_strips_watermark(
+    http_client: requests.Session,
+) -> None:
+    """``output_mode=disabled`` on license-plate-recognition triggers the strip path.
+
+    The pipeline has a single ``gvawatermark`` followed by a single
+    ``fakesink``, so
+    :meth:`Graph.strip_watermark_if_all_sinks_are_fake` MUST remove the
+    watermark and reconnect the surrounding edges. The job must still
+    complete with a positive FPS, which proves the modified graph is
+    still launchable.
+    """
+    logger.info(
+        "Running %s/%s with output_mode=disabled (strip path)",
+        STRIP_PIPELINE_ID,
+        STRIP_VARIANT_ID,
+    )
+    payload = _build_payload(STRIP_PIPELINE_ID, STRIP_VARIANT_ID, "disabled", streams=1)
+    final_status = run_job_with_retry(
+        lambda: _attempt_job(http_client, payload),
+        retry_delay_seconds=RETRY_DELAY_SECONDS,
+    )
+
+    label = f"pipeline_id={STRIP_PIPELINE_ID} variant_id={STRIP_VARIANT_ID}"
+    assert final_status.get("state") == "COMPLETED", (
+        f"{label} finished in unexpected state {final_status.get('state')}"
+    )
+    assert final_status.get("error_message") is None, (
+        f"{label} returned error message: {final_status.get('error_message')}"
+    )
+    assert (final_status.get("per_stream_fps") or 0) > 0, (
+        f"{label} per_stream_fps must be greater than zero"
+    )
+
+
+@pytest.mark.full
+def test_license_plate_recognition_with_output_file_preserves_watermark(
+    http_client: requests.Session,
+) -> None:
+    """``output_mode=file`` on license-plate-recognition keeps the watermark.
+
+    With ``output_mode=file`` the main fakesink is converted to an
+    OUTPUT_PLACEHOLDER and replaced by the encoder + filesink, so the
+    strip path is a no-op and the overlay is preserved in the produced
+    file. The job must complete and report a non-empty
+    ``video_output_paths`` entry.
+    """
+    logger.info(
+        "Running %s/%s with output_mode=file (preserve path)",
+        STRIP_PIPELINE_ID,
+        STRIP_VARIANT_ID,
+    )
+    payload = _build_payload(STRIP_PIPELINE_ID, STRIP_VARIANT_ID, "file", streams=1)
+    final_status = run_job_with_retry(
+        lambda: _attempt_job(http_client, payload),
+        retry_delay_seconds=RETRY_DELAY_SECONDS,
+    )
+
+    label = f"pipeline_id={STRIP_PIPELINE_ID} variant_id={STRIP_VARIANT_ID}"
+    assert final_status.get("state") == "COMPLETED", (
+        f"{label} finished in unexpected state {final_status.get('state')}"
+    )
+    assert final_status.get("error_message") is None, (
+        f"{label} returned error message: {final_status.get('error_message')}"
+    )
+
+    video_output_paths = final_status.get("video_output_paths")
+    assert isinstance(video_output_paths, dict) and video_output_paths, (
+        f"{label} 'video_output_paths' must be a non-empty dict, "
+        f"got {video_output_paths!r}"
+    )
+    for variant_path, paths in video_output_paths.items():
+        assert isinstance(paths, list) and len(paths) > 0, (
+            f"{label} 'video_output_paths[{variant_path!r}]' must be a "
+            f"non-empty list, got {paths!r}"
+        )
+
+
+@pytest.mark.full
+def test_smart_nvr_with_output_disabled_preserves_watermark(
+    http_client: requests.Session,
+) -> None:
+    """``output_mode=disabled`` on smart-nvr keeps the watermark.
+
+    smart-nvr has an intermediate ``splitmuxsink`` next to the main
+    ``fakesink``, so the strip path MUST be a no-op (the recorded file
+    is itself a visible output). The job must complete with a positive
+    FPS to confirm the optimization does not accidentally fire on
+    NVR-style graphs.
+    """
+    logger.info(
+        "Running %s/%s with output_mode=disabled (no-op path)",
+        SMART_NVR_PIPELINE_ID,
+        SMART_NVR_VARIANT_ID,
+    )
+    payload = _build_payload(
+        SMART_NVR_PIPELINE_ID, SMART_NVR_VARIANT_ID, "disabled", streams=1
+    )
+    final_status = run_job_with_retry(
+        lambda: _attempt_job(http_client, payload),
+        retry_delay_seconds=RETRY_DELAY_SECONDS,
+    )
+
+    label = f"pipeline_id={SMART_NVR_PIPELINE_ID} variant_id={SMART_NVR_VARIANT_ID}"
+    assert final_status.get("state") == "COMPLETED", (
+        f"{label} finished in unexpected state {final_status.get('state')}"
+    )
+    assert final_status.get("error_message") is None, (
+        f"{label} returned error message: {final_status.get('error_message')}"
+    )
+    assert (final_status.get("per_stream_fps") or 0) > 0, (
+        f"{label} per_stream_fps must be greater than zero"
+    )

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/graph_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/graph_test.py
@@ -5187,6 +5187,46 @@ class TestStripWatermarkIfAllSinksAreFake(unittest.TestCase):
         edge_ids = [e.id for e in result.edges]
         self.assertEqual(len(edge_ids), len(set(edge_ids)), "Edge IDs must be unique")
 
+    def test_removes_chained_watermarks_with_unique_ids(self):
+        """Direct ``gvawatermark -> gvawatermark`` chain must be fully removed.
+
+        This is the adversarial case for the reconnection logic: the edge
+        added when the first watermark is dropped immediately becomes an
+        input of the second watermark, so it is removed again in the
+        next iteration. The end result must be a single ``src -> sink``
+        edge with an ID that does not collide with any other edge in the
+        resulting graph.
+        """
+        graph = Graph(
+            nodes=[
+                Node(id="0", type="filesrc", data={}),
+                Node(id="1", type="gvawatermark", data={}),
+                Node(id="2", type="gvawatermark", data={}),
+                Node(id="3", type="fakesink", data={}),
+            ],
+            edges=[
+                Edge(id="0", source="0", target="1"),
+                Edge(id="1", source="1", target="2"),
+                Edge(id="2", source="2", target="3"),
+            ],
+        )
+
+        result = graph.strip_watermark_if_all_sinks_are_fake()
+
+        # Both watermark nodes are gone, only src and sink remain.
+        result_types = [n.type for n in result.nodes]
+        self.assertNotIn("gvawatermark", result_types)
+        self.assertEqual(len(result.nodes), 2)
+
+        # Exactly one edge connecting filesrc directly to fakesink.
+        self.assertEqual(len(result.edges), 1)
+        self.assertEqual(result.edges[0].source, "0")
+        self.assertEqual(result.edges[0].target, "3")
+
+        # Edge IDs are unique strings.
+        edge_ids = [e.id for e in result.edges]
+        self.assertEqual(len(edge_ids), len(set(edge_ids)))
+
 
 class TestPrepareMainOutputPlaceholder(unittest.TestCase):
     """Test cases for Graph.prepare_main_output_placeholder method."""

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/pipeline_manager_watermark_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/pipeline_manager_watermark_test.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for automatic gvawatermark handling in PipelineManager.
+
+These tests exercise the path inside
+:meth:`PipelineManager.build_pipeline_command` that calls
+:meth:`Graph.strip_watermark_if_all_sinks_are_fake` once per stream. They
+verify that the produced pipeline command string contains (or does not
+contain) ``gvawatermark`` depending on the requested output mode and on the
+sink layout of the pipeline graph.
+"""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from graph import Graph
+from internal_types import (
+    InternalExecutionConfig,
+    InternalMetadataMode,
+    InternalOutputMode,
+    InternalPipelinePerformanceSpec,
+)
+from managers.pipeline_manager import PipelineManager
+
+
+# Re-use the same VideosManager stub strategy as pipeline_manager_test.py.
+# build_pipeline_command goes through graph.to_pipeline_description, which
+# instantiates VideosManager. The real singleton downloads default
+# recordings and converts them to .ts on first use; both are unwanted in
+# unit tests.
+_videos_manager_patcher = None
+
+
+def _mock_get_video_filename(path: str) -> str:
+    return os.path.basename(path)
+
+
+def _mock_get_video_path(filename: str) -> str:
+    return os.path.join("/tmp", filename)
+
+
+def setUpModule() -> None:
+    """Install the VideosManager patch before any test runs."""
+    global _videos_manager_patcher
+    mock_instance = MagicMock()
+    mock_instance.get_video_filename.side_effect = _mock_get_video_filename
+    mock_instance.get_video_path.side_effect = _mock_get_video_path
+    mock_instance.get_video.return_value = None
+    mock_instance.get_ts_path.side_effect = lambda p: p
+    mock_instance.ensure_ts_file.side_effect = lambda p: p
+
+    _videos_manager_patcher = patch("graph.VideosManager", return_value=mock_instance)
+    _videos_manager_patcher.start()
+
+
+def tearDownModule() -> None:
+    """Remove the VideosManager patch after the module's tests finish."""
+    global _videos_manager_patcher
+    if _videos_manager_patcher is not None:
+        _videos_manager_patcher.stop()
+        _videos_manager_patcher = None
+
+
+def _watermark_graph_single_fakesink() -> Graph:
+    """videotestsrc -> gvawatermark -> fakesink(default_output_sink)."""
+    return Graph.from_dict(
+        {
+            "nodes": [
+                {"id": "0", "type": "videotestsrc", "data": {}},
+                {"id": "1", "type": "gvawatermark", "data": {}},
+                {
+                    "id": "2",
+                    "type": "fakesink",
+                    "data": {"name": "default_output_sink"},
+                },
+            ],
+            "edges": [
+                {"id": "0", "source": "0", "target": "1"},
+                {"id": "1", "source": "1", "target": "2"},
+            ],
+        }
+    )
+
+
+def _watermark_graph_with_intermediate_filesink() -> Graph:
+    """NVR-style graph: a tee with a non-fakesink intermediate recorder and
+    a main fakesink, both fed through gvawatermark.
+
+    videotestsrc -> tee -> queue -> gvawatermark -> filesink (intermediate)
+                       \\-> queue -> gvawatermark -> fakesink(default_output_sink)
+    """
+    return Graph.from_dict(
+        {
+            "nodes": [
+                {"id": "0", "type": "videotestsrc", "data": {}},
+                {"id": "1", "type": "tee", "data": {}},
+                {"id": "2", "type": "queue", "data": {}},
+                {"id": "3", "type": "gvawatermark", "data": {}},
+                {
+                    "id": "4",
+                    "type": "filesink",
+                    "data": {"location": "/tmp/intermediate.mp4"},
+                },
+                {"id": "5", "type": "queue", "data": {}},
+                {"id": "6", "type": "gvawatermark", "data": {}},
+                {
+                    "id": "7",
+                    "type": "fakesink",
+                    "data": {"name": "default_output_sink"},
+                },
+            ],
+            "edges": [
+                {"id": "0", "source": "0", "target": "1"},
+                {"id": "1", "source": "1", "target": "2"},
+                {"id": "2", "source": "2", "target": "3"},
+                {"id": "3", "source": "3", "target": "4"},
+                {"id": "4", "source": "1", "target": "5"},
+                {"id": "5", "source": "5", "target": "6"},
+                {"id": "6", "source": "6", "target": "7"},
+            ],
+        }
+    )
+
+
+def _execution_config(output_mode: InternalOutputMode) -> InternalExecutionConfig:
+    return InternalExecutionConfig(
+        output_mode=output_mode,
+        max_runtime=0,
+        metadata_mode=InternalMetadataMode.DISABLED,
+    )
+
+
+def _performance_spec(graph: Graph) -> list[InternalPipelinePerformanceSpec]:
+    return [
+        InternalPipelinePerformanceSpec(
+            pipeline_id="/pipelines/wm-test/variants/cpu",
+            pipeline_name="wm-test",
+            pipeline_graph=graph,
+            streams=1,
+        )
+    ]
+
+
+class TestWatermarkHandlingInBuildPipelineCommand(unittest.TestCase):
+    """Verify that gvawatermark stripping is wired correctly per output mode."""
+
+    def setUp(self) -> None:
+        PipelineManager._instance = None
+        self.job_id = "wm-test-job"
+
+    def test_output_disabled_strips_watermark_when_only_fakesink(self) -> None:
+        """With output_mode=disabled and a fakesink-only graph the watermark
+        must be removed from the generated pipeline command."""
+        manager = PipelineManager()
+        manager.pipelines = []
+
+        pipeline_cmd = manager.build_pipeline_command(
+            _performance_spec(_watermark_graph_single_fakesink()),
+            _execution_config(InternalOutputMode.DISABLED),
+            self.job_id,
+        )
+
+        self.assertNotIn("gvawatermark", pipeline_cmd.command)
+        # The fakesink terminal is preserved because output_mode=disabled
+        # does not install the encoder/file subpipeline.
+        self.assertIn("fakesink", pipeline_cmd.command)
+
+    def test_output_file_preserves_watermark(self) -> None:
+        """With output_mode=file the main fakesink is converted to an
+        OUTPUT_PLACEHOLDER and replaced by the encoder subpipeline, so the
+        watermark must stay (the user will see it in the produced file)."""
+        manager = PipelineManager()
+        manager.pipelines = []
+
+        pipeline_cmd = manager.build_pipeline_command(
+            _performance_spec(_watermark_graph_single_fakesink()),
+            _execution_config(InternalOutputMode.FILE),
+            self.job_id,
+        )
+
+        self.assertIn("gvawatermark", pipeline_cmd.command)
+        # The placeholder fakesink is replaced by a real filesink.
+        self.assertIn("filesink", pipeline_cmd.command)
+
+    def test_output_live_stream_preserves_watermark(self) -> None:
+        """With output_mode=live_stream the watermark must stay so the live
+        viewer sees the overlay."""
+        manager = PipelineManager()
+        manager.pipelines = []
+
+        pipeline_cmd = manager.build_pipeline_command(
+            _performance_spec(_watermark_graph_single_fakesink()),
+            _execution_config(InternalOutputMode.LIVE_STREAM),
+            self.job_id,
+        )
+
+        self.assertIn("gvawatermark", pipeline_cmd.command)
+        # rtspclientsink is used for live streaming output.
+        self.assertIn("rtspclientsink", pipeline_cmd.command)
+
+    def test_output_disabled_preserves_watermark_when_intermediate_non_fakesink(
+        self,
+    ) -> None:
+        """When the graph has at least one non-fakesink terminal (e.g. an
+        intermediate filesink/splitmuxsink in NVR-style pipelines) the
+        watermark must be kept even with output_mode=disabled, because the
+        recorded file is itself a visible output for the user."""
+        manager = PipelineManager()
+        manager.pipelines = []
+
+        pipeline_cmd = manager.build_pipeline_command(
+            _performance_spec(_watermark_graph_with_intermediate_filesink()),
+            _execution_config(InternalOutputMode.DISABLED),
+            self.job_id,
+        )
+
+        self.assertIn("gvawatermark", pipeline_cmd.command)
+        self.assertIn("filesink", pipeline_cmd.command)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`PipelineManager.build_pipeline_command()` now drops every `gvawatermark` node when the only terminals in the per-stream graph are `fakesink` elements.
This removes the overlay-rendering cost from default benchmark runs while keeping the watermark whenever the user actually sees the video (file output, live stream, or pipelines with intermediate non-fakesink recorders such as `splitmuxsink`).

## Code

- `vippet/graph.py` - refactored `strip_watermark_if_all_sinks_are_fake()` to compute the next available edge ID once before the removal loop instead of rescanning the edge list each iteration; new reconnection edge IDs are strictly increasing and never collide with deleted ones.
- `vippet/graph.py` - expanded the method docstring to enumerate all branches: the `OUTPUT_PLACEHOLDER` early exit, the no-sinks early exit, the non-fakesink terminal early exit, and the regular removal path.
- `vippet/managers/pipeline_manager.py` - expanded the inline comment at the call site to document the three scenarios (`disabled` strips, `file`/`live_stream` keep via `OUTPUT_PLACEHOLDER`, intermediate non-fakesink terminals keep).

## Tests

- `vippet/tests/unit/graph_test.py` - added `test_removes_chained_watermarks_with_unique_ids` covering the adversarial direct `gvawatermark -> gvawatermark` chain.
- `vippet/tests/unit/managers_tests/pipeline_manager_watermark_test.py` - new integration tests over `build_pipeline_command()` for `disabled` (fakesink-only graph, strip), `file` (replaces fakesink with `filesink`, keep), `live_stream` (replaces fakesink with `rtspclientsink`, keep), and `disabled` with intermediate non-fakesink terminal (keep).
- `vippet/tests/functional/test_watermark_optimization.py` - new end-to-end performance jobs: `license-plate-recognition/cpu` with `output_mode=disabled` exercises the strip path, the same pipeline with `output_mode=file` exercises the preservation path, and `smart-nvr/cpu` with `output_mode=disabled` exercises the no-op path on the most complex predefined pipeline.

## Documentation

- `docs/user-guide/developer-guide/architecture/vippet-be.md` - added the `### Automatic Graph Transformations` subsection describing the per-stream transforms applied by `build_pipeline_command()` and the exact conditions under which `gvawatermark` is stripped or preserved.
