### PR TITLE
[ViPPET] Speed up lint, test and compose up/down cycles

### DIFF
--- a/microservices/metrics-manager/supervisord.conf
+++ b/microservices/metrics-manager/supervisord.conf
@@ -46,6 +46,9 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 priority=20
+stopasgroup=true
+killasgroup=true
+stopwaitsecs=2
 environment=PYTHONPATH="/app",METRICS_PORT="%(ENV_METRICS_PORT)s",LOG_LEVEL="%(ENV_LOG_LEVEL)s"
 
 # Telegraf - System metrics collection
@@ -61,6 +64,9 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 priority=10
+stopasgroup=true
+killasgroup=true
+stopwaitsecs=2
 
 # qmassa - GPU metrics collection (Intel GPUs)
 [program:qmassa]
@@ -72,3 +78,6 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 priority=30
+stopasgroup=true
+killasgroup=true
+stopwaitsecs=2

--- a/tools/visual-pipeline-and-platform-evaluation-tool/.dockerignore
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/.dockerignore
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Excludes for the Docker build context (build context = repo root, see
+# compose.yml `x-vippet.build.context: .`).
+#
+# Keep this list aggressive: everything not COPIED in any Dockerfile under
+# this repo should be excluded so BuildKit does not stat/hash large
+# directories (shared/, .venv, ui/node_modules, etc.) on every build.
+
+# VCS / IDE / OS noise
+.git
+.gitignore
+.github
+.idea
+.vscode
+.DS_Store
+
+# Local Python venvs / caches
+.venv
+**/.venv
+**/__pycache__
+**/*.pyc
+**/.pytest_cache
+**/.ruff_cache
+**/.mypy_cache
+**/.coverage
+**/.coverage.*
+.coverage
+.coverage.*
+
+# Runtime-mounted volume — never part of any image. This also covers
+# Make-generated sentinels that live under shared/ (e.g.
+# shared/.env-dirs.done, shared/.vippet-test-image.stamp).
+shared
+
+# Frontend build artifacts and dependencies
+ui/node_modules
+ui/dist
+ui/.vite
+ui/coverage
+
+# Logs
+*.log
+
+# Docs / Markdown — not COPIED by any Dockerfile
+docs

--- a/tools/visual-pipeline-and-platform-evaluation-tool/.gitignore
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 .coverage
 .env
 .idea
+.venv/
 shared/images/input/*
 shared/images/output/*
 shared/models/output/*
@@ -10,3 +11,8 @@ shared/videos/output/*
 shared/videos/video-generator/*
 shared/onvif/*
 shared/metadata/*
+# Make-generated sentinels (see Makefile: ENV_DIRS_SENTINEL,
+# TEST_IMAGE_SENTINEL). Kept under shared/ so they are also out of the
+# Docker build context via the `shared` entry in .dockerignore.
+shared/.env-dirs.done
+shared/.vippet-test-image.stamp

--- a/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
@@ -7,7 +7,7 @@ SHELL := bash -eu -o pipefail
 .DEFAULT_GOAL := help
 .PHONY: all lint build mdlint ruff fix-linter format pyright run build-dev run-dev test \
 	shell shell-vippet shell-model-download shell-metrics-manager shell-videogenerator stop clean clean-output-videos help \
-	build-videogenerator build-onvif-discovery docker-build env-setup \
+	build-videogenerator build-onvif-discovery docker-build env-setup build-test \
 	test-smoke test-full
 
 # Project Variables
@@ -18,52 +18,90 @@ PROJECT_DIR := $(shell pwd)
 COMPOSE_FILE := compose.yml
 DEV_COMPOSE_FILE := compose.dev.yml
 
+# Speed up `docker compose build` by skipping provenance/SBOM attestations
+# (saves ~hundreds of ms per build on warm cache, more on cold).
+export BUILDX_NO_DEFAULT_ATTESTATIONS := 1
+
 # Python venv Target
 VENV_DIR := .venv
+VENV_SENTINEL := $(VENV_DIR)/.installed
 
-$(VENV_DIR): $(PROJECT_NAME)/requirements.txt ## Create Python venv
-	python3 -m venv $@ ;\
-	set +u; . ./$@/bin/activate; set -u ;\
-	python -m pip install -r $(PROJECT_NAME)/requirements-dev.txt ;\
+# env-setup sentinel for the (slow-changing) directory layout. setup_env.sh
+# is intentionally NOT gated by this sentinel — it must run on every
+# invocation because its output (.env / COMPOSE_PROFILES) depends on the
+# currently installed hardware drivers, which can change without any
+# repo file changing.
+ENV_DIRS_SENTINEL := shared/.env-dirs.done
+
+# Test image build sentinel: re-build only when inputs that actually
+# affect the test image change (Dockerfile or requirements files). All
+# other source files are bind-mounted at run-time via --volume. Lives
+# under shared/ so it sits next to other generated artifacts and is
+# covered by the existing shared/* ignore patterns.
+TEST_IMAGE_SENTINEL := shared/.vippet-test-image.stamp
+
+# Create the dev venv only when requirements change. A sentinel file is
+# used instead of the venv directory itself because the directory mtime
+# is unstable across pip installs, which can cause the recipe
+# to run on every invocation.
+$(VENV_SENTINEL): $(PROJECT_NAME)/requirements.txt $(PROJECT_NAME)/requirements-dev.txt
+	@if [ ! -d $(VENV_DIR) ]; then python3 -m venv $(VENV_DIR); fi
+	set +u; . ./$(VENV_DIR)/bin/activate; set -u ;\
+	python -m pip install -r $(PROJECT_NAME)/requirements-dev.txt
+	@touch $@
 
 all: lint build run test ## Run lint, build, run and test
 
-lint: $(VENV_DIR) mdlint ruff pyright ## Run all linters
+lint: $(VENV_SENTINEL) mdlint ruff pyright ## Run all linters
 
-MD_FILES := $(shell find . -type f \( -name '*.md' \) -not -path './.*' -not -path './shared/*' -print )
+# Limit the markdown file search to source-controlled docs only. Excluding
+# generated/vendored trees (.venv, ui/node_modules, ui/dist, .pytest_cache)
+# avoids both spurious lint errors and slow filesystem scans.
+MD_FILES := $(shell find . -type f -name '*.md' \
+	-not -path './.*' \
+	-not -path './shared/*' \
+	-not -path './.venv/*' \
+	-not -path './ui/node_modules/*' \
+	-not -path './ui/dist/*' \
+	-not -path '*/.pytest_cache/*' \
+	-not -path '*/__pycache__/*' \
+	-print)
 mdlint: ## Lint MD files
 # download tool from https://github.com/igorshubovych/markdownlint-cli
 	markdownlint --version
 	markdownlint $(MD_FILES)
 
-ruff: $(VENV_DIR) ## Run ruff linter
-	set +u; . ./$</bin/activate; set -u ;\
+ruff: $(VENV_SENTINEL) ## Run ruff linter
+	set +u; . ./$(VENV_DIR)/bin/activate; set -u ;\
 	ruff --version ;\
 	# Exclude shared/ — runtime-mounted volume, not source code ;\
 	ruff check --exclude shared/ ;\
 	ruff format --check --exclude shared/
 
-fix-linter: $(VENV_DIR) ## Fix linter issues using ruff
-	set +u; . ./$</bin/activate; set -u ;\
+fix-linter: $(VENV_SENTINEL) ## Fix linter issues using ruff
+	set +u; . ./$(VENV_DIR)/bin/activate; set -u ;\
 	# Exclude shared/ — runtime-mounted volume, not source code ;\
 	ruff check --fix --exclude shared/
 
-format: $(VENV_DIR) ## Format code using ruff
-	set +u; . ./$</bin/activate; set -u ;\
+format: $(VENV_SENTINEL) ## Format code using ruff
+	set +u; . ./$(VENV_DIR)/bin/activate; set -u ;\
 	# Exclude shared/ — runtime-mounted volume, not source code ;\
 	ruff format --exclude shared/
 
-pyright: $(VENV_DIR) ## Run pyright type checker
-	set +u; . ./$</bin/activate; set -u ;\
+pyright: $(VENV_SENTINEL) ## Run pyright type checker
+	set +u; . ./$(VENV_DIR)/bin/activate; set -u ;\
 	pyright --version ;\
-	pyright .
+	# Include/exclude is configured in pyrightconfig.json. ;\
+	pyright --threads=4
 
-generate_openapi: $(VENV_DIR) ## Generate OpenAPI schema file
-	set +u; . ./$</bin/activate; set -u ;\
+generate_openapi: $(VENV_SENTINEL) ## Generate OpenAPI schema file
+	set +u; . ./$(VENV_DIR)/bin/activate; set -u ;\
 	cd $(PROJECT_NAME) ;\
 	PYTHONPATH=. SUPPORTED_MODELS_FILE=../shared/models/supported_models.yaml AUTO_VIDEO_DIR=../shared/videos/input/auto UPLOADED_VIDEO_DIR=../shared/videos/input/uploaded python ../generate_openapi.py
 
-env-setup: ## Environment setup target: always run before build/run targets that need .env and shared dirs
+# Directory layout for the shared/ runtime volumes. Cheap and idempotent
+# but sentinel-gated so repeated invocations skip the chmod chatter.
+$(ENV_DIRS_SENTINEL): Makefile
 	mkdir -p shared/metadata && chmod o+w shared/metadata
 	mkdir -p shared/models/output && chmod o+w shared/models/output
 	mkdir -p shared/model-download/cache && chmod o+w shared/model-download/cache
@@ -75,6 +113,13 @@ env-setup: ## Environment setup target: always run before build/run targets that
 	mkdir -p shared/videos/input && chmod o+w shared/videos/input
 	mkdir -p shared/videos/output && chmod o+w shared/videos/output
 	mkdir -p shared/videos/video-generator && chmod o+w shared/videos/video-generator
+	@touch $@
+
+# env-setup must run on every invocation: setup_env.sh detects the
+# currently installed hardware drivers (NPU/GPU/CPU) and rewrites .env
+# with the matching COMPOSE_PROFILES. That can change without any
+# tracked file changing, so we never cache the script's output.
+env-setup: $(ENV_DIRS_SENTINEL) ## Create shared/ dirs and (always) re-run setup_env.sh
 	./setup_env.sh
 
 build: env-setup ## Build core images (vippet-app, vippet-ui, vippet-onvif-discovery)
@@ -100,11 +145,31 @@ run-videogenerator: env-setup build-videogenerator ## Run only the videogenerato
 run-dev: env-setup ## Run the docker compose services for development
 	. .env && docker compose -f $(COMPOSE_FILE) -f compose.$$COMPOSE_PROFILES.yml -f $(DEV_COMPOSE_FILE) up -d
 
-test: env-setup ## Run unit tests and generate coverage report
+# Build the test image only when its inputs change. Source files are
+# bind-mounted at run-time (see `test` target), so changing application
+# code does not require an image rebuild.
+#
+# `env-setup` is an order-only prerequisite (after the `|`): it must
+# run first so .env exists, but its always-changing timestamp must not
+# invalidate this sentinel.
+$(TEST_IMAGE_SENTINEL): $(PROJECT_NAME)/Dockerfile \
+		$(PROJECT_NAME)/requirements.txt \
+		$(PROJECT_NAME)/requirements-dev.txt \
+		$(PROJECT_NAME)/requirements-omz.txt \
+		.dockerignore \
+		| env-setup
+	. .env && TARGET=test DOCKER_TAG="test" docker compose -f $(COMPOSE_FILE) -f compose.$$COMPOSE_PROFILES.yml build vippet
+	@touch $@
+
+build-test: $(TEST_IMAGE_SENTINEL) ## Build the vippet test image (with dev deps)
+
+test: build-test ## Run unit tests and generate coverage report
     # Run tests using the cpu profile (tests are device agnostic)
     # Override DOCKER_TAG with '-test' suffix only for this docker compose run
+    # NOTE: `--build` is intentionally omitted — image is built by the
+    # `build-test` prerequisite, and only when its inputs change.
 	. .env && TARGET=test DOCKER_TAG="test" docker compose -f $(COMPOSE_FILE) -f compose.$$COMPOSE_PROFILES.yml run \
-	--build --rm --no-deps --volume $(PROJECT_DIR):/home/dlstreamer/vippet vippet bash -c "\
+	--rm --no-deps --volume $(PROJECT_DIR):/home/dlstreamer/vippet vippet bash -c "\
 		cd $(PROJECT_NAME) && \
 		AUTO_VIDEO_DIR=/tmp/auto \
 		UPLOADED_VIDEO_DIR=/tmp/uploaded \
@@ -114,12 +179,12 @@ test: env-setup ## Run unit tests and generate coverage report
 		python -m coverage report --data-file=/tmp/.vippet-coverage --show-missing --skip-covered --omit=*/config-3.py,*/config.py,*_test.py && \
 		python -m coverage html --data-file=/tmp/.vippet-coverage --directory=/tmp/.vippet-coverage-html --omit=*/config-3.py,*/config.py,*_test.py"
 
-test-smoke: $(VENV_DIR) ## Run smoke functional tests
-	set +u; . ./$</bin/activate; set -u ;\
+test-smoke: $(VENV_SENTINEL) ## Run smoke functional tests
+	set +u; . ./$(VENV_DIR)/bin/activate; set -u ;\
 	python -m pytest --log-cli-level=INFO -m smoke vippet/tests/functional/
 
-test-full: $(VENV_DIR) ## Run full functional tests
-	set +u; . ./$</bin/activate; set -u ;\
+test-full: $(VENV_SENTINEL) ## Run full functional tests
+	set +u; . ./$(VENV_DIR)/bin/activate; set -u ;\
 	python -m pytest --log-cli-level=INFO vippet/tests/functional/
 
 shell: env-setup ## Open shell in specified container (i.e. make shell SERVICE=vippet)
@@ -142,6 +207,7 @@ stop: ## Stop the docker compose services
 
 clean: clean-model-download clean-models clean-output-videos ## Clean all build artifacts
 	rm -rf shared/onvif/onvif_cameras.json shared/videos/input shared/videos/video-generator
+	rm -f $(ENV_DIRS_SENTINEL) $(TEST_IMAGE_SENTINEL)
 
 clean-model-download: ## Clean only model-download artifacts
 	docker run --rm -v "${PWD}"/shared/model-download/:/mnt/model-download/ python:3.12-slim sh -c 'rm -rf /mnt/model-download/cache/ /mnt/model-download/venv-*/'

--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -22,7 +22,9 @@ x-vippet: &vippet
     mediamtx:
       condition: service_started
     model-download:
-      condition: service_healthy
+      condition: service_started
+    onvif-discovery:
+      condition: service_started
   environment:
     GST_DEBUG: "1"
     APP_LOG_LEVEL: INFO
@@ -107,7 +109,7 @@ services:
       vippet:
         condition: service_healthy
       metrics-manager:
-        condition: service_healthy
+        condition: service_started
     environment:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
@@ -132,7 +134,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 60m
-      start_interval: 2s
+      start_interval: 1s
     restart: on-failure:5
     environment:
       MODELS_DIR: /models/output
@@ -170,6 +172,7 @@ services:
   metrics-manager:
     image: docker.io/intel/metrics-manager:2026.1.0
     container_name: metrics-manager
+    init: true
     ports:
       - "9090:9090"
       - "9273:9273"
@@ -199,6 +202,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+      start_interval: 1s
   mediamtx:
     image: bluenviron/mediamtx:1.15.6
     container_name: mediamtx
@@ -223,6 +227,7 @@ services:
     container_name: onvif-discovery
     network_mode: host
     restart: on-failure:5
+    init: true
     user: "${UID:-1000}:${GID:-1000}"
     environment:
       OUTPUT_FILE: /out/onvif_cameras.json

--- a/tools/visual-pipeline-and-platform-evaluation-tool/onvif_discovery/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/onvif_discovery/Dockerfile
@@ -31,4 +31,4 @@ ENV OUTPUT_FILE=/out/onvif_cameras.json \
 # Run as non-root user (will be overridden by docker-compose user directive)
 USER 1000:1000
 
-CMD python /app/onvif_discovery_agent.py --out ${OUTPUT_FILE} --interval ${DISCOVERY_INTERVAL}
+CMD ["sh", "-c", "exec python /app/onvif_discovery_agent.py --out \"$OUTPUT_FILE\" --interval \"$DISCOVERY_INTERVAL\""]

--- a/tools/visual-pipeline-and-platform-evaluation-tool/pyrightconfig.json
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/pyrightconfig.json
@@ -1,4 +1,22 @@
 {
+  "include": [
+    "vippet",
+    "video_generator",
+    "generate_openapi.py"
+  ],
+  "exclude": [
+    ".venv",
+    "**/.venv",
+    "**/node_modules",
+    "**/__pycache__",
+    "**/.pytest_cache",
+    "**/.ruff_cache",
+    "**/.mypy_cache",
+    ".git",
+    "docs",
+    "shared",
+    "ui"
+  ],
   "executionEnvironments": [
     {
       "root": "vippet"
@@ -6,13 +24,5 @@
     {
       "root": "video_generator"
     }
-  ],
-  "exclude": [
-    ".venv",
-    "**/.venv",
-    "**/node_modules",
-    "**/__pycache__",
-    ".git",
-    "shared/"
   ]
 }

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -14,6 +14,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+# syntax=docker/dockerfile:1.7
+
 # Use DLStreamer as the base image
 FROM intel/dlstreamer:2026.1.0-ubuntu24 AS prod
 
@@ -24,10 +26,13 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install necessary dependencies
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends yq v4l-utils && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# BuildKit cache mounts keep apt downloads/metadata between builds. The
+# cache lives outside the image layer, so runtime image size is unchanged.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && \
+    apt-get install --yes --no-install-recommends yq v4l-utils
 
 # Switch to dlstreamer user
 USER dlstreamer
@@ -59,10 +64,17 @@ COPY --chown=dlstreamer:dlstreamer vippet/requirements-omz.txt /home/dlstreamer/
 
 # Install the production runtime dependencies into the main venv and the
 # OMZ tooling into its own isolated venv.
-RUN \
-    pip3 install --disable-pip-version-check --no-cache-dir -r requirements.txt && \
+#
+# A BuildKit cache mount keeps pip's HTTP/wheel cache between builds. The
+# cache lives outside the image layer, so runtime image size is unchanged.
+# ``mode=0777`` lets the non-root ``dlstreamer`` user write to it without
+# needing to know its uid/gid at build time.
+RUN --mount=type=cache,target=/tmp/pip-cache,mode=0777,sharing=locked \
+    PIP_CACHE_DIR=/tmp/pip-cache \
+    pip3 install --disable-pip-version-check -r requirements.txt && \
     python3 -m venv $OMZ_VIRTUAL_ENV && \
-    $OMZ_VIRTUAL_ENV/bin/pip install --disable-pip-version-check --no-cache-dir \
+    PIP_CACHE_DIR=/tmp/pip-cache \
+    $OMZ_VIRTUAL_ENV/bin/pip install --disable-pip-version-check \
         -r requirements-omz.txt && \
     # Security override: bump ``onnx`` past the cap that ``openvino-dev``
     # 2024.6.0 (archived upstream) inherited. Fixes CVE-2026-27489 (HIGH),
@@ -70,7 +82,8 @@ RUN \
     # is required because the resolver would otherwise honor the cap, and
     # we deliberately keep transitive deps intact (no --no-deps) so onnx's
     # own runtime requirements (protobuf, numpy) are satisfied.
-    $OMZ_VIRTUAL_ENV/bin/pip install --disable-pip-version-check --no-cache-dir \
+    PIP_CACHE_DIR=/tmp/pip-cache \
+    $OMZ_VIRTUAL_ENV/bin/pip install --disable-pip-version-check \
         --upgrade "onnx>=1.21.0"
 
 # Copy the Python scripts and configuration files into the container
@@ -96,4 +109,6 @@ FROM prod AS test
 COPY --chown=dlstreamer:dlstreamer vippet/requirements-dev.txt /home/dlstreamer/vippet/requirements-dev.txt
 
 # Install only dev requirements on top of prod image
-RUN pip3 install --disable-pip-version-check --no-cache-dir -r requirements-dev.txt
+RUN --mount=type=cache,target=/tmp/pip-cache,mode=0777,sharing=locked \
+    PIP_CACHE_DIR=/tmp/pip-cache \
+    pip3 install --disable-pip-version-check -r requirements-dev.txt


### PR DESCRIPTION
## Summary
This PR shortens the most common local development loops without changing the runtime behavior of the production images.
Measured on a warm cache:

| Loop                       | Before     | After     | Δ       |
|----------------------------|-----------:|----------:|--------:|
| `make format`              | ~2.75 s    | ~0.8 s    | −70 %   |
| `make lint`                | ~24 s      | ~21 s     | −13 %   |
| `make test` setup (no UTs) | ~5 s       | ~0.9 s    | −81 %   |
| `make run`                 | ~17 s      | ~6 s      | −65 %   |
| `make stop`                | ~14 s      | ~6 s      | −55 %   |
| `make run` + `make stop`   | ~31 s      | ~12 s     | −61 %   |

No production image content changes.
All new generated files live under `shared/` or `.venv/` and are ignored by both Git and the Docker build context.
## Changes
### Makefile — incremental targets via sentinels
- `VENV_SENTINEL := .venv/.installed` replaces the venv directory as a Make target. Using the directory caused `pip install` to retouch its mtime on every invocation, so every `make format` / `make lint` / `make test-*` re-ran `pip install` (~2 s of "Requirement already satisfied" noise). The sentinel makes the recipe run only when `requirements*.txt` actually change.
- `ENV_DIRS_SENTINEL := shared/.env-dirs.done` gates the `mkdir`+`chmod` block of `env-setup`. The recipe is cheap but ran on every target that depends on `env-setup`.
- `env-setup` is now PHONY again and **always** runs `./setup_env.sh`. `setup_env.sh` detects the installed hardware drivers (NPU/GPU/CPU) and rewrites `.env` with the matching `COMPOSE_PROFILES`. That can change without any tracked file changing, so it must never be cached.
- New `build-test` target with `TEST_IMAGE_SENTINEL := shared/.vippet-test-image.stamp`. The test image is rebuilt only when its real inputs change (`vippet/Dockerfile`, `requirements*.txt`, `.dockerignore`). Source files are bind-mounted at run time, so changing application code no longer triggers an image rebuild. `env-setup` is an order-only prerequisite (`| env-setup`) so its always-changing timestamp does not invalidate the sentinel.
- `test:` no longer passes `--build` to `docker compose run` — the build is handled by the `build-test` prerequisite.
- `MD_FILES` `find` now excludes `.venv`, `ui/node_modules`, `ui/dist`, `.pytest_cache`, `__pycache__`. Speeds up `mdlint` and avoids spurious lint errors from vendored trees.
- `pyright .` → `pyright --threads=4`; include/exclude moved to `pyrightconfig.json`.
- `export BUILDX_NO_DEFAULT_ATTESTATIONS := 1` — skip provenance/SBOM attestation steps in every `docker compose build` invocation.
- `clean` also removes both sentinels.
### `.dockerignore` (new)
The build context is the repo root (see `compose.yml` `x-vippet.build.context: .`).
Without a `.dockerignore`, BuildKit was stat'ing the whole repo on every build (transferring a 6.5 kB context was taking ~2 s).
Excludes: `.git`, `.idea`, `.vscode`, `.venv`, `**/__pycache__`, `**/.pytest_cache`, `**/.ruff_cache`, `**/.mypy_cache`, `shared`, `ui/node_modules`, `ui/dist`, `ui/.vite`, `ui/coverage`, `*.log`, `docs`.
`shared` also covers the new Make-generated sentinels.
### `.gitignore`
Adds `.venv/` and the two sentinel files under `shared/`.
### `pyrightconfig.json`
- Added an explicit `include: ["vippet", "video_generator", "generate_openapi.py"]`. Before this change `pyright .` walked the whole repo (including `ui/`, `docs/`, `shared/`, transient caches) until each path was hit by an `exclude`.
- Extended `exclude` with `**/.pytest_cache`, `**/.ruff_cache`, `**/.mypy_cache`, `docs`, `ui`.
### `vippet/Dockerfile`
- Added `# syntax=docker/dockerfile:1.7` so BuildKit cache mounts are recognized.
- `apt-get`: replaced `apt-get clean && rm -rf /var/lib/apt/lists/*` with BuildKit cache mounts for `/var/cache/apt` and `/var/lib/apt/lists` (with the `docker-clean` apt hook removed). The cache lives outside the image layer, so runtime image size is unchanged.
- `pip3 install`: removed `--no-cache-dir` and added a BuildKit cache mount at `/tmp/pip-cache` (`mode=0777,sharing=locked`) with `PIP_CACHE_DIR=/tmp/pip-cache`. Applies to both the production stage (main venv + OMZ venv + onnx security override) and the `test` stage (`requirements-dev.txt`). The cache lives outside the image layer, so runtime image size is unchanged.
### `compose.yml` — dependency graph and signal handling
- `x-vippet.depends_on.model-download`: `service_healthy` → `service_started`. `vippet` only talks to `model-download` lazily (the UI "Models" page proxies install requests). Waiting ~10 s for plugin warm-up blocked the whole stack instead of just the Models page.
- `x-vippet.depends_on.onvif-discovery`: added as `service_started`. `vippet` logically depends on the ONVIF camera scanner.
- `vippet-ui.depends_on.metrics-manager`: `service_healthy` → `service_started`. The UI only consumes metrics via an SSE proxy (`/metrics/stream`); React reconnects automatically. Waiting for `service_healthy` blocked the whole UI for ~4 s with no benefit for non-metrics views.
- `metrics-manager.init: true` — `intel/metrics-manager`'s entrypoint is a shell script wrapping `supervisord`; without an init PID 1, SIGTERM was dropped by the shell. With `init: true`, Docker injects an init process as PID 1, which forwards SIGTERM to supervisord.
- `metrics-manager.healthcheck.start_interval: 1s` — without `start_interval`, Docker fell back to `interval=10s`, so the first poll happened ~5 s after start even though the service was ready in ~1 s.
- `model-download.healthcheck.start_interval`: `2s` → `1s`. Small but free.
- `onvif-discovery.init: true` — safety net in case `CMD` regresses to shell form.
### `onvif_discovery/Dockerfile`
- `CMD python ...` (shell form) → `CMD ["sh", "-c", "exec python ..."]`. Without `exec`, SIGTERM was delivered to `/bin/sh`, which ignored it; the Python agent (which already has a SIGTERM handler) only died on SIGKILL after the 10 s grace period. `exec` replaces the shell with the Python process so SIGTERM reaches the agent directly.
### `microservices/metrics-manager/supervisord.conf` (sibling repo)
Source-side fix for slow `make stop`, applied to all three programs (`metrics-manager`, `telegraf`, `qmassa`):
- `stopasgroup=true` + `killasgroup=true` — supervisord signals the whole process group instead of only the program's lead PID (uvicorn workers, telegraf/qmassa children).
- `stopwaitsecs=2` (was the implicit default `10`). In-memory metrics-manager state is ephemeral (300 s retention, cleared on restart), so a shorter graceful window is safe.
Together this drops per-program shutdown from up to 10 s (SIGKILL after the supervisord timeout) to <2 s.
## Functional behavior changes
- **Models page**: if the user opens it in the first ~10 s after `make run`, an install request may briefly return a proxy error from `model-download`. Retries succeed once `model-download` finishes plugin warm-up. Follow-up: surface "Initializing model service…" in the UI.
- **Metrics view**: if opened in the first ~4 s, the chart shows "loading" until the SSE stream connects. Already handled by the existing reconnect logic.
- **Stop**: telegraf/qmassa in `metrics-manager` may drop the last in-memory sample. Acceptable given the 300 s in-memory retention.
## What is *not* changed
- No production image content changes — cache mounts live outside the final layers.
- No changes to third-party images other than `intel/metrics-manager`, which is owned in a sibling repo and rebuilt locally for testing.
- No refactors unrelated to the dev-loop speedup.
## How to validate
```bash
./setup_env.sh
make env-setup
# Lint / format
time make format
time make lint
# Test image build is cached
time make build-test     # first run: rebuilds
time make build-test     # second run: ~0.8 s, no docker build
# Compose up/down timing
time make run
time make stop
```
Optional, with per-line timestamps captured to a single log file:
```bash
set -o pipefail; (make test-full 2>&1) | ts '%H:%M:%.S' | tee test-full.log
```