### PR TITLE
[VSS Microservices] Added initial set of dev and user skills for VSS microservices

### DIFF
--- a/microservices/multimodal-embedding-serving/.cursor/rules/multimodal-embedding-serving.mdc
+++ b/microservices/multimodal-embedding-serving/.cursor/rules/multimodal-embedding-serving.mdc
@@ -1,0 +1,29 @@
+---
+description: Multimodal Embedding Serving Cursor agent router — canonical instructions and workflow skills
+alwaysApply: true
+---
+
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+## Canonical instructions
+
+Read [.github/copilot-instructions.md](../../.github/copilot-instructions.md)
+first. Do not duplicate policy here.
+
+## Skills
+
+Discover workflow skills by reading the `SKILL.md` files under
+[.github/skills/](../../.github/skills/); prefer
+[skill-catalog.json](../../.github/skills/skill-catalog.json) for routing and
+do not assume a fixed list.
+
+## Cursor workflow
+
+- Prefer the service's real interfaces: `source setup.sh` (requires
+  `EMBEDDING_MODEL_NAME`), `docker compose -f docker/compose.yaml`, the REST
+  API on port `9777`, or the Python SDK wheel.
+- Run commands yourself and relay results; keep changes minimal.
+- Commit or open PRs only when explicitly asked.

--- a/microservices/multimodal-embedding-serving/.github/copilot-instructions.md
+++ b/microservices/multimodal-embedding-serving/.github/copilot-instructions.md
@@ -1,0 +1,124 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Multimodal Embedding Serving — AI agents
+
+## Canonical Instructions
+
+Use this file as the canonical router for coding agents. Keep tool-specific
+files such as `AGENTS.md`, `CLAUDE.md`, and
+`.cursor/rules/multimodal-embedding-serving.mdc` as short pointers to this
+file.
+
+## What This Service Is
+
+Multimodal Embedding Serving generates embeddings for **text, images, and
+videos** in a shared semantic space (FastAPI + PyTorch/OpenVINO). It is
+consumable two ways: as a **REST service** (prebuilt
+`intel/multimodal-embedding-serving:latest` on Docker Hub, port 9777) and as a
+**Python SDK wheel** (`multimodal_embedding_serving`, built with
+`poetry build`) for in-process use. Deeper user docs live under
+[`docs/user-guide/`](../docs/user-guide/); this file is the agent-facing map.
+
+## Run Interfaces
+
+- `setup.sh` must be **sourced**, never executed. It **hard-fails
+  (`return 1`) unless `EMBEDDING_MODEL_NAME` is exported first** (e.g.
+  `CLIP/clip-vit-b-32`). It creates the external volumes `ov-models` and
+  `data-prep`.
+- Deploy: `export EMBEDDING_MODEL_NAME="CLIP/clip-vit-b-32" && source setup.sh
+  && docker compose -f docker/compose.yaml up -d`. Host port
+  `EMBEDDING_SERVER_PORT` (**9777**, hardcoded by setup.sh) maps to container
+  8000.
+- Models download and (optionally) convert to OpenVINO lazily at startup;
+  `EMBEDDING_DEVICE=GPU` auto-enables `EMBEDDING_USE_OV=true` + THROUGHPUT
+  mode in setup.sh.
+
+## API Surface
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/embeddings` | Embed text / image / video (typed `input` union) |
+| GET | `/models` | All available model ids by family |
+| GET | `/model/current` | Loaded model + device + OpenVINO flag |
+| GET | `/model/capabilities` | Modalities the loaded model supports |
+| GET | `/health` | 200 healthy / 500 unhealthy |
+
+## Model Families
+
+CLIP (×4), CN-CLIP (×3, Chinese+English), MobileCLIP (×5), SigLIP (×3),
+Blip2 (`Blip2/blip2_transformers`), QwenText (×3, `Qwen/Qwen3-Embedding-*`,
+**text-only**). Model ids are `Family/name`, e.g. `CLIP/clip-vit-b-16`. Always
+check `GET /model/capabilities` before sending non-text inputs.
+
+## Repository Map
+
+| Path | Contents |
+|---|---|
+| `setup.sh` | Env export + volume creation (source it; needs `EMBEDDING_MODEL_NAME`). |
+| `docker/` | `compose.yaml` + `Dockerfile`. |
+| `src/app.py` | FastAPI routes + request models (input union). |
+| `src/wrapper.py` | `EmbeddingModel` — the high-level embed API (also the SDK surface). |
+| `src/models/` | `config.py` (registry of 19 models), `registry.py` (factory), `base.py` (ABC), `handlers/` (one per family). |
+| `src/utils/` | Settings, downloads/SSRF checks, video decoder, path security. |
+| `examples/` | `sdk_examples.py`, `server_examples.py`. |
+| `tests/` | `test_path_security.py` (unittest). |
+| `docs/user-guide/` | get-started, api-reference, supported-models, sdk-usage, wheel-installation. |
+
+## Tech Stack
+
+Python 3.10+ with Poetry (packaged — `poetry build` yields the SDK wheel),
+FastAPI + Gunicorn, open_clip / cn_clip / transformers / optimum-intel,
+OpenVINO optional per model.
+
+## Conventions
+
+- Run commands from this microservice's root unless a skill says otherwise.
+- `setup.sh` is **sourced**, never executed directly.
+- Every new source/config/doc file carries the repo SPDX header
+  (`SPDX-FileCopyrightText: (C) 2026 Intel Corporation` / `Apache-2.0`).
+- Probe `GET http://localhost:9777/health` before any API workflow.
+- Destructive operations (removing `ov-models`/`data-prep` volumes) need
+  explicit user confirmation.
+
+## Gotchas
+
+- QwenText models reject image/video inputs (400) — capability-check first.
+- `mobileclip` and `salesforce-lavis` are installed **only in the Docker
+  image** (not in `pyproject.toml`); MobileCLIP/BLIP2 families can't run in a
+  bare Poetry env.
+- `INFER_BATCH_SIZE` compiles OpenVINO models to a **fixed batch shape**.
+- `video_file`/`frames_batch` inputs accept bare filenames only, resolved
+  under the container's `/tmp/videoQnA` sandbox.
+- This package is a **path dependency of the VDMS DataPrep microservice**
+  (`visual-data-preparation-for-retrieval/vdms`) — changes to
+  `src/wrapper.py`'s API ripple there.
+
+## Skills
+
+Reusable workflow skills live under [`.github/skills/`](skills/). Use
+[`skill-catalog.json`](skills/skill-catalog.json) to pick the relevant skill,
+then read that skill's `SKILL.md`.
+
+| User intent | Skill |
+|---|---|
+| Deploy the service or embed content from an app (REST or SDK) | `multimodal-embedding-serving-user` |
+| Build from source, run tests, add model handlers | `multimodal-embedding-serving-dev` |
+
+## Skill Loading Rules
+
+- Load only the skill needed for the current request.
+- Open a skill's linked docs or `references/` files only when its `SKILL.md`
+  points to them.
+- Run commands yourself when the harness permits it and relay the result.
+
+## Path Conventions
+
+All paths in the skill catalog are relative to this microservice's root
+(`microservices/multimodal-embedding-serving/`). The skills live in
+`.github/skills` as the shared location for Codex, Copilot CLI, Claude Code,
+Cursor, and local agent scripts. Skills also work without a repo clone — the
+`-user` skill fetches the same `setup.sh`/compose files and docs from GitHub
+and uses the prebuilt image.

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/SKILL.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/SKILL.md
@@ -6,9 +6,6 @@ description: >
   architecture, add a new model family, and build the image from source. Use
   when modifying, testing, or debugging this service's code. Not for merely
   deploying or calling the API — that is multimodal-embedding-serving-user.
-argument-hint: >
-  Describe what you want to build, test, or debug (e.g. "add a new embedding
-  model family handler", or "why does MobileCLIP fail to import in Poetry?")
 ---
 
 # Multimodal Embedding Serving — Dev

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/SKILL.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: multimodal-embedding-serving-dev
+description: >
+  Develop the Multimodal Embedding Serving microservice itself — Poetry
+  install, run the existing tests, navigate the wrapper/registry/handler
+  architecture, add a new model family, and build the image from source. Use
+  when modifying, testing, or debugging this service's code. Not for merely
+  deploying or calling the API — that is multimodal-embedding-serving-user.
+argument-hint: >
+  Describe what you want to build, test, or debug (e.g. "add a new embedding
+  model family handler", or "why does MobileCLIP fail to import in Poetry?")
+---
+
+# Multimodal Embedding Serving — Dev
+
+Work on the service's source. **This skill assumes a repo clone** of
+`edge-ai-libraries` with this microservice at
+`microservices/multimodal-embedding-serving/`; if there is no clone, clone the
+repo first (`git clone
+https://github.com/open-edge-platform/edge-ai-libraries.git`) or — if the user
+only wants to *use* the service — switch to
+[`../multimodal-embedding-serving-user/SKILL.md`](../multimodal-embedding-serving-user/SKILL.md).
+Run all commands from the microservice root.
+
+## When to Use
+
+- Add or modify a model-family handler (CLIP/SigLIP/MobileCLIP/CN-CLIP/Blip2/QwenText)
+- Run or extend the existing test suite
+- Navigate the wrapper → registry → handler architecture before editing
+- Build the image from source
+- Debug model load, OpenVINO conversion, or import failures
+
+## Example Prompts
+
+Sample Problem-solving scenarios this skill handles end-to-end:
+
+| Example | Problem it solves |
+|---|---|
+| [onboard-new-model.md](./example-prompts/onboard-new-model.md) | Onboard a new embedding model family (REST + SDK) |
+| [update-test-cases.md](./example-prompts/update-test-cases.md) | Update test cases to cover a newly onboarded model |
+
+## Reference Lookup
+
+| File | Load when… |
+|---|---|
+| [`references/source-map.md`](./references/source-map.md) | locating code before editing, or adding a model family (checklist inside) |
+| [`references/testing.md`](./references/testing.md) | running/adding tests or smoke-testing changes |
+
+## Environment setup
+
+```bash
+poetry install    # Python >=3.10,<3.14
+```
+
+**Known limitation:** `mobileclip` and `salesforce-lavis` are installed only
+in the Docker image (see `docker/Dockerfile`), not via `pyproject.toml`. In a
+bare Poetry env, MobileCLIP and Blip2 handlers fail to import — develop those
+families against the container:
+
+```bash
+export EMBEDDING_MODEL_NAME="MobileCLIP/mobileclip_s0"
+source setup.sh && docker compose -f docker/compose.yaml up -d --build
+```
+
+## Architecture in one paragraph
+
+`src/app.py` (routes, input union) → `src/wrapper.py` (`EmbeddingModel`, the
+high-level API — also the **SDK surface**) → `src/models/registry.py`
+(factory) → `src/models/handlers/<family>_handler.py` (per-family
+`load_model`/`encode_text`/`encode_image`, PyTorch and optional OpenVINO
+paths). `src/models/config.py` holds the 19-model registry. Map + add-a-model
+checklist: [`references/source-map.md`](./references/source-map.md).
+
+## Test / verify loop
+
+```bash
+poetry run python -m unittest tests/test_path_security.py -v   # the existing suite
+```
+
+Coverage is thin (path security only) — for behavior changes, smoke-test via
+`examples/server_examples.py` / `examples/sdk_examples.py` against a small
+CLIP model: [`references/testing.md`](./references/testing.md).
+
+## Build from source
+
+```bash
+export EMBEDDING_MODEL_NAME="CLIP/clip-vit-b-32"
+source setup.sh                                   # sourced; hard-fails without the model name
+docker compose -f docker/compose.yaml build
+docker compose -f docker/compose.yaml up -d
+```
+
+## Debug a running instance
+
+1. `docker logs -f multimodal-embedding-serving` — model load, conversion,
+   request logs (server runs `--log-level debug`).
+2. `curl -s localhost:9777/model/current` and `/model/capabilities` — ground
+   truth for what's loaded.
+3. Slow first inference = lazy OpenVINO export/compile into
+   `EMBEDDING_OV_MODELS_DIR` (`/app/ov_models`); cached afterwards in the
+   `ov-models` volume.
+
+## Contribution gotchas
+
+| Gotcha | Consequence |
+|---|---|
+| `src/wrapper.py` is a **path dependency of vdms-dataprep** (`visual-data-preparation-for-retrieval/vdms`) | API changes there ripple into that service — check its usage before changing signatures |
+| Package is built as a wheel (`poetry build`; `packages` maps `src/` → `multimodal_embedding_serving`) | keep new modules importable under the package name; SDK users import from it |
+| `INFER_BATCH_SIZE` compiles OpenVINO models to a fixed batch shape | handler changes must keep the pad/split logic intact |
+| QwenText handlers are text-only by design | don't "fix" the 400 for images; capability flags live on the handler |
+| Every new file needs the SPDX header | CI/license scans fail otherwise |

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/evals/evals.json
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/evals/evals.json
@@ -4,29 +4,32 @@
   "skill_name": "multimodal-embedding-serving-dev",
   "evals": [
     {
-      "id": "add-model-family",
+      "id": 1,
+      "name": "add-model-family",
       "prompt": "I want to add a new 'JinaCLIP' model family to the multimodal-embedding-serving microservice in my edge-ai-libraries checkout. Which files do I need to touch?",
       "expected_output": "The registry-pattern checklist: a new handler in src/models/handlers/ subclassing BaseEmbeddingModel (copy clip_handler.py), registration in src/models/registry.py, and model entries in MODEL_CONFIGS in src/models/config.py.",
-      "assertions": [
+      "expectations": [
         "Names src/models/handlers/ as the location for a new handler subclassing BaseEmbeddingModel",
         "Mentions registering the handler in src/models/registry.py",
         "Mentions adding model entries to MODEL_CONFIGS in src/models/config.py"
       ]
     },
     {
-      "id": "run-existing-tests",
+      "id": 2,
+      "name": "run-existing-tests",
       "prompt": "Run the automated tests for the multimodal-embedding-serving microservice in this checkout and summarize the coverage situation honestly.",
       "expected_output": "Runs tests/test_path_security.py (unittest or pytest), reports results, and states that this path-security suite is the only automated coverage — handlers and routes are untested.",
-      "assertions": [
+      "expectations": [
         "Runs tests/test_path_security.py via python -m unittest or pytest",
         "States that path security is the only area with automated test coverage"
       ]
     },
     {
-      "id": "negative-consume-routing",
+      "id": 3,
+      "name": "negative-consume-routing",
       "prompt": "My Node.js app needs to call the multimodal embedding service over HTTP. Get me set up.",
       "expected_output": "Recognizes this as consumption, not development: deploys/verifies the service and provides the REST request shapes for a Node client, without modifying the service source.",
-      "assertions": [
+      "expectations": [
         "Does not modify the microservice source code for this request",
         "Provides the POST /embeddings request shape usable over REST (not the Python SDK)"
       ]

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/evals/evals.json
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/evals/evals.json
@@ -4,45 +4,31 @@
   "skill_name": "multimodal-embedding-serving-dev",
   "evals": [
     {
-      "id": "add-model-family-navigation",
-      "prompt": "I want to add support for a new 'JinaCLIP' embedding model family to the multimodal-embedding-serving microservice in my edge-ai-libraries checkout. Walk me through exactly which files I need to touch and in what order.",
-      "expected_output": "The registry-pattern checklist: new handler in src/models/handlers/ subclassing BaseEmbeddingModel (clip_handler.py as template), registration in MODEL_HANDLER_REGISTRY in src/models/registry.py, entries in MODEL_CONFIGS in src/models/config.py, dependency placement (pyproject vs Dockerfile), setup.sh known-model case + supported-models.md doc update, and a smoke test via /models + /embeddings.",
+      "id": "add-model-family",
+      "prompt": "I want to add a new 'JinaCLIP' model family to the multimodal-embedding-serving microservice in my edge-ai-libraries checkout. Which files do I need to touch?",
+      "expected_output": "The registry-pattern checklist: a new handler in src/models/handlers/ subclassing BaseEmbeddingModel (copy clip_handler.py), registration in src/models/registry.py, and model entries in MODEL_CONFIGS in src/models/config.py.",
       "assertions": [
         "Names src/models/handlers/ as the location for a new handler subclassing BaseEmbeddingModel",
-        "Mentions registering the handler in src/models/registry.py (MODEL_HANDLER_REGISTRY or register_model_handler)",
-        "Mentions adding the model entries to MODEL_CONFIGS in src/models/config.py",
-        "Recommends clip_handler.py (or another existing handler) as the pattern to copy",
-        "Includes updating user-facing model docs or setup.sh model validation as part of the change"
+        "Mentions registering the handler in src/models/registry.py",
+        "Mentions adding model entries to MODEL_CONFIGS in src/models/config.py"
       ]
     },
     {
       "id": "run-existing-tests",
-      "prompt": "Run whatever automated tests exist for the multimodal-embedding-serving microservice in this checkout and summarize the coverage situation honestly.",
-      "expected_output": "Runs tests/test_path_security.py via unittest (or pytest), reports results, and states plainly that this path-security suite is the only automated coverage — handlers/wrapper/routes are untested, with smoke-testing via examples/ as the practical alternative.",
+      "prompt": "Run the automated tests for the multimodal-embedding-serving microservice in this checkout and summarize the coverage situation honestly.",
+      "expected_output": "Runs tests/test_path_security.py (unittest or pytest), reports results, and states that this path-security suite is the only automated coverage — handlers and routes are untested.",
       "assertions": [
-        "Runs tests/test_path_security.py via python -m unittest or pytest within the poetry environment",
-        "States that path security is the only area with automated tests (no handler/wrapper/route coverage)",
-        "Mentions examples/sdk_examples.py or examples/server_examples.py as the smoke-test path for broader verification"
-      ]
-    },
-    {
-      "id": "mobileclip-import-edge",
-      "prompt": "In my local poetry environment for multimodal-embedding-serving, creating a MobileCLIP handler dies with ModuleNotFoundError: No module named 'mobileclip'. But the same model works fine when I run the Docker image. Why?",
-      "expected_output": "Diagnosis: mobileclip (and salesforce-lavis for Blip2) are pip-installed only in docker/Dockerfile, not declared in pyproject.toml, so poetry install never brings them in. Options: develop those families against the container, or manually pip-install the git dependency into the env.",
-      "assertions": [
-        "Identifies that mobileclip is installed only in the Docker image (docker/Dockerfile), not via pyproject.toml/poetry",
-        "Notes salesforce-lavis/Blip2 has the same container-only dependency situation",
-        "Recommends developing/testing MobileCLIP against the container or manually installing the dependency, not adding random PyPI packages blindly"
+        "Runs tests/test_path_security.py via python -m unittest or pytest",
+        "States that path security is the only area with automated test coverage"
       ]
     },
     {
       "id": "negative-consume-routing",
-      "prompt": "My Node.js order-search app needs to call the multimodal embedding service over HTTP. Get me set up.",
-      "expected_output": "Recognizes this is consumption, not development: deploys/verifies the service (compose or prebuilt image), provides the REST endpoint shapes for a Node client, and does not modify the service source or run its test suite.",
+      "prompt": "My Node.js app needs to call the multimodal embedding service over HTTP. Get me set up.",
+      "expected_output": "Recognizes this as consumption, not development: deploys/verifies the service and provides the REST request shapes for a Node client, without modifying the service source.",
       "assertions": [
         "Does not modify the microservice source code for this request",
-        "Provides or verifies a running service plus the POST /embeddings request shape usable from Node.js (REST, not the Python SDK)",
-        "Checks or mentions the /health endpoint before use"
+        "Provides the POST /embeddings request shape usable over REST (not the Python SDK)"
       ]
     }
   ]

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/evals/evals.json
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/evals/evals.json
@@ -1,0 +1,49 @@
+{
+  "SPDX-FileCopyrightText": "(C) 2026 Intel Corporation",
+  "SPDX-License-Identifier": "Apache-2.0",
+  "skill_name": "multimodal-embedding-serving-dev",
+  "evals": [
+    {
+      "id": "add-model-family-navigation",
+      "prompt": "I want to add support for a new 'JinaCLIP' embedding model family to the multimodal-embedding-serving microservice in my edge-ai-libraries checkout. Walk me through exactly which files I need to touch and in what order.",
+      "expected_output": "The registry-pattern checklist: new handler in src/models/handlers/ subclassing BaseEmbeddingModel (clip_handler.py as template), registration in MODEL_HANDLER_REGISTRY in src/models/registry.py, entries in MODEL_CONFIGS in src/models/config.py, dependency placement (pyproject vs Dockerfile), setup.sh known-model case + supported-models.md doc update, and a smoke test via /models + /embeddings.",
+      "assertions": [
+        "Names src/models/handlers/ as the location for a new handler subclassing BaseEmbeddingModel",
+        "Mentions registering the handler in src/models/registry.py (MODEL_HANDLER_REGISTRY or register_model_handler)",
+        "Mentions adding the model entries to MODEL_CONFIGS in src/models/config.py",
+        "Recommends clip_handler.py (or another existing handler) as the pattern to copy",
+        "Includes updating user-facing model docs or setup.sh model validation as part of the change"
+      ]
+    },
+    {
+      "id": "run-existing-tests",
+      "prompt": "Run whatever automated tests exist for the multimodal-embedding-serving microservice in this checkout and summarize the coverage situation honestly.",
+      "expected_output": "Runs tests/test_path_security.py via unittest (or pytest), reports results, and states plainly that this path-security suite is the only automated coverage — handlers/wrapper/routes are untested, with smoke-testing via examples/ as the practical alternative.",
+      "assertions": [
+        "Runs tests/test_path_security.py via python -m unittest or pytest within the poetry environment",
+        "States that path security is the only area with automated tests (no handler/wrapper/route coverage)",
+        "Mentions examples/sdk_examples.py or examples/server_examples.py as the smoke-test path for broader verification"
+      ]
+    },
+    {
+      "id": "mobileclip-import-edge",
+      "prompt": "In my local poetry environment for multimodal-embedding-serving, creating a MobileCLIP handler dies with ModuleNotFoundError: No module named 'mobileclip'. But the same model works fine when I run the Docker image. Why?",
+      "expected_output": "Diagnosis: mobileclip (and salesforce-lavis for Blip2) are pip-installed only in docker/Dockerfile, not declared in pyproject.toml, so poetry install never brings them in. Options: develop those families against the container, or manually pip-install the git dependency into the env.",
+      "assertions": [
+        "Identifies that mobileclip is installed only in the Docker image (docker/Dockerfile), not via pyproject.toml/poetry",
+        "Notes salesforce-lavis/Blip2 has the same container-only dependency situation",
+        "Recommends developing/testing MobileCLIP against the container or manually installing the dependency, not adding random PyPI packages blindly"
+      ]
+    },
+    {
+      "id": "negative-consume-routing",
+      "prompt": "My Node.js order-search app needs to call the multimodal embedding service over HTTP. Get me set up.",
+      "expected_output": "Recognizes this is consumption, not development: deploys/verifies the service (compose or prebuilt image), provides the REST endpoint shapes for a Node client, and does not modify the service source or run its test suite.",
+      "assertions": [
+        "Does not modify the microservice source code for this request",
+        "Provides or verifies a running service plus the POST /embeddings request shape usable from Node.js (REST, not the Python SDK)",
+        "Checks or mentions the /health endpoint before use"
+      ]
+    }
+  ]
+}

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/example-prompts/onboard-new-model.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/example-prompts/onboard-new-model.md
@@ -1,0 +1,15 @@
+Onboard a new image+text embedding model family into this service so it is selectable over both the REST API and the SDK.
+
+- Add a handler under src/models/handlers/ implementing load_model, encode_text, and encode_image (PyTorch path; optional OpenVINO path).
+- Register the family in src/models/registry.py and add its model ids (Family/name form) to the registry in src/models/config.py.
+- Keep the new module importable under the packaged name so SDK users (multimodal_embedding_serving) get it too.
+- Do not change src/wrapper.py's public API — it is a path dependency of vdms-dataprep. Add the SPDX header to any new file.
+
+Validate the change using:
+- Select the new model via EMBEDDING_MODEL_NAME and confirm it appears in GET /models on http://localhost:9777.
+- Embed one text and one image against the new model.
+- Run: poetry run python -m unittest tests/test_path_security.py -v
+
+Expected results:
+- The new family loads, appears in GET /models, and returns one flat vector for text and one for image.
+- The existing test suite still passes and src/wrapper.py's signatures are unchanged.

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/example-prompts/update-test-cases.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/example-prompts/update-test-cases.md
@@ -1,0 +1,14 @@
+Update the test suite so a newly onboarded embedding model family is covered and future changes can't silently break it.
+
+- Add or extend tests that exercise the new handler's encode_text and (if multimodal) encode_image.
+- Assert a batch of N inputs returns N equal-length vectors (locks in the OpenVINO fixed-batch pad/split path).
+- Keep the tests offline and CPU-only, matching the existing suite's style. Add the SPDX header to any new test file.
+
+Validate the change using:
+- The newly onboarded family (a small variant).
+- A batch of 3 text inputs in one POST /embeddings call.
+- Run: poetry run python -m unittest from the microservice root.
+
+Expected results:
+- New tests pass: text (and image, if supported) return correctly shaped vectors; 3 inputs yield 3 equal-length vectors.
+- The full existing suite still passes.

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/references/source-map.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/references/source-map.md
@@ -1,0 +1,64 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Source map — Multimodal Embedding Serving
+
+## Request flow
+
+```
+src/app.py            routes + Pydantic input union; @app.on_event("startup")
+                      loads the model via the factory; globals embedding_model,
+                      health_status
+  └─ src/wrapper.py   EmbeddingModel — embed_query / embed_documents /
+                      get_image_embedding_from_url|base64 /
+                      get_video_embedding(s)_from_* / check_health /
+                      modality helpers.  ← SDK surface too
+      └─ src/models/registry.py   ModelFactory + MODEL_HANDLER_REGISTRY,
+                                  get_model_handler(), register_model_handler(),
+                                  is_model_supported()
+          └─ src/models/handlers/<family>_handler.py
+                                  load_model / encode_text / encode_image;
+                                  PyTorch path + optional OpenVINO path
+```
+
+## Key modules
+
+| Path | Contents |
+|---|---|
+| `src/models/config.py` | `MODEL_CONFIGS` — the 19-model registry; `get_model_config()` injects device/OV/batch settings from env; `list_available_models()` |
+| `src/models/base.py` | `BaseEmbeddingModel` ABC: abstract `load_model`/`encode_text`/`encode_image`/`convert_to_openvino`; capability hooks `supports_text/image/video`; instruction hooks `prepare_query/documents`; `get_embedding_dim` (default 512) |
+| `src/models/handlers/` | `clip_handler.py` (reference implementation: open_clip PyTorch path + `optimum.intel.OVModelOpenCLIPVisual/Text` OV path), `cn_clip_handler.py`, `mobileclip_handler.py`, `siglip_handler.py`, `blip2_handler.py`, `blip2_transformers_handler.py`, `qwen_handler.py` (text-only, `OVModelForFeatureExtraction`, instruction template + last-token pooling) |
+| `src/models/utils/openvino_utils.py` | `check_and_convert_openvino_models()`, `load_openvino_models()`, `AsyncBatchInference` (AsyncInferQueue streaming) |
+| `src/utils/common.py` | pydantic `Settings` (note: falls back to `_env_file=None` for SDK use), `ErrorMessages`, logger |
+| `src/utils/utils.py` | `download_image/video`, `decode_base64_*`, `validate_remote_media_url` (SSRF checks), `ParallelImagePreprocessor`, proxy bypass |
+| `src/utils/decoder.py` | `extract_batched_frames` — shared-memory-pool video frame pipeline |
+| `src/utils/path_security.py` | filename/extension allowlists; sandbox root `/tmp/videoQnA` for `video_file`/`frames_batch` |
+
+## Adding a model family (checklist)
+
+1. Create `src/models/handlers/<family>_handler.py` subclassing
+   `BaseEmbeddingModel`; implement `load_model`, `encode_text`,
+   `encode_image` (and OV conversion if supported). Copy `clip_handler.py`
+   as the template.
+2. Register the handler class in `MODEL_HANDLER_REGISTRY`
+   (`src/models/registry.py`).
+3. Add entries to `MODEL_CONFIGS` in `src/models/config.py` (model id
+   `Family/name`, weights source, dim, handler class name, capabilities).
+4. If the family needs new pip deps: add to `pyproject.toml` if on PyPI;
+   otherwise install in `docker/Dockerfile` (like mobileclip) and document
+   that the family is container-only.
+5. Update `setup.sh`'s known-model `case` (it warns on unknown ids) and
+   `docs/user-guide/supported-models.md`.
+6. Smoke-test: `GET /models` lists it, `GET /model/capabilities` is right,
+   one `POST /embeddings` per supported modality.
+
+## Config & scripts
+
+- `docker/Dockerfile` — two-stage python:3.12-slim; pip-installs
+  `git+…ml-mobileclip` and `salesforce-lavis==1.0.2 --no-deps`; single-worker
+  gunicorn CMD with `--timeout 300 --log-level debug`.
+- `setup.sh` — env defaults, model-name validation, volume creation, GPU →
+  OV auto-enable.
+- `logging.conf` — logger configuration loaded by the app.

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/references/testing.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-dev/references/testing.md
@@ -1,0 +1,51 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Testing — Multimodal Embedding Serving
+
+## What exists today
+
+```bash
+poetry run python -m unittest tests/test_path_security.py -v
+# or: poetry run pytest tests/  (pytest runs unittest cases fine; no pytest.ini here)
+```
+
+`tests/test_path_security.py` covers the `/tmp/videoQnA` sandbox
+(`src/utils/path_security.py`): filename validation, extension allowlists,
+traversal rejection. That is the **entire** automated suite — model handlers,
+wrapper, and routes have no unit tests.
+
+## Smoke-testing changes (recommended for any behavior change)
+
+Fast in-process check with a small model (downloads `CLIP/clip-vit-b-32` on
+first run):
+
+```bash
+poetry run python examples/sdk_examples.py       # SDK path: handler + EmbeddingModel
+```
+
+Full server check:
+
+```bash
+export EMBEDDING_MODEL_NAME="CLIP/clip-vit-b-32"
+source setup.sh && docker compose -f docker/compose.yaml up -d --build
+until curl -sf localhost:9777/health; do sleep 5; done
+poetry run python examples/server_examples.py    # exercises the REST endpoints
+docker compose -f docker/compose.yaml down
+```
+
+## Adding tests
+
+- Follow the existing `unittest.TestCase` style in `tests/` (class per area,
+  `test_*` methods); pytest also collects these.
+- Keep unit tests offline: patch `download_image`, handler `load_model`, and
+  anything touching huggingface.co. Loading a real model in a unit test makes
+  the suite unusably slow.
+- Good first targets when touching related code: the `/embeddings` input
+  union validation (`TestClient(app)` with a mocked `embedding_model` global),
+  `src/models/registry.py` lookup/registration, `segment_config` priority
+  handling in `src/utils/decoder.py`.
+- Test the **wrapper API** (`EmbeddingModel`) when changing it — it is the
+  SDK contract consumed by vdms-dataprep.

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/SKILL.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/SKILL.md
@@ -9,10 +9,6 @@ description: >
   QwenText), or integrate in-process via the Python SDK wheel. Use when an app
   needs embeddings for similarity search or retrieval. Not for modifying the
   service's source — that is multimodal-embedding-serving-dev.
-argument-hint: >
-  Describe what you want to deploy or embed (e.g. "bring up a CLIP model and
-  embed this image URL", or "sample 16 frames from this mp4 and return
-  per-frame vectors")
 ---
 
 # Multimodal Embedding Serving — User

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/SKILL.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: multimodal-embedding-serving-user
+description: >
+  Deploy and consume the Multimodal Embedding Serving microservice — bring it
+  up with setup.sh + docker compose (from a repo clone, or by fetching those
+  same files from GitHub when no clone exists) using the prebuilt
+  intel/multimodal-embedding-serving image, embed text/images/videos over REST
+  on port 9777, choose among 19 models (CLIP/SigLIP/MobileCLIP/CN-CLIP/Blip2/
+  QwenText), or integrate in-process via the Python SDK wheel. Use when an app
+  needs embeddings for similarity search or retrieval. Not for modifying the
+  service's source — that is multimodal-embedding-serving-dev.
+argument-hint: >
+  Describe what you want to deploy or embed (e.g. "bring up a CLIP model and
+  embed this image URL", or "sample 16 frames from this mp4 and return
+  per-frame vectors")
+---
+
+# Multimodal Embedding Serving — User
+
+Run and call the embedding service. **Run commands yourself** and relay
+output. REST base URL: `http://localhost:9777` (host port hardcoded by
+setup.sh; container 8000).
+
+## When to Use
+
+- Deploy the embedding service (Docker Compose or standalone) and confirm health
+- Embed text, images, or videos over REST on port 9777
+- Choose or switch among the CLIP/SigLIP/MobileCLIP/CN-CLIP/Blip2/QwenText models
+- Integrate embeddings in-process via the Python SDK wheel
+- Diagnose 400/422 errors or model-capability mismatches
+
+## Example Prompts
+
+Sample Problem-solving scenarios this skill handles end-to-end:
+
+| Example | Problem it solves |
+|---|---|
+| [image-similarity-finder.md](./example-prompts/image-similarity-finder.md) | Find visually/semantically similar images in a local folder |
+| [text-to-image-search.md](./example-prompts/text-to-image-search.md) | Search an image folder with natural-language queries ("Google Lens" for local media) |
+| [image-duplicate-detector.md](./example-prompts/image-duplicate-detector.md) | Flag duplicate / near-duplicate images in a folder for cleanup, QC, and dataset deduplication |
+
+## Docs & deploy files — with or without a clone
+
+All paths below are relative to `microservices/multimodal-embedding-serving/`
+in the
+[edge-ai-libraries](https://github.com/open-edge-platform/edge-ai-libraries)
+repo. **No clone?** Fetch any of them from GitHub raw:
+
+```
+https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/main/microservices/multimodal-embedding-serving/<path>
+```
+
+Load these existing docs only when needed:
+
+| Resource | Load when… |
+|---|---|
+| `docs/user-guide/api-reference.md` + `docs/user-guide/api-docs/openapi.yaml` | building non-text payloads (image/video, base64, `segment_config`) or parsing responses/errors |
+| `docs/user-guide/supported-models.md` | choosing or switching models (dimensions, modalities, language, size) |
+| `docs/user-guide/sdk-usage.md` + `docs/user-guide/wheel-installation.md` | integrating in-process via the Python SDK wheel |
+| `docs/user-guide/get-started.md` | more curl examples and env-var tables |
+| `setup.sh`, `docker/compose.yaml` | the deploy artifacts used below |
+
+## 1. Context routing — repo clone or standalone? REST or SDK?
+
+- **In-process Python integration wanted** (no separate server): the service
+  doubles as an SDK — build the wheel with `poetry build` (needs the repo) and
+  use `get_model_handler(...)` + `EmbeddingModel`; see
+  `docs/user-guide/sdk-usage.md`. Rule of thumb: default to REST; pick the SDK
+  when a Python process embeds heavily and an HTTP hop per item would
+  dominate. Note: MobileCLIP/Blip2 extras exist only in the Docker image, and
+  the wheel is not on PyPI.
+- Otherwise detect a clone:
+  ```bash
+  [ -f setup.sh ] && grep -q 'name = "multimodal-embedding-serving"' pyproject.toml 2>/dev/null \
+    && echo REPO || echo STANDALONE
+  ```
+  **REPO** → Step 2 from the microservice root. **STANDALONE** → fetch the two
+  deploy files, then the exact same Step 2:
+  ```bash
+  RAW=https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/main/microservices/multimodal-embedding-serving
+  mkdir -p embedding-serving/docker && cd embedding-serving
+  curl -fsSL $RAW/setup.sh -o setup.sh
+  curl -fsSL $RAW/docker/compose.yaml -o docker/compose.yaml
+  ```
+  Already running (`curl -sf localhost:9777/health`) → Step 3.
+
+## 2. Bring-up (identical in both contexts)
+
+1. Pick a model — default `CLIP/clip-vit-b-32` (512-dim, text+image+video).
+   Trade-offs: `docs/user-guide/supported-models.md`.
+2. `setup.sh` must be **sourced** and hard-fails without
+   `EMBEDDING_MODEL_NAME`. `REGISTRY_URL=intel` selects the prebuilt image;
+   `--no-build` prevents a source build. Run in the background — first start
+   downloads the model:
+   ```bash
+   bash -c 'export EMBEDDING_MODEL_NAME="CLIP/clip-vit-b-32" REGISTRY_URL=intel TAG=latest \
+     && source setup.sh && docker compose -f docker/compose.yaml up -d --no-build'
+   ```
+   Intel GPU: also `export EMBEDDING_DEVICE=GPU` (setup.sh then auto-enables
+   OpenVINO + THROUGHPUT mode).
+3. Wait for readiness:
+   ```bash
+   until curl -sf http://localhost:9777/health; do sleep 5; done
+   ```
+
+## 3. Capability check (mandatory before non-text inputs)
+
+```bash
+curl -s http://localhost:9777/model/capabilities
+```
+
+QwenText models are **text-only** — image/video requests return 400. `GET
+/model/current` shows the exact loaded model id to use in requests.
+
+## 4. Embed
+
+Text (single string or list of strings):
+
+```bash
+curl -s http://localhost:9777/embeddings -H 'Content-Type: application/json' -d '{
+  "model": "CLIP/clip-vit-b-32",
+  "input": {"type": "text", "text": "a red truck at a loading dock"},
+  "encoding_format": "float"
+}'
+```
+
+Response: `{"embedding": [...]}` — a flat vector for text/image; a **list of
+per-frame vectors** for video inputs.
+
+- `model` must equal the loaded model (else 400).
+- Image: `{"type":"image_url","image_url":"https://…"}` (plain string, not a
+  nested object) or `image_base64`. Video: `video_url`/`video_base64`/
+  `video_frames` with `segment_config` (`num_frames` default 64,
+  `extraction_fps`, `frame_indexes`) — full shapes and examples:
+  `docs/user-guide/api-reference.md`.
+
+## 5. Stop / clean
+
+- `docker compose -f docker/compose.yaml down`
+- Volumes `ov-models` (model caches) and `data-prep` persist; removing them
+  forces re-downloads — **confirm with the user first**.
+
+## Troubleshooting
+
+| Symptom | Likely cause → action |
+|---|---|
+| `source setup.sh` prints ERROR and stops | `EMBEDDING_MODEL_NAME` not exported → export it first |
+| No response on 9777 | still starting/downloading → `docker logs -f multimodal-embedding-serving` |
+| 400 "model mismatch" | request `model` ≠ loaded model → `GET /model/current` |
+| 400 unsupported modality on image/video | text-only model (QwenText) → switch model or send text |
+| First non-text request slow | lazy OpenVINO conversion/compile → expected once |
+| 422 on `/embeddings` | malformed `input` union → check shapes in `docs/user-guide/api-reference.md` |
+| Port 9777 busy | stop the conflicting service (`EMBEDDING_SERVER_PORT` is hardcoded by setup.sh) |

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/evals/evals.json
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/evals/evals.json
@@ -4,49 +4,54 @@
   "skill_name": "multimodal-embedding-serving-user",
   "evals": [
     {
-      "id": "bringup-and-health",
+      "id": 1,
+      "name": "bringup-and-health",
       "prompt": "Get Intel's multimodal embedding service running locally with the CLIP/clip-vit-b-32 model and verify it is healthy.",
       "expected_output": "Sets EMBEDDING_MODEL_NAME=CLIP/clip-vit-b-32, uses the prebuilt intel image (REGISTRY_URL=intel) with docker compose up -d, and verifies with GET http://localhost:9777/health.",
-      "assertions": [
+      "expectations": [
         "Sets EMBEDDING_MODEL_NAME to CLIP/clip-vit-b-32 before starting the service",
         "Starts the service from the prebuilt intel image via docker compose (no source build)",
         "Verifies readiness with GET /health on port 9777"
       ]
     },
     {
-      "id": "text-embedding-request",
+      "id": 2,
+      "name": "text-embedding-request",
       "prompt": "The embedding service is running on localhost:9777 with CLIP/clip-vit-b-32. Show me the exact request to embed the text 'a forklift in a warehouse'.",
       "expected_output": "A POST /embeddings with JSON body {input: {type: 'text', text: '...'}, model: 'CLIP/clip-vit-b-32'}, returning an embedding vector.",
-      "assertions": [
+      "expectations": [
         "Sends POST /embeddings with input shaped as {type: 'text', text: ...}",
         "Includes a model field matching the loaded model (CLIP/clip-vit-b-32)"
       ]
     },
     {
-      "id": "video-url-embedding-request",
+      "id": 3,
+      "name": "video-url-embedding-request",
       "prompt": "The embedding service is running on localhost:9777 with CLIP/clip-vit-b-32. Give me the request to embed the video at https://example.com/cam.mp4 sampling 16 frames, and tell me what the response looks like.",
       "expected_output": "A POST /embeddings with input type video_url (video_url as a plain string) and segment_config {num_frames: 16}; the response contains one vector per sampled frame, not a single flat vector.",
-      "assertions": [
+      "expectations": [
         "Uses input type video_url with video_url as a plain string field",
         "Sets num_frames to 16 inside segment_config",
         "States the response holds a list of per-frame vectors, not one flat vector"
       ]
     },
     {
-      "id": "model-capabilities-check",
+      "id": 4,
+      "name": "model-capabilities-check",
       "prompt": "Image requests to my embedding service return HTTP 400, but text requests work. It's running QwenText/qwen3-embedding-0.6b. What's wrong?",
       "expected_output": "Nothing is broken: QwenText models are text-only, so image inputs are rejected by design. Points to GET /model/capabilities to check supported modalities and suggests a multimodal model (e.g. CLIP or SigLIP) if images are needed.",
-      "assertions": [
+      "expectations": [
         "Explains QwenText models are text-only and the 400 is expected, not a service fault",
         "References GET /model/capabilities to check supported modalities",
         "Suggests a multimodal model family (e.g. CLIP or SigLIP) for image embedding"
       ]
     },
     {
-      "id": "negative-summarization-routing",
+      "id": 5,
+      "name": "negative-summarization-routing",
       "prompt": "Use the multimodal embedding service to give me a text summary of this warehouse video.",
       "expected_output": "Declines: the service returns embedding vectors, not text descriptions. Points to a vision-language model (e.g. vlm-openvino-serving) for summarization.",
-      "assertions": [
+      "expectations": [
         "Does not claim the embedding service can produce a text summary",
         "Explains embeddings are vectors for similarity/retrieval, not descriptions",
         "Points to a VLM or summarization pipeline as the right tool"

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/evals/evals.json
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/evals/evals.json
@@ -4,55 +4,52 @@
   "skill_name": "multimodal-embedding-serving-user",
   "evals": [
     {
-      "id": "standalone-bringup-and-text-embed",
-      "prompt": "My retrieval prototype needs an embedding endpoint. I don't have any Intel repos cloned. Get Intel's multimodal embedding service running locally with a small CLIP model and show me it works by embedding the sentence 'forklift moving pallets in a warehouse'.",
-      "expected_output": "Bring-up from the prebuilt intel/multimodal-embedding-serving image without a full repo clone or source build — e.g. fetching setup.sh + docker/compose.yaml from GitHub raw, exporting REGISTRY_URL=intel, and running docker compose up -d --no-build (or an equivalent docker run) — with EMBEDDING_MODEL_NAME set to a CLIP model, health polled on port 9777, then a POST /embeddings with input {type: text, text: ...} returning a vector.",
+      "id": "bringup-and-health",
+      "prompt": "Get Intel's multimodal embedding service running locally with the CLIP/clip-vit-b-32 model and verify it is healthy.",
+      "expected_output": "Sets EMBEDDING_MODEL_NAME=CLIP/clip-vit-b-32, uses the prebuilt intel image (REGISTRY_URL=intel) with docker compose up -d, and verifies with GET http://localhost:9777/health.",
       "assertions": [
-        "Uses the prebuilt intel/multimodal-embedding-serving image (e.g. REGISTRY_URL=intel with docker compose --no-build, or docker run) without building the image from source or requiring a full repo clone",
-        "Sets EMBEDDING_MODEL_NAME to a valid CLIP model id in Family/name format (e.g. CLIP/clip-vit-b-32)",
-        "Waits for GET /health on port 9777 before embedding",
-        "Sends POST /embeddings with a correctly shaped input union {type: 'text', text: ...} and a model field matching the loaded model"
+        "Sets EMBEDDING_MODEL_NAME to CLIP/clip-vit-b-32 before starting the service",
+        "Starts the service from the prebuilt intel image via docker compose (no source build)",
+        "Verifies readiness with GET /health on port 9777"
       ]
     },
     {
-      "id": "video-url-16-frames",
-      "prompt": "The embedding service is already up on localhost:9777 with CLIP/clip-vit-b-32. Give me the exact request to embed this video https://example.com/dock-cam.mp4 sampling exactly 16 frames, and tell me what shape the response will have.",
-      "expected_output": "A POST /embeddings request with input type video_url, video_url as a plain string, and segment_config {num_frames: 16, ...}; explains the response is a list of 16 per-frame vectors under the 'embedding' key (not one flat vector).",
+      "id": "text-embedding-request",
+      "prompt": "The embedding service is running on localhost:9777 with CLIP/clip-vit-b-32. Show me the exact request to embed the text 'a forklift in a warehouse'.",
+      "expected_output": "A POST /embeddings with JSON body {input: {type: 'text', text: '...'}, model: 'CLIP/clip-vit-b-32'}, returning an embedding vector.",
       "assertions": [
-        "Uses input type video_url with video_url as a plain string field (not a nested {url: ...} object)",
-        "Includes segment_config with num_frames set to 16",
-        "States the response contains a list of per-frame vectors (one per sampled frame), not a single flat vector"
+        "Sends POST /embeddings with input shaped as {type: 'text', text: ...}",
+        "Includes a model field matching the loaded model (CLIP/clip-vit-b-32)"
       ]
     },
     {
-      "id": "qwen-image-capability-edge",
-      "prompt": "We deployed the embedding service with QwenText/qwen3-embedding-0.6b because we liked its text quality. Now our image ingestion calls fail with HTTP 400. Is the service broken?",
-      "expected_output": "Not broken: QwenText models are text-only, so image/video inputs are rejected with 400 by design. Recommends checking GET /model/capabilities, and either switching to a multimodal model (CLIP/SigLIP/...) for images — noting existing text vectors would need re-ingestion since dimensions and space change — or running text-only.",
+      "id": "video-url-embedding-request",
+      "prompt": "The embedding service is running on localhost:9777 with CLIP/clip-vit-b-32. Give me the request to embed the video at https://example.com/cam.mp4 sampling 16 frames, and tell me what the response looks like.",
+      "expected_output": "A POST /embeddings with input type video_url (video_url as a plain string) and segment_config {num_frames: 16}; the response contains one vector per sampled frame, not a single flat vector.",
       "assertions": [
-        "Explains QwenText models are text-only and the 400 is expected behavior, not a service fault",
-        "References GET /model/capabilities as the way to verify supported modalities",
-        "Recommends a multimodal model family (CLIP, SigLIP, CN-CLIP, MobileCLIP, or Blip2) for image embedding",
-        "Mentions that switching models changes the embedding space/dimension so an existing vector index must be rebuilt or re-ingested"
+        "Uses input type video_url with video_url as a plain string field",
+        "Sets num_frames to 16 inside segment_config",
+        "States the response holds a list of per-frame vectors, not one flat vector"
       ]
     },
     {
-      "id": "sdk-integration-question",
-      "prompt": "Our Python batch pipeline embeds about 2 million product images a night. Calling an HTTP endpoint per image feels wasteful. Is there a way to use Intel's multimodal embedding code in-process?",
-      "expected_output": "Yes: the service doubles as a Python SDK — build the wheel with poetry build from the microservice directory and use get_model_handler(...) + EmbeddingModel for in-process embedding; notes the wheel is not on PyPI (needs the repo) and MobileCLIP/Blip2 extras are Docker-only.",
+      "id": "model-capabilities-check",
+      "prompt": "Image requests to my embedding service return HTTP 400, but text requests work. It's running QwenText/qwen3-embedding-0.6b. What's wrong?",
+      "expected_output": "Nothing is broken: QwenText models are text-only, so image inputs are rejected by design. Points to GET /model/capabilities to check supported modalities and suggests a multimodal model (e.g. CLIP or SigLIP) if images are needed.",
       "assertions": [
-        "Recommends the SDK/wheel path (multimodal_embedding_serving package) rather than optimizing HTTP calls",
-        "Shows or describes the get_model_handler + EmbeddingModel usage pattern",
-        "Notes the wheel is built from the repo with poetry build (not installed from PyPI)"
+        "Explains QwenText models are text-only and the 400 is expected, not a service fault",
+        "References GET /model/capabilities to check supported modalities",
+        "Suggests a multimodal model family (e.g. CLIP or SigLIP) for image embedding"
       ]
     },
     {
       "id": "negative-summarization-routing",
-      "prompt": "Can you use the multimodal embedding service to give me a text summary of what happens in this warehouse video?",
-      "expected_output": "Declines to misuse embeddings as a summarizer: the service returns vectors, not text descriptions. Points to a VLM (e.g. vlm-openvino-serving chat completions with video input) or a video summarization application instead.",
+      "prompt": "Use the multimodal embedding service to give me a text summary of this warehouse video.",
+      "expected_output": "Declines: the service returns embedding vectors, not text descriptions. Points to a vision-language model (e.g. vlm-openvino-serving) for summarization.",
       "assertions": [
         "Does not claim the embedding service can produce a text summary",
-        "Explains embeddings are numeric vectors for similarity/retrieval, not descriptions",
-        "Points to a vision-language model or summarization pipeline (e.g. vlm-openvino-serving) as the right tool"
+        "Explains embeddings are vectors for similarity/retrieval, not descriptions",
+        "Points to a VLM or summarization pipeline as the right tool"
       ]
     }
   ]

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/evals/evals.json
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/evals/evals.json
@@ -1,0 +1,59 @@
+{
+  "SPDX-FileCopyrightText": "(C) 2026 Intel Corporation",
+  "SPDX-License-Identifier": "Apache-2.0",
+  "skill_name": "multimodal-embedding-serving-user",
+  "evals": [
+    {
+      "id": "standalone-bringup-and-text-embed",
+      "prompt": "My retrieval prototype needs an embedding endpoint. I don't have any Intel repos cloned. Get Intel's multimodal embedding service running locally with a small CLIP model and show me it works by embedding the sentence 'forklift moving pallets in a warehouse'.",
+      "expected_output": "Bring-up from the prebuilt intel/multimodal-embedding-serving image without a full repo clone or source build — e.g. fetching setup.sh + docker/compose.yaml from GitHub raw, exporting REGISTRY_URL=intel, and running docker compose up -d --no-build (or an equivalent docker run) — with EMBEDDING_MODEL_NAME set to a CLIP model, health polled on port 9777, then a POST /embeddings with input {type: text, text: ...} returning a vector.",
+      "assertions": [
+        "Uses the prebuilt intel/multimodal-embedding-serving image (e.g. REGISTRY_URL=intel with docker compose --no-build, or docker run) without building the image from source or requiring a full repo clone",
+        "Sets EMBEDDING_MODEL_NAME to a valid CLIP model id in Family/name format (e.g. CLIP/clip-vit-b-32)",
+        "Waits for GET /health on port 9777 before embedding",
+        "Sends POST /embeddings with a correctly shaped input union {type: 'text', text: ...} and a model field matching the loaded model"
+      ]
+    },
+    {
+      "id": "video-url-16-frames",
+      "prompt": "The embedding service is already up on localhost:9777 with CLIP/clip-vit-b-32. Give me the exact request to embed this video https://example.com/dock-cam.mp4 sampling exactly 16 frames, and tell me what shape the response will have.",
+      "expected_output": "A POST /embeddings request with input type video_url, video_url as a plain string, and segment_config {num_frames: 16, ...}; explains the response is a list of 16 per-frame vectors under the 'embedding' key (not one flat vector).",
+      "assertions": [
+        "Uses input type video_url with video_url as a plain string field (not a nested {url: ...} object)",
+        "Includes segment_config with num_frames set to 16",
+        "States the response contains a list of per-frame vectors (one per sampled frame), not a single flat vector"
+      ]
+    },
+    {
+      "id": "qwen-image-capability-edge",
+      "prompt": "We deployed the embedding service with QwenText/qwen3-embedding-0.6b because we liked its text quality. Now our image ingestion calls fail with HTTP 400. Is the service broken?",
+      "expected_output": "Not broken: QwenText models are text-only, so image/video inputs are rejected with 400 by design. Recommends checking GET /model/capabilities, and either switching to a multimodal model (CLIP/SigLIP/...) for images — noting existing text vectors would need re-ingestion since dimensions and space change — or running text-only.",
+      "assertions": [
+        "Explains QwenText models are text-only and the 400 is expected behavior, not a service fault",
+        "References GET /model/capabilities as the way to verify supported modalities",
+        "Recommends a multimodal model family (CLIP, SigLIP, CN-CLIP, MobileCLIP, or Blip2) for image embedding",
+        "Mentions that switching models changes the embedding space/dimension so an existing vector index must be rebuilt or re-ingested"
+      ]
+    },
+    {
+      "id": "sdk-integration-question",
+      "prompt": "Our Python batch pipeline embeds about 2 million product images a night. Calling an HTTP endpoint per image feels wasteful. Is there a way to use Intel's multimodal embedding code in-process?",
+      "expected_output": "Yes: the service doubles as a Python SDK — build the wheel with poetry build from the microservice directory and use get_model_handler(...) + EmbeddingModel for in-process embedding; notes the wheel is not on PyPI (needs the repo) and MobileCLIP/Blip2 extras are Docker-only.",
+      "assertions": [
+        "Recommends the SDK/wheel path (multimodal_embedding_serving package) rather than optimizing HTTP calls",
+        "Shows or describes the get_model_handler + EmbeddingModel usage pattern",
+        "Notes the wheel is built from the repo with poetry build (not installed from PyPI)"
+      ]
+    },
+    {
+      "id": "negative-summarization-routing",
+      "prompt": "Can you use the multimodal embedding service to give me a text summary of what happens in this warehouse video?",
+      "expected_output": "Declines to misuse embeddings as a summarizer: the service returns vectors, not text descriptions. Points to a VLM (e.g. vlm-openvino-serving chat completions with video input) or a video summarization application instead.",
+      "assertions": [
+        "Does not claim the embedding service can produce a text summary",
+        "Explains embeddings are numeric vectors for similarity/retrieval, not descriptions",
+        "Points to a vision-language model or summarization pipeline (e.g. vlm-openvino-serving) as the right tool"
+      ]
+    }
+  ]
+}

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/example-prompts/image-duplicate-detector.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/example-prompts/image-duplicate-detector.md
@@ -1,0 +1,16 @@
+Build an image duplicate / near-duplicate detector using the multimodal embedding service (embeddings only — no LLM). It scans a folder of product images, CCTV frames, or documents and flags pairs with high similarity — useful for media cleanup, quality control, and dataset deduplication.
+
+- Bring the embedding service up if it isn't already (prebuilt image, CPU is fine).
+- Embed every image in the folder via POST /embeddings (input.type = image_base64 for local files, image_url for hosted ones), one request per image.
+- Compute pairwise cosine similarity across all image vectors.
+- Flag pairs above a similarity threshold — e.g. ≥ 0.99 exact/re-encoded duplicate, ≥ 0.95 near-duplicate (resized, cropped, watermarked, re-compressed); make both thresholds configurable.
+- Group flagged pairs into clusters and write duplicates.json: one entry per cluster with a kept file and its duplicates [{filename, similarity}], plus a list of unique images.
+
+Validate the application using:
+- Model CLIP/clip-vit-b-32 on http://localhost:9777.
+- A folder built from Intel's sample videos (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4): extract one frame each (ffmpeg) from 5–6 different videos (e.g. bottle-detection, store-aisle-detection, person-bicycle-car-detection, worker-zone-detection, classroom), then add an exact copy of one frame and a resized/re-compressed copy of another.
+
+Expected results:
+- The exact copy and the re-encoded copy are each paired with their original above the threshold; frames from different videos are not paired.
+- duplicates.json groups them into clusters with one keeper each and per-pair similarity scores.
+- All embeddings are 512-dim vectors and model in each request matches the loaded model.

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/example-prompts/image-similarity-finder.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/example-prompts/image-similarity-finder.md
@@ -1,0 +1,15 @@
+Build an image similarity finder using the multimodal embedding service (embeddings only — no LLM). Given a query image, it returns the most similar images from a local folder — catalogs, factory datasets, retail imagery, or surveillance snapshots.
+
+- Bring the embedding service up if it isn't already (prebuilt image, CPU is fine).
+- Embed every image in the folder via POST /embeddings (input.type = image_base64 for local files, image_url for hosted ones), one request per image, and keep {filename, vector} in an in-memory index — the service does not store vectors; add a local vector DB in the app layer if persistence is needed.
+- Embed the query image the same way and rank the folder by cosine similarity.
+- Print the top-5 matches with their scores.
+
+Validate the application using:
+- Model CLIP/clip-vit-b-32 on http://localhost:9777.
+- An image folder built from Intel's sample videos (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4): extract ~5 frames each (ffmpeg, e.g. -vf fps=1/3) from store-aisle-detection.mp4, person-bicycle-car-detection.mp4, and fruit-and-vegetable-detection.mp4.
+- One extracted store-aisle frame as the query image.
+
+Expected results:
+- The top matches for the store-aisle query are the other store-aisle frames, scoring clearly above frames from the other two videos.
+- All embeddings are 512-dim flat vectors and model in each request matches the loaded model.

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/example-prompts/text-to-image-search.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/example-prompts/text-to-image-search.md
@@ -1,0 +1,15 @@
+Build a text-to-image search demo — "Google Lens for a local folder" — using the multimodal embedding service (embeddings only — no LLM). The user types a phrase like "person wearing a red helmet" and gets the matching images back.
+
+- Bring the embedding service up if it isn't already (prebuilt image, CPU is fine); the model must be multimodal — confirm image support via GET /model/capabilities (QwenText models are text-only).
+- Embed every image in the folder once via POST /embeddings (input.type = image_base64 for local files) and keep {filename, vector} in an in-memory index — the service does not store vectors; add a local vector DB in the app layer if persistence is needed.
+- Embed each text query with the same model (input.type = text) and rank images by cosine similarity — CLIP text and image vectors share one embedding space.
+- Print the top-3 filenames with scores for each query.
+
+Validate the application using:
+- Model CLIP/clip-vit-b-32 on http://localhost:9777.
+- An image folder built from Intel's sample videos (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4): ~5 frames each (ffmpeg) from person-bicycle-car-detection.mp4, store-aisle-detection.mp4, and fruit-and-vegetable-detection.mp4.
+- Queries: "a person riding a bicycle on a street", "shelves in a store aisle", "fresh fruit and vegetables".
+
+Expected results:
+- Each query's top hits come from the matching video's frames (the bicycle query ranks person-bicycle-car frames first, and so on).
+- Text and image embeddings are both 512-dim and produced by the same loaded model; the script errors out rather than mixing models between corpus and query.

--- a/microservices/multimodal-embedding-serving/.github/skills/skill-catalog.json
+++ b/microservices/multimodal-embedding-serving/.github/skills/skill-catalog.json
@@ -1,0 +1,47 @@
+{
+  "SPDX-FileCopyrightText": "(C) 2026 Intel Corporation",
+  "SPDX-License-Identifier": "Apache-2.0",
+  "schemaVersion": "1.0",
+  "description": "Harness-neutral discovery catalog for Multimodal Embedding Serving workflow skills. Paths are relative to the microservice root.",
+  "skillsRoot": ".github/skills",
+  "skills": [
+    {
+      "name": "multimodal-embedding-serving-user",
+      "path": ".github/skills/multimodal-embedding-serving-user/SKILL.md",
+      "description": "Deploy and consume the multimodal embedding service: bring it up from a repo clone (setup.sh + compose) or standalone (prebuilt intel/multimodal-embedding-serving image), embed text/images/videos over REST on port 9777, pick the right model, or integrate in-process via the Python SDK wheel. Not for modifying the service's source (use multimodal-embedding-serving-dev).",
+      "triggers": [
+        "generate embeddings",
+        "embed text",
+        "embed an image",
+        "embed a video",
+        "similarity search embeddings",
+        "clip embeddings",
+        "run the embedding service",
+        "embedding sdk or rest",
+        "which embedding model"
+      ],
+      "requires": [
+        "docker",
+        "curl"
+      ]
+    },
+    {
+      "name": "multimodal-embedding-serving-dev",
+      "path": ".github/skills/multimodal-embedding-serving-dev/SKILL.md",
+      "description": "Develop the multimodal embedding service itself: Poetry install, run the existing tests, navigate the wrapper/registry/handler architecture, add a new model family, and build the image from source. Not for merely deploying or calling the API (use multimodal-embedding-serving-user).",
+      "triggers": [
+        "add a model handler",
+        "add an embedding model family",
+        "run the embedding tests",
+        "debug the embedding service code",
+        "build embedding service from source",
+        "mobileclip import fails"
+      ],
+      "requires": [
+        "repo clone",
+        "poetry",
+        "docker"
+      ]
+    }
+  ]
+}

--- a/microservices/multimodal-embedding-serving/AGENTS.md
+++ b/microservices/multimodal-embedding-serving/AGENTS.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Multimodal Embedding Serving — AI agents
+
+**Do not add project policy here.**
+
+- **All tools:** [`.github/copilot-instructions.md`](.github/copilot-instructions.md)
+- **Claude:** [`CLAUDE.md`](CLAUDE.md)
+- **Cursor:** [`.cursor/rules/multimodal-embedding-serving.mdc`](.cursor/rules/multimodal-embedding-serving.mdc)

--- a/microservices/multimodal-embedding-serving/CLAUDE.md
+++ b/microservices/multimodal-embedding-serving/CLAUDE.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Multimodal Embedding Serving — Claude
+
+**Do not add project policy here.**
+
+- **Canonical instructions:** [`.github/copilot-instructions.md`](.github/copilot-instructions.md)
+- **Skills:** [`.github/skills/`](.github/skills/)

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.cursor/rules/vdms-dataprep.mdc
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.cursor/rules/vdms-dataprep.mdc
@@ -1,0 +1,32 @@
+---
+description: VDMS DataPrep Cursor agent router — canonical instructions and workflow skills
+alwaysApply: true
+---
+
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+## Canonical instructions
+
+Read [.github/copilot-instructions.md](../../.github/copilot-instructions.md)
+first. Do not duplicate policy here.
+
+## Skills
+
+Discover workflow skills by reading the `SKILL.md` files under
+[.github/skills/](../../.github/skills/); prefer
+[skill-catalog.json](../../.github/skills/skill-catalog.json) for routing and
+do not assume a fixed list.
+
+## Cursor workflow
+
+- Prefer the service's real interfaces: `source ./setup.sh` (needs
+  `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` + `EMBEDDING_MODEL_NAME` exported),
+  `./build.sh` for image builds, and the REST API at
+  `http://localhost:6007/v1/dataprep`.
+- Never `docker build` from this directory — the build context is
+  `microservices/` (three levels up); always go through `./build.sh`.
+- Run commands yourself and relay results; keep changes minimal.
+- Commit or open PRs only when explicitly asked.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/copilot-instructions.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/copilot-instructions.md
@@ -42,10 +42,9 @@ container; `docker/compose-with-embedding.yaml` + `setup-with-embedding.sh`).
   them) and `EMBEDDING_MODEL_NAME` (e.g. `CLIP/clip-vit-b-32`) exported first.
 - Bare `source ./setup.sh` **builds from source** via `./build.sh`, then
   `docker compose -f docker/compose.yaml up -d --no-build`.
-- Subcommands: `--nd` (foreground), `--dev [--nd]` (dev overlay, live
-  reload), `--down`, `--conf`/`--conf-dev` (print resolved compose),
-  `--build`/`--build-dev`/`--build-lint`/`--build-test`/`--build-report`,
-  `lint [-a]`, `test [file]`.
+- Subcommands: `--nd` (foreground), `--down`, `--conf` (print resolved
+  compose), and `--build [tag]`. Tests and lint run directly through Poetry;
+  `setup.sh` has no test/lint or dev-overlay subcommands in this checkout.
 - **Never `docker build` from this directory** — the build context is
   `microservices/` (three levels up) because of the
   `../../multimodal-embedding-serving` path dependency. Always use
@@ -56,7 +55,7 @@ container; `docker/compose-with-embedding.yaml` + `setup-with-embedding.sh`).
 | Method | Path | Purpose |
 |---|---|---|
 | GET | `/health` | Service + embedding-backend status |
-| POST | `/videos/upload` | Multipart MP4 upload (≤500 MB) → store + embed |
+| POST | `/videos/upload` | Multipart MP4 upload → store + embed (currently buffers the full body) |
 | POST | `/videos/minio` | Embed a video already in MinIO (JSON body) |
 | POST | `/summary` | Embed a text summary with video time range |
 | POST | `/videos/rtsp` | Ingest RTSP streams (experimental; not in api-reference.md) |
@@ -71,13 +70,13 @@ container; `docker/compose-with-embedding.yaml` + `setup-with-embedding.sh`).
 |---|---|
 | `setup.sh` / `setup-with-embedding.sh` | Env + lifecycle entrypoints (source them). |
 | `build.sh` | The only sanctioned image build (context = `microservices/`). |
-| `docker/` | `compose.yaml` (sdk), `compose-with-embedding.yaml` (api), `compose-dev.yaml` (overlay), `Dockerfile`. |
+| `docker/` | `compose.yaml` (sdk), `compose-with-embedding.yaml` (api), `Dockerfile`. |
 | `src/main.py` | FastAPI app (`root_path=/v1/dataprep`); lifespan preloads SDK client + YOLOX, flushes the VDMS index on shutdown. |
 | `src/endpoints/` | One router package per API area. |
 | `src/core/embedding/` | The pipeline: `sdk_embedding_helper.py` (SDK mode), `simple_client.py` (api mode), `sdk_client.py` (VDMS writes via langchain-vdms), `decoder.py` (frame extraction). |
 | `src/core/object_detection/` | YOLOX detector + utils. |
 | `src/core/minio_client.py`, `src/common/settings.py` | Object storage client; pydantic Settings. |
-| `scripts/` | `tester.sh` (coverage ≥80%), `linter.sh` (black/isort), `entrypoint.sh`. |
+| `scripts/` | Container entrypoint and runtime helpers. |
 | `tests/` | 12 pytest files + `conftest.py` (mocked MinIO, TestClient). |
 
 ## Conventions
@@ -97,14 +96,13 @@ container; `docker/compose-with-embedding.yaml` + `setup-with-embedding.sh`).
   (new collection name or wipe), so confirm first.
 - **YOLOX downloads on first run** — without network, object detection is
   **silently disabled**.
-- `docker/compose.yaml` reads `DB_COLLECTION` from `VS_INDEX_NAME`, but
-  `setup.sh` exports `INDEX_NAME` — unless `VS_INDEX_NAME` is set, the
-  collection falls back to the code default `video-rag-test`
-  (`src/common/settings.py`).
+- `setup.sh` exports `INDEX_NAME=video-rag`; compose maps it to
+  `DB_COLLECTION`.
 - Volumes `vdms-yolox-models`, `ov-models`, `data-prep` hold model/scratch
   state; MinIO persists to `MINIO_MOUNT_PATH` (default `/mnt/miniodata`).
-- Uploads >500 MB are rejected (413) — stage big files in MinIO and use
-  `POST /videos/minio`.
+- A 413 may come from an upstream proxy/server; the source upload endpoint has
+  no implemented size check and buffers the full body. Stage large files in
+  MinIO and use `POST /videos/minio`.
 - Only MP4 is supported for embedding creation.
 
 ## Skills

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/copilot-instructions.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/copilot-instructions.md
@@ -1,0 +1,135 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# VDMS DataPrep — AI agents
+
+## Canonical Instructions
+
+Use this file as the canonical router for coding agents. Keep tool-specific
+files such as `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/vdms-dataprep.mdc`
+as short pointers to this file.
+
+## What This Service Is
+
+VDMS DataPrep ingests videos for retrieval: it extracts frames (optionally
+YOLOX object crops and text summaries), embeds them with a multimodal
+embedding model, and stores vectors + metadata in the **VDMS** vector DB;
+raw MP4s live in **MinIO**. It is one half of a video-RAG pipeline — ingestion
+only; search/query is a separate concern. Prebuilt image:
+`intel/vdms-dataprep:latest`. Deeper user docs live under
+[`docs/user-guide/`](../docs/user-guide/); this file is the agent-facing map.
+
+## The Stack
+
+| Service | Image | Host port → container |
+|---|---|---|
+| vdms-dataprep | `intel/vdms-dataprep:latest` (or local build) | `6007` → 8000, API under `/v1/dataprep` |
+| vdms-vector-db | `intellabs/vdms:v2.12.0` | `6020` → 55555 |
+| minio-server | MinIO | `6010` → 9000 (API), `6011` → 9001 (console) |
+| multimodal-embedding-serving | `intel/multimodal-embedding-serving` | `9777` → 8000 — **only in `api` embedding mode** |
+
+Two embedding modes (`EMBEDDING_PROCESSING_MODE`): **`sdk`** (default —
+embedding runs in-process via the `multimodal-embedding-serving` path
+dependency; `docker/compose.yaml`) and **`api`** (HTTP to a separate embedding
+container; `docker/compose-with-embedding.yaml` + `setup-with-embedding.sh`).
+
+## Run Interfaces
+
+- `setup.sh` must be **sourced**, never executed. It requires
+  `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD` (any strong values — never commit
+  them) and `EMBEDDING_MODEL_NAME` (e.g. `CLIP/clip-vit-b-32`) exported first.
+- Bare `source ./setup.sh` **builds from source** via `./build.sh`, then
+  `docker compose -f docker/compose.yaml up -d --no-build`.
+- Subcommands: `--nd` (foreground), `--dev [--nd]` (dev overlay, live
+  reload), `--down`, `--conf`/`--conf-dev` (print resolved compose),
+  `--build`/`--build-dev`/`--build-lint`/`--build-test`/`--build-report`,
+  `lint [-a]`, `test [file]`.
+- **Never `docker build` from this directory** — the build context is
+  `microservices/` (three levels up) because of the
+  `../../multimodal-embedding-serving` path dependency. Always use
+  `./build.sh`.
+
+## API Surface (prefix `/v1/dataprep`, e.g. `http://localhost:6007/v1/dataprep/health`)
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/health` | Service + embedding-backend status |
+| POST | `/videos/upload` | Multipart MP4 upload (≤500 MB) → store + embed |
+| POST | `/videos/minio` | Embed a video already in MinIO (JSON body) |
+| POST | `/summary` | Embed a text summary with video time range |
+| POST | `/videos/rtsp` | Ingest RTSP streams (experimental; not in api-reference.md) |
+| GET | `/videos` | List videos in a bucket |
+| GET | `/videos/download` | Download/stream a video |
+| DELETE | `/videos/{bucket_name}/{video_id}` | Delete one file (`?video_name=`) or the whole directory |
+| GET | `/telemetry` | Recent ingestion telemetry |
+
+## Repository Map
+
+| Path | Contents |
+|---|---|
+| `setup.sh` / `setup-with-embedding.sh` | Env + lifecycle entrypoints (source them). |
+| `build.sh` | The only sanctioned image build (context = `microservices/`). |
+| `docker/` | `compose.yaml` (sdk), `compose-with-embedding.yaml` (api), `compose-dev.yaml` (overlay), `Dockerfile`. |
+| `src/main.py` | FastAPI app (`root_path=/v1/dataprep`); lifespan preloads SDK client + YOLOX, flushes the VDMS index on shutdown. |
+| `src/endpoints/` | One router package per API area. |
+| `src/core/embedding/` | The pipeline: `sdk_embedding_helper.py` (SDK mode), `simple_client.py` (api mode), `sdk_client.py` (VDMS writes via langchain-vdms), `decoder.py` (frame extraction). |
+| `src/core/object_detection/` | YOLOX detector + utils. |
+| `src/core/minio_client.py`, `src/common/settings.py` | Object storage client; pydantic Settings. |
+| `scripts/` | `tester.sh` (coverage ≥80%), `linter.sh` (black/isort), `entrypoint.sh`. |
+| `tests/` | 12 pytest files + `conftest.py` (mocked MinIO, TestClient). |
+
+## Conventions
+
+- Run commands from this microservice's root unless a skill says otherwise.
+- **Credentials are never committed** — export MinIO creds in-shell.
+- Every new source/config/doc file carries the repo SPDX header
+  (`SPDX-FileCopyrightText: (C) 2026 Intel Corporation` / `Apache-2.0`).
+- Probe `GET http://localhost:6007/v1/dataprep/health` before API workflows.
+- Destructive operations (wiping the VDMS collection, deleting volumes or
+  bucket contents) need explicit user confirmation.
+
+## Gotchas
+
+- **VDMS dimension mismatch**: reusing a `DB_COLLECTION` created with a
+  different embedding model throws "Dimensions mismatch" — fix is destructive
+  (new collection name or wipe), so confirm first.
+- **YOLOX downloads on first run** — without network, object detection is
+  **silently disabled**.
+- `docker/compose.yaml` reads `DB_COLLECTION` from `VS_INDEX_NAME`, but
+  `setup.sh` exports `INDEX_NAME` — unless `VS_INDEX_NAME` is set, the
+  collection falls back to the code default `video-rag-test`
+  (`src/common/settings.py`).
+- Volumes `vdms-yolox-models`, `ov-models`, `data-prep` hold model/scratch
+  state; MinIO persists to `MINIO_MOUNT_PATH` (default `/mnt/miniodata`).
+- Uploads >500 MB are rejected (413) — stage big files in MinIO and use
+  `POST /videos/minio`.
+- Only MP4 is supported for embedding creation.
+
+## Skills
+
+Reusable workflow skills live under [`.github/skills/`](skills/). Use
+[`skill-catalog.json`](skills/skill-catalog.json) to pick the relevant skill,
+then read that skill's `SKILL.md`.
+
+| User intent | Skill |
+|---|---|
+| Bring up the stack and ingest/manage videos from an app | `vdms-dataprep-user` |
+| Build from source, run tests/lint, modify the pipeline | `vdms-dataprep-dev` |
+
+## Skill Loading Rules
+
+- Load only the skill needed for the current request.
+- Open a skill's linked docs or `references/` files only when its `SKILL.md`
+  points to them.
+- Run commands yourself when the harness permits it and relay the result.
+
+## Path Conventions
+
+All paths in the skill catalog are relative to this microservice's root
+(`microservices/visual-data-preparation-for-retrieval/vdms/`). The skills live
+in `.github/skills` as the shared location for Codex, Copilot CLI, Claude
+Code, Cursor, and local agent scripts. Skills also work without a repo clone —
+the `-user` skill fetches the same `setup.sh`/compose files and docs from
+GitHub and uses the prebuilt images.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/skill-catalog.json
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/skill-catalog.json
@@ -27,15 +27,14 @@
     {
       "name": "vdms-dataprep-dev",
       "path": ".github/skills/vdms-dataprep-dev/SKILL.md",
-      "description": "Develop the VDMS DataPrep microservice itself: build images the sanctioned way (./build.sh, context three levels up), run the pytest suite with the 80% coverage gate, lint, use the dev compose overlay with live reload, and navigate the SDK/API embedding pipeline code. Not for merely deploying or ingesting videos (use vdms-dataprep-user).",
+      "description": "Develop the VDMS DataPrep microservice itself: build images the sanctioned way (./build.sh, context three levels up), run the pytest suite with coverage, lint, and navigate the SDK/API embedding pipeline code. Not for merely deploying or ingesting videos (use vdms-dataprep-user).",
       "triggers": [
         "run the dataprep tests",
         "dataprep coverage",
         "lint dataprep",
         "build vdms-dataprep from source",
         "docker build fails on embedding path dependency",
-        "modify the ingestion pipeline",
-        "dev mode with live reload"
+        "modify the ingestion pipeline"
       ],
       "requires": [
         "repo clone",

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/skill-catalog.json
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/skill-catalog.json
@@ -1,0 +1,47 @@
+{
+  "SPDX-FileCopyrightText": "(C) 2026 Intel Corporation",
+  "SPDX-License-Identifier": "Apache-2.0",
+  "schemaVersion": "1.0",
+  "description": "Harness-neutral discovery catalog for VDMS DataPrep workflow skills. Paths are relative to the microservice root.",
+  "skillsRoot": ".github/skills",
+  "skills": [
+    {
+      "name": "vdms-dataprep-user",
+      "path": ".github/skills/vdms-dataprep-user/SKILL.md",
+      "description": "Deploy and consume the VDMS DataPrep video-ingestion stack (dataprep + VDMS vector DB + MinIO): bring it up from a repo clone (setup.sh) or standalone via the skill's compose file with prebuilt images, then upload/ingest videos, add text summaries, and list/download/delete videos through the REST API on port 6007. Ingestion only — this service does not answer search queries. Not for modifying its source (use vdms-dataprep-dev).",
+      "triggers": [
+        "ingest videos for retrieval",
+        "video rag ingestion",
+        "run vdms dataprep",
+        "upload video for embedding",
+        "store video embeddings in vdms",
+        "add video summary embedding",
+        "list ingested videos",
+        "delete ingested video"
+      ],
+      "requires": [
+        "docker",
+        "curl"
+      ]
+    },
+    {
+      "name": "vdms-dataprep-dev",
+      "path": ".github/skills/vdms-dataprep-dev/SKILL.md",
+      "description": "Develop the VDMS DataPrep microservice itself: build images the sanctioned way (./build.sh, context three levels up), run the pytest suite with the 80% coverage gate, lint, use the dev compose overlay with live reload, and navigate the SDK/API embedding pipeline code. Not for merely deploying or ingesting videos (use vdms-dataprep-user).",
+      "triggers": [
+        "run the dataprep tests",
+        "dataprep coverage",
+        "lint dataprep",
+        "build vdms-dataprep from source",
+        "docker build fails on embedding path dependency",
+        "modify the ingestion pipeline",
+        "dev mode with live reload"
+      ],
+      "requires": [
+        "repo clone",
+        "docker",
+        "poetry"
+      ]
+    }
+  ]
+}

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/SKILL.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/SKILL.md
@@ -7,9 +7,6 @@ description: >
   reload, and navigate the SDK/API embedding pipeline. Use when modifying,
   testing, or debugging this service's code. Not for merely deploying the stack
   or ingesting videos — that is vdms-dataprep-user.
-argument-hint: >
-  Describe what you want to build, test, or debug (e.g. "build the image the
-  sanctioned way", or "add a new endpoint to the ingestion API")
 ---
 
 # VDMS DataPrep — Dev

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/SKILL.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/SKILL.md
@@ -3,10 +3,10 @@ name: vdms-dataprep-dev
 description: >
   Develop the VDMS DataPrep microservice itself — build images the sanctioned
   way (./build.sh with its microservices/-level context), run the pytest suite
-  with the 80% coverage gate, lint, use the dev compose overlay with live
-  reload, and navigate the SDK/API embedding pipeline. Use when modifying,
-  testing, or debugging this service's code. Not for merely deploying the stack
-  or ingesting videos — that is vdms-dataprep-user.
+  with coverage, lint, and navigate the SDK/API embedding
+  pipeline. Use when modifying, testing, or debugging this service's code. Not
+  for merely deploying the stack or ingesting videos — that is
+  vdms-dataprep-user.
 ---
 
 # VDMS DataPrep — Dev
@@ -23,10 +23,9 @@ commands from the microservice root.
 ## When to Use
 
 - Build the image the sanctioned way (`./build.sh`, `microservices/` context)
-- Run the pytest suite with the 80% coverage gate, or lint
-- Use the dev compose overlay with live reload
+- Run the pytest suite with coverage, or lint
 - Navigate/modify the SDK-or-API embedding pipeline and endpoints
-- Debug the path dependency, `VS_INDEX_NAME` wiring, or MinIO endpoints
+- Debug the path dependency, fixed collection wiring, or MinIO endpoints
 
 ## Example Prompts
 
@@ -35,7 +34,7 @@ Sample Problem-solving scenarios this skill handles end-to-end:
 | Example | Problem it solves |
 |---|---|
 | [onboard-embedding-model.md](./example-prompts/onboard-embedding-model.md) | Onboard a new embedding model into the ingestion pipeline |
-| [update-test-cases.md](./example-prompts/update-test-cases.md) | Update test cases and keep the 80% coverage gate green |
+| [update-test-cases.md](./example-prompts/update-test-cases.md) | Update test cases and inspect coverage |
 
 ## Reference Lookup
 
@@ -54,7 +53,7 @@ fails on the path dependency.
 ## Environment setup
 
 ```bash
-poetry install --with dev,cpu     # Python >=3.10,<3.14; cpu group pins torch-cpu
+poetry install --with dev         # Python >=3.11,<3.14; CPU wheels are base dependencies
 ```
 
 `setup.sh` is **sourced** and (except for `--down`/`--build*`) requires
@@ -64,26 +63,27 @@ poetry install --with dev,cpu     # Python >=3.10,<3.14; cpu group pins torch-cp
 ## Test / lint loop
 
 ```bash
-source ./setup.sh test                       # full suite + coverage gate (fails under 80%)
-source ./setup.sh test tests/test_db.py      # single file
-source ./setup.sh lint                       # black + isort check (add -a to apply)
+poetry run coverage run --rcfile ./pyproject.toml -m pytest tests
+poetry run coverage report -m
+poetry run coverage run --rcfile ./pyproject.toml -m pytest tests/test_db.py
+poetry run black --check src tests && poetry run isort --check-only src tests
 ```
 
-The suite (12 files, `conftest.py` with a `TestClient` and mocked MinIO) runs
-offline. Details and Docker-gated variants (`--build-test`, `--build-lint`,
-`--build-report`):
+The suite (13 files, `conftest.py` with a `TestClient` and mocked MinIO) runs
+offline. `setup.sh` currently has no test/lint subcommands, so use the direct
+Poetry commands above. Details:
 [`references/testing-and-build.md`](./references/testing-and-build.md).
 
-## Dev loop with live reload
+## Build-and-run loop
 
 ```bash
 bash -c 'export MINIO_ROOT_USER=... MINIO_ROOT_PASSWORD=... EMBEDDING_MODEL_NAME="CLIP/clip-vit-b-32" \
-  && source ./setup.sh --dev'     # compose.yaml + compose-dev.yaml: mounts source, uvicorn --reload
+  && source ./setup.sh'           # builds with ./build.sh, then starts detached compose
 ```
 
-Uses collection `video-rag-dev`; `--dev --nd` for foreground. Prod-style run:
-bare `source ./setup.sh` (builds via `./build.sh`, then detached compose).
-Teardown: `source ./setup.sh --down`.
+This checkout has no dev compose overlay or live-reload subcommand. Rebuild
+after source changes; use `source ./setup.sh --nd` for foreground logs and
+`source ./setup.sh --down` for teardown.
 
 ## Architecture in one paragraph
 
@@ -102,8 +102,8 @@ and `src/core/minio_client.py`. Full map:
 | Gotcha | Consequence |
 |---|---|
 | Path dependency on `../../multimodal-embedding-serving` | its `EmbeddingModel` API is your contract; coordinate changes across both services |
-| `docker/compose.yaml` reads `DB_COLLECTION` from `VS_INDEX_NAME` but `setup.sh` exports `INDEX_NAME` | without `VS_INDEX_NAME`, prod compose silently uses the code default `video-rag-test` (`src/common/settings.py`) |
-| Repo compose sets `MINIO_ENDPOINT` from the **host** port (`${MINIO_HOST}:${MINIO_API_HOST_PORT:-4001}`) | container-internal MinIO listens on 9000 — `compose-with-embedding.yaml` hardcodes `:9000`; keep endpoint wiring consistent when touching compose |
+| `setup.sh` unconditionally exports `INDEX_NAME=video-rag` and compose maps it to `DB_COLLECTION` | `VS_INDEX_NAME` has no effect; change the source or override `INDEX_NAME` after sourcing `--nosetup` before Compose |
+| Compose sets `MINIO_ENDPOINT=${MINIO_HOST}:9000` | use the container port for service-to-service traffic; host access uses port 6010 |
 | YOLOX weights download at first startup into the `vdms-yolox-models` volume | offline first run silently disables detection — don't chase it as a code bug |
 | Reusing a VDMS collection after changing embedding model | `Dimensions mismatch` at insert; use a fresh collection in tests |
 | Every new file needs the SPDX header | CI/license scans fail otherwise |

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/SKILL.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: vdms-dataprep-dev
+description: >
+  Develop the VDMS DataPrep microservice itself — build images the sanctioned
+  way (./build.sh with its microservices/-level context), run the pytest suite
+  with the 80% coverage gate, lint, use the dev compose overlay with live
+  reload, and navigate the SDK/API embedding pipeline. Use when modifying,
+  testing, or debugging this service's code. Not for merely deploying the stack
+  or ingesting videos — that is vdms-dataprep-user.
+argument-hint: >
+  Describe what you want to build, test, or debug (e.g. "build the image the
+  sanctioned way", or "add a new endpoint to the ingestion API")
+---
+
+# VDMS DataPrep — Dev
+
+Work on the service's source. **This skill assumes a repo clone** of
+`edge-ai-libraries` with this microservice at
+`microservices/visual-data-preparation-for-retrieval/vdms/`; if there is no
+clone, clone the repo first (`git clone
+https://github.com/open-edge-platform/edge-ai-libraries.git`) or — if the user
+only wants to *use* the stack — switch to
+[`../vdms-dataprep-user/SKILL.md`](../vdms-dataprep-user/SKILL.md). Run all
+commands from the microservice root.
+
+## When to Use
+
+- Build the image the sanctioned way (`./build.sh`, `microservices/` context)
+- Run the pytest suite with the 80% coverage gate, or lint
+- Use the dev compose overlay with live reload
+- Navigate/modify the SDK-or-API embedding pipeline and endpoints
+- Debug the path dependency, `VS_INDEX_NAME` wiring, or MinIO endpoints
+
+## Example Prompts
+
+Sample Problem-solving scenarios this skill handles end-to-end:
+
+| Example | Problem it solves |
+|---|---|
+| [onboard-embedding-model.md](./example-prompts/onboard-embedding-model.md) | Onboard a new embedding model into the ingestion pipeline |
+| [update-test-cases.md](./example-prompts/update-test-cases.md) | Update test cases and keep the 80% coverage gate green |
+
+## Reference Lookup
+
+| File | Load when… |
+|---|---|
+| [`references/source-map.md`](./references/source-map.md) | locating pipeline/endpoint code before editing |
+| [`references/testing-and-build.md`](./references/testing-and-build.md) | test/lint/coverage details, build targets, or build failures |
+
+## The one rule to know first
+
+**Never `docker build` from this directory.** The image depends on the sibling
+`../../multimodal-embedding-serving` package, so the build context is
+`microservices/` (three levels up). `./build.sh` handles that; a direct build
+fails on the path dependency.
+
+## Environment setup
+
+```bash
+poetry install --with dev,cpu     # Python >=3.10,<3.14; cpu group pins torch-cpu
+```
+
+`setup.sh` is **sourced** and (except for `--down`/`--build*`) requires
+`MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD` exported; ingestion also needs
+`EMBEDDING_MODEL_NAME`.
+
+## Test / lint loop
+
+```bash
+source ./setup.sh test                       # full suite + coverage gate (fails under 80%)
+source ./setup.sh test tests/test_db.py      # single file
+source ./setup.sh lint                       # black + isort check (add -a to apply)
+```
+
+The suite (12 files, `conftest.py` with a `TestClient` and mocked MinIO) runs
+offline. Details and Docker-gated variants (`--build-test`, `--build-lint`,
+`--build-report`):
+[`references/testing-and-build.md`](./references/testing-and-build.md).
+
+## Dev loop with live reload
+
+```bash
+bash -c 'export MINIO_ROOT_USER=... MINIO_ROOT_PASSWORD=... EMBEDDING_MODEL_NAME="CLIP/clip-vit-b-32" \
+  && source ./setup.sh --dev'     # compose.yaml + compose-dev.yaml: mounts source, uvicorn --reload
+```
+
+Uses collection `video-rag-dev`; `--dev --nd` for foreground. Prod-style run:
+bare `source ./setup.sh` (builds via `./build.sh`, then detached compose).
+Teardown: `source ./setup.sh --down`.
+
+## Architecture in one paragraph
+
+`src/main.py` (FastAPI, `root_path=/v1/dataprep`; lifespan preloads the SDK
+embedding client + YOLOX detector, flushes the VDMS index on shutdown) →
+`src/endpoints/<area>/` routers → `src/core/embedding/`
+(`simplified_embedding_helper.py` orchestrates; `sdk_embedding_helper.py` is
+the in-process pipeline: decode → detect → embed → store;
+`simple_client.py` is the HTTP alternative for `api` mode; `sdk_client.py`
+writes to VDMS via langchain-vdms) with `src/core/object_detection/` (YOLOX)
+and `src/core/minio_client.py`. Full map:
+[`references/source-map.md`](./references/source-map.md).
+
+## Contribution gotchas
+
+| Gotcha | Consequence |
+|---|---|
+| Path dependency on `../../multimodal-embedding-serving` | its `EmbeddingModel` API is your contract; coordinate changes across both services |
+| `docker/compose.yaml` reads `DB_COLLECTION` from `VS_INDEX_NAME` but `setup.sh` exports `INDEX_NAME` | without `VS_INDEX_NAME`, prod compose silently uses the code default `video-rag-test` (`src/common/settings.py`) |
+| Repo compose sets `MINIO_ENDPOINT` from the **host** port (`${MINIO_HOST}:${MINIO_API_HOST_PORT:-4001}`) | container-internal MinIO listens on 9000 — `compose-with-embedding.yaml` hardcodes `:9000`; keep endpoint wiring consistent when touching compose |
+| YOLOX weights download at first startup into the `vdms-yolox-models` volume | offline first run silently disables detection — don't chase it as a code bug |
+| Reusing a VDMS collection after changing embedding model | `Dimensions mismatch` at insert; use a fresh collection in tests |
+| Every new file needs the SPDX header | CI/license scans fail otherwise |

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/evals/evals.json
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/evals/evals.json
@@ -6,12 +6,12 @@
     {
       "id": 1,
       "name": "run-tests-with-coverage",
-      "prompt": "I'm in a checkout of edge-ai-libraries at microservices/visual-data-preparation-for-retrieval/vdms. Run the test suite the way this project intends and summarize the results.",
-      "expected_output": "Runs the suite via source ./setup.sh test (or the equivalent coverage+pytest command), reports pass/fail and coverage against the 80% gate, without starting any containers.",
+      "prompt": "I'm in a checkout of edge-ai-libraries at microservices/visual-data-preparation-for-retrieval/vdms. Give me the exact project-supported commands to install test dependencies, run the unit suite with coverage, and report the result.",
+      "expected_output": "Provides poetry install --with dev, the Poetry-managed coverage+pytest command over tests, and coverage report -m. It does not invent a coverage threshold, use the nonexistent setup.sh test command, or start service containers.",
       "expectations": [
-        "Runs tests through setup.sh test or the equivalent poetry coverage+pytest command",
-        "Reports coverage relative to the 80% fail-under gate",
-        "Does not start MinIO/VDMS containers to run the unit tests"
+        "Provides poetry install --with dev followed by the Poetry-managed coverage+pytest command over tests",
+        "Reports coverage with coverage report -m without inventing a fail-under threshold absent from project configuration",
+        "Does not use a nonexistent setup.sh test command or require MinIO/VDMS containers for unit tests"
       ]
     },
     {
@@ -26,12 +26,13 @@
     },
     {
       "id": 3,
-      "name": "negative-ingest-routing",
-      "prompt": "Spin up the vdms dataprep stack and load these 5 warehouse videos into it.",
-      "expected_output": "Recognizes this as deployment + ingestion (user-skill territory): brings the stack up via setup.sh or prebuilt images and ingests through the REST API, without modifying source or running the test suite.",
+      "name": "collection-name-wiring",
+      "prompt": "I exported VS_INDEX_NAME=my-new-index before sourcing setup.sh, but the VDMS dataprep container still gets DB_COLLECTION=video-rag. Why is my override ignored, and how can I make a one-off override work without changing source?",
+      "expected_output": "Explains that setup.sh unconditionally sets INDEX_NAME=video-rag and compose maps DB_COLLECTION from INDEX_NAME; VS_INDEX_NAME is unused. For a one-off override, source setup.sh --nosetup, then export INDEX_NAME=my-new-index after sourcing and invoke docker compose.",
       "expectations": [
-        "Does not modify service source code or run the pytest suite for this request",
-        "Ingests the videos through the documented REST endpoints and verifies via /health or /videos"
+        "Identifies setup.sh's unconditional INDEX_NAME=video-rag assignment and compose's DB_COLLECTION=${INDEX_NAME} mapping",
+        "States that VS_INDEX_NAME is unused in the current wiring",
+        "Provides a one-off override sequence that sets INDEX_NAME after source setup.sh --nosetup and before docker compose"
       ]
     }
   ]

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/evals/evals.json
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/evals/evals.json
@@ -4,29 +4,32 @@
   "skill_name": "vdms-dataprep-dev",
   "evals": [
     {
-      "id": "run-tests-with-coverage",
+      "id": 1,
+      "name": "run-tests-with-coverage",
       "prompt": "I'm in a checkout of edge-ai-libraries at microservices/visual-data-preparation-for-retrieval/vdms. Run the test suite the way this project intends and summarize the results.",
       "expected_output": "Runs the suite via source ./setup.sh test (or the equivalent coverage+pytest command), reports pass/fail and coverage against the 80% gate, without starting any containers.",
-      "assertions": [
+      "expectations": [
         "Runs tests through setup.sh test or the equivalent poetry coverage+pytest command",
         "Reports coverage relative to the 80% fail-under gate",
         "Does not start MinIO/VDMS containers to run the unit tests"
       ]
     },
     {
-      "id": "build-context-edge",
+      "id": 2,
+      "name": "build-context-edge",
       "prompt": "Running docker build -f docker/Dockerfile . from the vdms directory fails with COPY errors about multimodal-embedding-serving not being found. What's the actual problem?",
       "expected_output": "The build context is wrong: the image needs the sibling multimodal-embedding-serving path dependency, so the context must be the microservices/ directory. Use ./build.sh, never docker build from the vdms directory.",
-      "assertions": [
+      "expectations": [
         "Identifies the build context (not the Dockerfile) as the problem",
         "Prescribes ./build.sh (or setup.sh --build) as the sanctioned build entry point"
       ]
     },
     {
-      "id": "negative-ingest-routing",
+      "id": 3,
+      "name": "negative-ingest-routing",
       "prompt": "Spin up the vdms dataprep stack and load these 5 warehouse videos into it.",
       "expected_output": "Recognizes this as deployment + ingestion (user-skill territory): brings the stack up via setup.sh or prebuilt images and ingests through the REST API, without modifying source or running the test suite.",
-      "assertions": [
+      "expectations": [
         "Does not modify service source code or run the pytest suite for this request",
         "Ingests the videos through the documented REST endpoints and verifies via /health or /videos"
       ]

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/evals/evals.json
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/evals/evals.json
@@ -1,0 +1,47 @@
+{
+  "SPDX-FileCopyrightText": "(C) 2026 Intel Corporation",
+  "SPDX-License-Identifier": "Apache-2.0",
+  "skill_name": "vdms-dataprep-dev",
+  "evals": [
+    {
+      "id": "run-tests-with-coverage",
+      "prompt": "I'm in a checkout of edge-ai-libraries at microservices/visual-data-preparation-for-retrieval/vdms. Run the test suite the way this project intends, including its coverage requirement, and summarize the results.",
+      "expected_output": "Runs the suite via source ./setup.sh test (or scripts/tester.sh / the equivalent coverage+pytest command), reports pass/fail and the coverage percentage against the 80% gate, without starting MinIO/VDMS containers.",
+      "assertions": [
+        "Runs tests through setup.sh test, scripts/tester.sh, or the equivalent poetry coverage run -m pytest command",
+        "Reports coverage relative to the 80% fail-under gate",
+        "Does not start MinIO/VDMS/embedding containers to run unit tests (the suite is mocked/offline)"
+      ]
+    },
+    {
+      "id": "build-context-edge",
+      "prompt": "cd microservices/visual-data-preparation-for-retrieval/vdms && docker build -f docker/Dockerfile . fails with COPY errors about multimodal-embedding-serving not being found. The Dockerfile looks correct to me. What's the actual problem?",
+      "expected_output": "Diagnosis: the build context is wrong — the image needs both this service and the sibling multimodal-embedding-serving path dependency, so the context must be the microservices/ directory (three levels up). Fix: use ./build.sh (or setup.sh --build), never docker build from the vdms directory.",
+      "assertions": [
+        "Identifies the build context (not the Dockerfile) as the problem — it must be the microservices/ directory because of the multimodal-embedding-serving path dependency",
+        "Prescribes ./build.sh or source ./setup.sh --build as the sanctioned build entry point",
+        "Does not suggest editing the Dockerfile COPY paths as the fix"
+      ]
+    },
+    {
+      "id": "locate-pipeline-code",
+      "prompt": "In the vdms dataprep codebase, where would I add a per-frame blur-detection step that runs after frame extraction but before embedding, in the default processing mode?",
+      "expected_output": "Points to the SDK-mode pipeline in src/core/embedding/sdk_embedding_helper.py (default EMBEDDING_PROCESSING_MODE=sdk) as the integration point between the decoder (src/core/embedding/decoder.py) and the embed/store stages, possibly noting the detection worker stage as the analogous pattern to follow.",
+      "assertions": [
+        "Names src/core/embedding/sdk_embedding_helper.py as the SDK-mode pipeline where the step belongs",
+        "Correctly orders the stages: after frame extraction (decoder.py) and before embedding/storage",
+        "Mentions that sdk is the default processing mode (vs the api mode client in simple_client.py)"
+      ]
+    },
+    {
+      "id": "negative-ingest-routing",
+      "prompt": "Spin up the vdms dataprep stack and load these 5 warehouse videos into it so the search team can start querying tomorrow.",
+      "expected_output": "Recognizes this as deployment + ingestion (user-skill territory): brings the stack up via setup.sh or prebuilt images, ingests through the REST API (/videos/upload or /videos/minio), and does not modify source, run the dev overlay, or run the test suite.",
+      "assertions": [
+        "Does not modify service source code or run the pytest suite for this request",
+        "Brings up the stack via setup.sh or the prebuilt-image compose (not the --dev live-reload overlay)",
+        "Ingests the videos through the documented REST endpoints and verifies via /health or /videos"
+      ]
+    }
+  ]
+}

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/evals/evals.json
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/evals/evals.json
@@ -5,41 +5,29 @@
   "evals": [
     {
       "id": "run-tests-with-coverage",
-      "prompt": "I'm in a checkout of edge-ai-libraries at microservices/visual-data-preparation-for-retrieval/vdms. Run the test suite the way this project intends, including its coverage requirement, and summarize the results.",
-      "expected_output": "Runs the suite via source ./setup.sh test (or scripts/tester.sh / the equivalent coverage+pytest command), reports pass/fail and the coverage percentage against the 80% gate, without starting MinIO/VDMS containers.",
+      "prompt": "I'm in a checkout of edge-ai-libraries at microservices/visual-data-preparation-for-retrieval/vdms. Run the test suite the way this project intends and summarize the results.",
+      "expected_output": "Runs the suite via source ./setup.sh test (or the equivalent coverage+pytest command), reports pass/fail and coverage against the 80% gate, without starting any containers.",
       "assertions": [
-        "Runs tests through setup.sh test, scripts/tester.sh, or the equivalent poetry coverage run -m pytest command",
+        "Runs tests through setup.sh test or the equivalent poetry coverage+pytest command",
         "Reports coverage relative to the 80% fail-under gate",
-        "Does not start MinIO/VDMS/embedding containers to run unit tests (the suite is mocked/offline)"
+        "Does not start MinIO/VDMS containers to run the unit tests"
       ]
     },
     {
       "id": "build-context-edge",
-      "prompt": "cd microservices/visual-data-preparation-for-retrieval/vdms && docker build -f docker/Dockerfile . fails with COPY errors about multimodal-embedding-serving not being found. The Dockerfile looks correct to me. What's the actual problem?",
-      "expected_output": "Diagnosis: the build context is wrong — the image needs both this service and the sibling multimodal-embedding-serving path dependency, so the context must be the microservices/ directory (three levels up). Fix: use ./build.sh (or setup.sh --build), never docker build from the vdms directory.",
+      "prompt": "Running docker build -f docker/Dockerfile . from the vdms directory fails with COPY errors about multimodal-embedding-serving not being found. What's the actual problem?",
+      "expected_output": "The build context is wrong: the image needs the sibling multimodal-embedding-serving path dependency, so the context must be the microservices/ directory. Use ./build.sh, never docker build from the vdms directory.",
       "assertions": [
-        "Identifies the build context (not the Dockerfile) as the problem — it must be the microservices/ directory because of the multimodal-embedding-serving path dependency",
-        "Prescribes ./build.sh or source ./setup.sh --build as the sanctioned build entry point",
-        "Does not suggest editing the Dockerfile COPY paths as the fix"
-      ]
-    },
-    {
-      "id": "locate-pipeline-code",
-      "prompt": "In the vdms dataprep codebase, where would I add a per-frame blur-detection step that runs after frame extraction but before embedding, in the default processing mode?",
-      "expected_output": "Points to the SDK-mode pipeline in src/core/embedding/sdk_embedding_helper.py (default EMBEDDING_PROCESSING_MODE=sdk) as the integration point between the decoder (src/core/embedding/decoder.py) and the embed/store stages, possibly noting the detection worker stage as the analogous pattern to follow.",
-      "assertions": [
-        "Names src/core/embedding/sdk_embedding_helper.py as the SDK-mode pipeline where the step belongs",
-        "Correctly orders the stages: after frame extraction (decoder.py) and before embedding/storage",
-        "Mentions that sdk is the default processing mode (vs the api mode client in simple_client.py)"
+        "Identifies the build context (not the Dockerfile) as the problem",
+        "Prescribes ./build.sh (or setup.sh --build) as the sanctioned build entry point"
       ]
     },
     {
       "id": "negative-ingest-routing",
-      "prompt": "Spin up the vdms dataprep stack and load these 5 warehouse videos into it so the search team can start querying tomorrow.",
-      "expected_output": "Recognizes this as deployment + ingestion (user-skill territory): brings the stack up via setup.sh or prebuilt images, ingests through the REST API (/videos/upload or /videos/minio), and does not modify source, run the dev overlay, or run the test suite.",
+      "prompt": "Spin up the vdms dataprep stack and load these 5 warehouse videos into it.",
+      "expected_output": "Recognizes this as deployment + ingestion (user-skill territory): brings the stack up via setup.sh or prebuilt images and ingests through the REST API, without modifying source or running the test suite.",
       "assertions": [
         "Does not modify service source code or run the pytest suite for this request",
-        "Brings up the stack via setup.sh or the prebuilt-image compose (not the --dev live-reload overlay)",
         "Ingests the videos through the documented REST endpoints and verifies via /health or /videos"
       ]
     }

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/example-prompts/onboard-embedding-model.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/example-prompts/onboard-embedding-model.md
@@ -1,11 +1,12 @@
 Onboard a different multimodal embedding model into the ingestion pipeline and confirm videos embed cleanly with it.
 
 - Wire the new model through EMBEDDING_MODEL_NAME (SDK mode uses the ../../multimodal-embedding-serving path dependency; its EmbeddingModel API is the contract).
-- Use a fresh VS_INDEX_NAME collection to avoid a "Dimensions mismatch" against vectors built with the previous model.
+- Use a fresh collection to avoid a "Dimensions mismatch" against vectors built with the previous model.
 - Verify the health endpoint reports the new model/device in SDK mode. Add the SPDX header to any new file.
 
 Validate the change using:
-- Start with EMBEDDING_MODEL_NAME=<new-model> and VS_INDEX_NAME=<fresh-name>.
+- After `source setup.sh --nosetup`, set `EMBEDDING_MODEL_NAME=<new-model>` and
+  override `INDEX_NAME=<fresh-name>` before invoking Docker Compose.
 - Ingest one MP4 via POST /videos/upload on http://localhost:6007/v1/dataprep.
 - Check GET /health for the loaded model.
 

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/example-prompts/onboard-embedding-model.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/example-prompts/onboard-embedding-model.md
@@ -1,0 +1,14 @@
+Onboard a different multimodal embedding model into the ingestion pipeline and confirm videos embed cleanly with it.
+
+- Wire the new model through EMBEDDING_MODEL_NAME (SDK mode uses the ../../multimodal-embedding-serving path dependency; its EmbeddingModel API is the contract).
+- Use a fresh VS_INDEX_NAME collection to avoid a "Dimensions mismatch" against vectors built with the previous model.
+- Verify the health endpoint reports the new model/device in SDK mode. Add the SPDX header to any new file.
+
+Validate the change using:
+- Start with EMBEDDING_MODEL_NAME=<new-model> and VS_INDEX_NAME=<fresh-name>.
+- Ingest one MP4 via POST /videos/upload on http://localhost:6007/v1/dataprep.
+- Check GET /health for the loaded model.
+
+Expected results:
+- Health shows the new model; ingestion of the MP4 succeeds with no dimension mismatch (fresh collection).
+- Reusing the old collection would surface "Dimensions mismatch"; the fresh-collection fix avoids it.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/example-prompts/update-test-cases.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/example-prompts/update-test-cases.md
@@ -1,13 +1,14 @@
-Update the pytest suite after changing the ingestion pipeline so the change is covered and the 80% coverage gate still passes.
+Update the pytest suite after changing the ingestion pipeline so the change is covered.
 
 - Add or extend tests under tests/ using the existing conftest.py fixtures (mocked MinIO, TestClient) so they run offline.
 - Cover the changed endpoint or pipeline path. Add the SPDX header to any new test file.
 
-Validate the change using the sanctioned entrypoint:
-- source ./setup.sh test            (full suite + coverage gate)
-- source ./setup.sh test tests/test_db.py   (single file while iterating)
-- source ./setup.sh lint            (black + isort; add -a to apply)
+Validate the change with the Poetry-managed tools:
+- `poetry run coverage run --rcfile ./pyproject.toml -m pytest tests`
+- `poetry run coverage report -m`
+- `poetry run coverage run --rcfile ./pyproject.toml -m pytest tests/test_db.py`
+- `poetry run black --check src tests && poetry run isort --check-only src tests`
 
 Expected results:
-- New/updated tests pass offline; total coverage stays at or above 80% so the gate does not fail.
+- New/updated tests pass offline and the measured coverage is reported honestly.
 - Lint is clean.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/example-prompts/update-test-cases.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/example-prompts/update-test-cases.md
@@ -1,0 +1,13 @@
+Update the pytest suite after changing the ingestion pipeline so the change is covered and the 80% coverage gate still passes.
+
+- Add or extend tests under tests/ using the existing conftest.py fixtures (mocked MinIO, TestClient) so they run offline.
+- Cover the changed endpoint or pipeline path. Add the SPDX header to any new test file.
+
+Validate the change using the sanctioned entrypoint:
+- source ./setup.sh test            (full suite + coverage gate)
+- source ./setup.sh test tests/test_db.py   (single file while iterating)
+- source ./setup.sh lint            (black + isort; add -a to apply)
+
+Expected results:
+- New/updated tests pass offline; total coverage stays at or above 80% so the gate does not fail.
+- Lint is clean.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/references/source-map.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/references/source-map.md
@@ -57,13 +57,12 @@ Mode selection: `EMBEDDING_PROCESSING_MODE` (`sdk` default / `api`) in
 
 ## Build & packaging
 
-- `docker/Dockerfile` — multi-stage (`prod`, `final-dev`, `lint`, `report`);
+- `docker/Dockerfile` — multi-stage (`python-base`, `builder-base`, `prod`);
   context must be `microservices/` so
   `visual-data-preparation-for-retrieval/vdms/…` and
   `multimodal-embedding-serving/…` both resolve.
 - `build.sh` — the sanctioned build; forwards proxies, `--push` to publish.
 - `pyproject.toml` — Poetry, path dep
   `multimodal-embedding-serving = { path = "../../multimodal-embedding-serving" }`,
-  groups `dev` (pytest/black/isort) and `cpu` (torch-cpu).
-- `docker/compose-dev.yaml` — dev overlay: mounts `..:/app`, uvicorn
-  `--reload`, `DB_COLLECTION=video-rag-dev`.
+  group `dev` (pytest/coverage/black/isort); CPU torch wheels are base
+  dependencies from the `pytorch-cpu` source.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/references/source-map.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/references/source-map.md
@@ -1,0 +1,69 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Source map — VDMS DataPrep
+
+## Entry point
+
+`src/main.py` — FastAPI app with `root_path="/v1/dataprep"`, custom
+`HTTPException` handler emitting `DataPrepResponse`, CORS from settings.
+Lifespan: **startup** preloads the SDK embedding client
+(`preload_sdk_client`) and YOLOX detector (`preload_object_detector`);
+**shutdown** persists the VDMS index (`FindDescriptorSet … storeIndex=True`).
+
+## Endpoints (`src/endpoints/<area>/`, one APIRouter each)
+
+| Route | Handler file |
+|---|---|
+| `GET /health` | `health/check_health.py` |
+| `POST /summary` | `document_processing/process_text.py` |
+| `POST /videos/minio` | `video_processing/process_minio_video.py` |
+| `POST /videos/upload`, `POST /videos/rtsp` | `video_processing/upload_and_process_video.py` |
+| `GET /videos` | `video_management/list_videos.py` |
+| `GET /videos/download` | `video_management/download_video.py` |
+| `DELETE /videos/{bucket}/{video_id}` | `video_management/delete_video.py` |
+| `GET /telemetry` | `telemetry/telemetry.py` |
+
+Request/response schemas: `src/common/schema.py` (`VideoRequest`,
+`VideoSummaryRequest`, `ObjectDetectionConfig`, `DataPrepResponse`,
+`BucketVideoListResponse`, telemetry models).
+
+## The embedding pipeline (`src/core/embedding/`)
+
+| File | Role |
+|---|---|
+| `simplified_embedding_helper.py` | Orchestrator — `generate_video_embedding[_from_content/_from_uri]`, `generate_text_embedding`; wires telemetry; hands storage to the VDMS client |
+| `sdk_embedding_helper.py` | **SDK mode** (~2300 lines): the in-process pipeline — decode → (optional) detect → embed → store; `preload_sdk_client`, worker threads, shared-memory frame pool |
+| `simple_client.py` | **API mode**: HTTP client to a separate multimodal-embedding-serving instance (`MULTIMODAL_EMBEDDING_ENDPOINT`) |
+| `sdk_client.py` | `SDKVDMSClient` — langchain-vdms `VDMS`/`VDMS_Client`; `store_frame_embeddings`/`store_text_embedding`; batched `video_db.add_from(...)`; embedding-dimension probing (source of the `Dimensions mismatch` error) |
+| `decoder.py` | Frame extraction: `SharedMemoryPool`, `VideoFrameExtractor`, `decode_and_batch_generator` (file/bytes/RTSP inputs) |
+
+Mode selection: `EMBEDDING_PROCESSING_MODE` (`sdk` default / `api`) in
+`src/common/settings.py`.
+
+## Supporting modules
+
+| Path | Contents |
+|---|---|
+| `src/core/object_detection/` | `detector.py` (YOLOX via OpenVINO), `yolox_utils.py`, COCO class names; weights land in `DETECTION_MODEL_DIR` (`/app/models/yolox`) |
+| `src/core/minio_client.py` | `MinioClient` — bucket/object ops, upload/download/list/delete |
+| `src/core/utils/` | `video_utils.py` (fetch from MinIO), `metadata_utils.py`, `config_utils.py`, `file_utils.py`, `common_utils.py` (`get_minio_client`) |
+| `src/core/validation.py` | `sanitize_model`, `validate_params` decorator, log sanitizing |
+| `src/core/telemetry/` | JSONL store + recorder behind `GET /telemetry` |
+| `src/common/settings.py` | pydantic `Settings` — every env var; note `DB_COLLECTION` default `video-rag-test` |
+| `src/config.yaml` | frame processing / ROI / YOLOX model config |
+
+## Build & packaging
+
+- `docker/Dockerfile` — multi-stage (`prod`, `final-dev`, `lint`, `report`);
+  context must be `microservices/` so
+  `visual-data-preparation-for-retrieval/vdms/…` and
+  `multimodal-embedding-serving/…` both resolve.
+- `build.sh` — the sanctioned build; forwards proxies, `--push` to publish.
+- `pyproject.toml` — Poetry, path dep
+  `multimodal-embedding-serving = { path = "../../multimodal-embedding-serving" }`,
+  groups `dev` (pytest/black/isort) and `cpu` (torch-cpu).
+- `docker/compose-dev.yaml` — dev overlay: mounts `..:/app`, uvicorn
+  `--reload`, `DB_COLLECTION=video-rag-dev`.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/references/testing-and-build.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/references/testing-and-build.md
@@ -8,14 +8,21 @@ SPDX-License-Identifier: Apache-2.0
 ## Tests
 
 ```bash
-source ./setup.sh test                        # scripts/tester.sh → coverage gate
-source ./setup.sh test tests/test_db.py       # one file
-# equivalent direct form:
-FASTAPI_ENV=development poetry run coverage run --rcfile ./pyproject.toml -m pytest tests/test_db.py
-poetry run coverage report -m                 # COVERAGE_REQ default 80 (export to override)
+poetry install --with dev
+poetry run coverage run --rcfile ./pyproject.toml -m pytest tests
+poetry run coverage report -m
+# one file:
+poetry run coverage run --rcfile ./pyproject.toml -m pytest tests/test_db.py
 ```
 
-- 12 test files (~850 lines): endpoint tests (`test_get_videos.py`,
+If `poetry install --with dev` fails building a native dependency with
+`Python.h: No such file or directory`, install the development headers for the
+active Python version (plus a C/C++ build toolchain) and rerun the install.
+Do not treat pytest results from the partially installed environment as a
+valid suite run; missing optional imports such as `mobileclip` are then a
+dependency-setup failure, not a test failure.
+
+- 13 test files: endpoint tests (`test_get_videos.py`,
   `test_download_video.py`, `test_delete_video.py`), pipeline/metadata
   (`test_prep_data.py`, `test_metadata.py`, `test_db.py`,
   `test_telemetry.py`), security (`test_validation_security.py`,
@@ -26,14 +33,17 @@ poetry run coverage report -m                 # COVERAGE_REQ default 80 (export 
   (`MagicMock(spec=MinioClient)`), temp `video_file`/`invalid_video_file`.
 - Suite is offline: MinIO/VDMS/embedding calls are mocked. Keep new tests
   that way — spin up no containers in unit tests.
-- Coverage sources are `src` and `tests` (`pyproject.toml`); the gate fails
-  under **80%** — new code needs tests to keep the bar.
+- Coverage sources are `src` and `tests` (`pyproject.toml`). The checkout does
+  not currently define a `fail_under` threshold; report the measured value
+  without inventing a gate.
 
 ## Lint
 
 ```bash
-source ./setup.sh lint        # black (line length 100) + isort (black profile), check-only
-source ./setup.sh lint -a     # apply fixes
+poetry run black --check src tests
+poetry run isort --check-only src tests
+# apply fixes:
+poetry run black src tests && poetry run isort src tests
 ```
 
 ## Builds (all go through the `microservices/` context)
@@ -42,10 +52,7 @@ source ./setup.sh lint -a     # apply fixes
 |---|---|
 | `./build.sh` | Build `${REGISTRY}vdms-dataprep:${TAG:-latest}` (target `prod`); `--push` publishes |
 | `source ./setup.sh --build` | Same target via setup.sh |
-| `source ./setup.sh --build-lint` | Image build that runs lint stage (fails on violations) |
-| `source ./setup.sh --build-test` | Image build running pytest + coverage gate (`COVERAGE_REQ` build-arg) |
-| `source ./setup.sh --build-report` | Coverage HTML server image (`scripts/reporter.sh`, port 8899) |
-| `source ./setup.sh --conf` / `--conf-dev` | Print resolved compose config without starting |
+| `source ./setup.sh --conf` | Print resolved compose config without starting |
 
 Why not `docker build .` from here: the Dockerfile copies both
 `visual-data-preparation-for-retrieval/vdms/` **and**
@@ -55,9 +62,9 @@ with context `../../..` for you.
 
 ## Debugging a running dev stack
 
-- `source ./setup.sh --dev` then `docker compose -f docker/compose.yaml -f
-  docker/compose-dev.yaml logs -f vdms-dataprep` — uvicorn `--reload` picks up
-  source edits from the bind mount.
+- `source ./setup.sh` builds the changed source and starts the stack; this
+  checkout has no live-reload compose overlay.
+- `docker compose -f docker/compose.yaml logs -f vdms-dataprep` follows logs.
 - `curl -s localhost:6007/v1/dataprep/health` — SDK mode reports
   `sdk_client_status`, model, device.
 - `curl -s 'localhost:6007/v1/dataprep/telemetry?limit=5'` — stage timings

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/references/testing-and-build.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-dev/references/testing-and-build.md
@@ -1,0 +1,66 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Testing & builds — VDMS DataPrep
+
+## Tests
+
+```bash
+source ./setup.sh test                        # scripts/tester.sh → coverage gate
+source ./setup.sh test tests/test_db.py       # one file
+# equivalent direct form:
+FASTAPI_ENV=development poetry run coverage run --rcfile ./pyproject.toml -m pytest tests/test_db.py
+poetry run coverage report -m                 # COVERAGE_REQ default 80 (export to override)
+```
+
+- 12 test files (~850 lines): endpoint tests (`test_get_videos.py`,
+  `test_download_video.py`, `test_delete_video.py`), pipeline/metadata
+  (`test_prep_data.py`, `test_metadata.py`, `test_db.py`,
+  `test_telemetry.py`), security (`test_validation_security.py`,
+  `test_logger_security.py`, `test_config_utils_security.py`,
+  `test_simple_client_security.py`), utils (`test_util.py`).
+- `tests/conftest.py` fixtures: `test_client` (`TestClient(app)` — importing
+  `src.main` is safe, no model loads at import), `mock_minio_client`
+  (`MagicMock(spec=MinioClient)`), temp `video_file`/`invalid_video_file`.
+- Suite is offline: MinIO/VDMS/embedding calls are mocked. Keep new tests
+  that way — spin up no containers in unit tests.
+- Coverage sources are `src` and `tests` (`pyproject.toml`); the gate fails
+  under **80%** — new code needs tests to keep the bar.
+
+## Lint
+
+```bash
+source ./setup.sh lint        # black (line length 100) + isort (black profile), check-only
+source ./setup.sh lint -a     # apply fixes
+```
+
+## Builds (all go through the `microservices/` context)
+
+| Command | What it does |
+|---|---|
+| `./build.sh` | Build `${REGISTRY}vdms-dataprep:${TAG:-latest}` (target `prod`); `--push` publishes |
+| `source ./setup.sh --build` | Same target via setup.sh |
+| `source ./setup.sh --build-lint` | Image build that runs lint stage (fails on violations) |
+| `source ./setup.sh --build-test` | Image build running pytest + coverage gate (`COVERAGE_REQ` build-arg) |
+| `source ./setup.sh --build-report` | Coverage HTML server image (`scripts/reporter.sh`, port 8899) |
+| `source ./setup.sh --conf` / `--conf-dev` | Print resolved compose config without starting |
+
+Why not `docker build .` from here: the Dockerfile copies both
+`visual-data-preparation-for-retrieval/vdms/` **and**
+`multimodal-embedding-serving/` from the context root — only
+`microservices/` contains both. `build.sh` passes `-f docker/Dockerfile`
+with context `../../..` for you.
+
+## Debugging a running dev stack
+
+- `source ./setup.sh --dev` then `docker compose -f docker/compose.yaml -f
+  docker/compose-dev.yaml logs -f vdms-dataprep` — uvicorn `--reload` picks up
+  source edits from the bind mount.
+- `curl -s localhost:6007/v1/dataprep/health` — SDK mode reports
+  `sdk_client_status`, model, device.
+- `curl -s 'localhost:6007/v1/dataprep/telemetry?limit=5'` — stage timings
+  (decode/detect/embed/store) to localize slowdowns.
+- VDMS state: `docker exec` into the `vdms-vector-db` container or probe TCP
+  6020; MinIO console at `http://localhost:6011`.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/SKILL.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/SKILL.md
@@ -77,36 +77,48 @@ Load these existing docs only when needed:
 
 ## 2. Bring-up (identical in both contexts)
 
-Credentials are never committed — export strong values in-shell and **reuse
-the same pair across restarts** (the MinIO data volume remembers the first
-ones). `setup.sh` must be **sourced**; `--nosetup` exports env without
+Credentials are never committed — export strong values in-shell and retain
+them securely if clients must keep using the same credentials across
+restarts. `setup.sh` must be **sourced**; `--nosetup` exports env without
 touching containers, `REGISTRY_URL=intel` selects the prebuilt image, and
 `--no-build` prevents a source build (building is the `-dev` skill's job).
 Run in the background — image pulls plus embedding/YOLOX model downloads take
 a while:
 
 ```bash
-bash -c 'export MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD="$(openssl rand -hex 16)" \
+bash -c 'export MINIO_ROOT_USER="<existing-or-new-user>" MINIO_ROOT_PASSWORD="<existing-or-new-strong-password>" \
   EMBEDDING_MODEL_NAME="CLIP/clip-vit-b-32" REGISTRY_URL=intel TAG=latest \
-  VS_INDEX_NAME="video-rag" \
   && source ./setup.sh --nosetup \
   && docker compose -f docker/compose.yaml up -d --no-build'
 ```
 
-(`VS_INDEX_NAME` pins the VDMS collection name — without it the compose file
-falls back to the code default `video-rag-test`.) Then wait for readiness:
+`setup.sh` fixes `INDEX_NAME=video-rag`, which compose passes as
+`DB_COLLECTION`; `VS_INDEX_NAME` is unused. Then wait for API readiness:
 
 ```bash
-until curl -sf http://localhost:6007/v1/dataprep/health; do sleep 10; done
+until curl -sf http://localhost:6007/v1/dataprep/health \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin); raise SystemExit(0 if d.get("embedding_mode") != "sdk" or d.get("sdk_client_status") == "preloaded" else 1)'
+do
+  sleep 10
+done
 ```
 
-Health shows `embedding_mode` (`sdk` default) and, in SDK mode, the loaded
-model/device. Teardown later with
+Health shows `embedding_mode` (`sdk` default) and, in SDK mode, require
+`sdk_client_status=preloaded`. This endpoint does not probe MinIO or VDMS, so
+also check the Compose services and MinIO separately:
+
+```bash
+docker compose -f docker/compose.yaml ps
+curl -sf http://localhost:6010/minio/health/live
+timeout 2 bash -c '</dev/tcp/localhost/6020'
+```
+
+Teardown later with
 `docker compose -f docker/compose.yaml down`.
 
 ## 3. Ingest a video
 
-Upload an MP4 (≤500 MB) — it is stored in MinIO and embedded in one step:
+Upload an MP4 — it is stored in MinIO and embedded in one step:
 
 ```bash
 curl -s -X POST 'http://localhost:6007/v1/dataprep/videos/upload?frame_interval=15' \
@@ -120,6 +132,22 @@ silently skipped).
 Other flows — ingest from MinIO (`POST /videos/minio`), text summaries
 (`POST /summary`), RTSP, detection tuning:
 `docs/user-guide/api-reference.md`.
+
+The upload response contains only status/message. Obtain the generated
+`dp_video_<timestamp>` identifier from `GET /videos`, then attach a summary
+using that exact bucket and `video_id`:
+
+```bash
+curl -s -X POST 'http://localhost:6007/v1/dataprep/summary' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "bucket_name": "vdms-bucket",
+    "video_id": "dp_video_1730000000",
+    "video_summary": "forklift narrowly misses pedestrian",
+    "video_start_time": 33,
+    "video_end_time": 41
+  }'
+```
 
 ## 4. Manage & observe
 
@@ -140,8 +168,8 @@ with the user first**. MinIO console: `http://localhost:6011`.
 | Health never responds on 6007 | still pulling/downloading models → `docker compose -f docker/compose.yaml logs -f vdms-dataprep` |
 | `setup.sh` errors about MINIO_ROOT_USER/PASSWORD | export them before sourcing |
 | Startup error "model name must be provided" | `EMBEDDING_MODEL_NAME` unset → export and redeploy |
-| Ingestion fails with "Dimensions mismatch" | collection was built with a different embedding model → new `VS_INDEX_NAME` or wipe (destructive — confirm) and re-ingest |
-| 413 on upload | file >500 MB → put it in MinIO (console :6011) and use `POST /videos/minio` |
+| Ingestion fails with "Dimensions mismatch" | collection was built with a different embedding model → override `INDEX_NAME` after `source setup.sh --nosetup`, or wipe (destructive — confirm), then re-ingest |
+| 413 on upload | the source endpoint has no implemented size check despite its docs; identify the rejecting proxy/server from headers and logs. For large files, avoid buffering through this endpoint: stage in MinIO and use `POST /videos/minio` |
 | Detected objects missing from results | YOLOX download failed on first run (no network) → restart with network access |
-| MinIO auth errors after re-deploy | creds differ from the ones the MinIO volume was created with → reuse originals |
-| MinIO bind-mount errors at start | default `MINIO_MOUNT_PATH=/mnt/miniodata` not writable → export a writable path first |
+| MinIO auth errors after re-deploy | inspect the effective container `MINIO_ROOT_*` environment and ensure clients use the same current credentials |
+| MinIO bind-mount errors at start | `setup.sh` overwrites `MINIO_MOUNT_PATH=/mnt/miniodata`; after `source setup.sh --nosetup`, export a writable path, then invoke Compose manually |

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/SKILL.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/SKILL.md
@@ -9,9 +9,6 @@ description: >
   at http://localhost:6007/v1/dataprep. Ingestion only: it does not answer
   search queries. Not for modifying the service's source — that is
   vdms-dataprep-dev.
-argument-hint: >
-  Describe what you want to deploy or ingest (e.g. "bring up the stack and
-  ingest this mp4", or "add a text summary embedding for a video time range")
 ---
 
 # VDMS DataPrep — User

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/SKILL.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: vdms-dataprep-user
+description: >
+  Deploy and consume the VDMS DataPrep video-ingestion stack (dataprep + VDMS
+  vector DB + MinIO) — bring it up with setup.sh + docker compose (from a repo
+  clone, or by fetching those same files from GitHub when no clone exists)
+  using the prebuilt intel/vdms-dataprep image, then upload/ingest MP4s, add
+  text-summary embeddings, and list/download/delete videos through the REST API
+  at http://localhost:6007/v1/dataprep. Ingestion only: it does not answer
+  search queries. Not for modifying the service's source — that is
+  vdms-dataprep-dev.
+argument-hint: >
+  Describe what you want to deploy or ingest (e.g. "bring up the stack and
+  ingest this mp4", or "add a text summary embedding for a video time range")
+---
+
+# VDMS DataPrep — User
+
+Run the ingestion stack and feed it videos. **Run commands yourself** and
+relay output. API base: `http://localhost:6007/v1/dataprep`. Scope note: this
+service **ingests** (video → embeddings → VDMS); querying/searching those
+embeddings is a different component (e.g. a video-search app reading the same
+VDMS).
+
+## When to Use
+
+- Bring up the dataprep + VDMS + MinIO stack and confirm health
+- Upload/ingest MP4s (direct upload or from MinIO) with embeddings
+- Add text-summary embeddings for a video time range
+- List, download, or delete ingested videos
+- Diagnose 413 uploads, dimension mismatches, or MinIO credential errors
+
+## Example Prompts
+
+Sample Problem-solving scenarios this skill handles end-to-end:
+
+| Example | Problem it solves |
+|---|---|
+| [manufacturing-inspection-archive.md](./example-prompts/manufacturing-inspection-archive.md) | Archive production-line clips with frame + object-crop metadata |
+| [object-aware-video-catalog.md](./example-prompts/object-aware-video-catalog.md) | Catalog clips by detected objects with confidence thresholds and tags |
+| [edge-video-preprocessing-box.md](./example-prompts/edge-video-preprocessing-box.md) | Preprocess camera MP4s near the source (MinIO + VDMS) before central sync |
+
+## Docs & deploy files — with or without a clone
+
+All paths below are relative to
+`microservices/visual-data-preparation-for-retrieval/vdms/` in the
+[edge-ai-libraries](https://github.com/open-edge-platform/edge-ai-libraries)
+repo. **No clone?** Fetch any of them from GitHub raw:
+
+```
+https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/main/microservices/visual-data-preparation-for-retrieval/vdms/<path>
+```
+
+Load these existing docs only when needed:
+
+| Resource | Load when… |
+|---|---|
+| `docs/user-guide/api-reference.md` + `docs/user-guide/api-docs/openapi.yaml` | building requests beyond a simple upload (minio ingest, summaries, delete/download, telemetry) |
+| `docs/user-guide/get-started.md` | env-var tables, detection/ROI tuning, more curl examples, troubleshooting |
+| `docs/user-guide/Overview.md` + `docs/user-guide/overview-architecture.md` | how the pipeline works (frames → detection → embeddings → VDMS) |
+| `setup.sh`, `docker/compose.yaml` | the deploy artifacts used below |
+
+## 1. Context routing — repo clone or standalone?
+
+```bash
+[ -f setup.sh ] && grep -q 'name = "vdms-dataprep"' pyproject.toml 2>/dev/null \
+  && echo REPO || echo STANDALONE
+```
+
+- **REPO** → run Step 2 from the microservice root.
+- **STANDALONE** → fetch the two deploy files, then the exact same Step 2:
+  ```bash
+  RAW=https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/main/microservices/visual-data-preparation-for-retrieval/vdms
+  mkdir -p vdms-dataprep/docker && cd vdms-dataprep
+  curl -fsSL $RAW/setup.sh -o setup.sh
+  curl -fsSL $RAW/docker/compose.yaml -o docker/compose.yaml
+  ```
+- Already running (`curl -sf http://localhost:6007/v1/dataprep/health`) →
+  Step 3.
+
+## 2. Bring-up (identical in both contexts)
+
+Credentials are never committed — export strong values in-shell and **reuse
+the same pair across restarts** (the MinIO data volume remembers the first
+ones). `setup.sh` must be **sourced**; `--nosetup` exports env without
+touching containers, `REGISTRY_URL=intel` selects the prebuilt image, and
+`--no-build` prevents a source build (building is the `-dev` skill's job).
+Run in the background — image pulls plus embedding/YOLOX model downloads take
+a while:
+
+```bash
+bash -c 'export MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD="$(openssl rand -hex 16)" \
+  EMBEDDING_MODEL_NAME="CLIP/clip-vit-b-32" REGISTRY_URL=intel TAG=latest \
+  VS_INDEX_NAME="video-rag" \
+  && source ./setup.sh --nosetup \
+  && docker compose -f docker/compose.yaml up -d --no-build'
+```
+
+(`VS_INDEX_NAME` pins the VDMS collection name — without it the compose file
+falls back to the code default `video-rag-test`.) Then wait for readiness:
+
+```bash
+until curl -sf http://localhost:6007/v1/dataprep/health; do sleep 10; done
+```
+
+Health shows `embedding_mode` (`sdk` default) and, in SDK mode, the loaded
+model/device. Teardown later with
+`docker compose -f docker/compose.yaml down`.
+
+## 3. Ingest a video
+
+Upload an MP4 (≤500 MB) — it is stored in MinIO and embedded in one step:
+
+```bash
+curl -s -X POST 'http://localhost:6007/v1/dataprep/videos/upload?frame_interval=15' \
+  -F 'file=@/path/to/video.mp4;type=video/mp4'
+```
+
+`201` → `{"status":"success","message":"..."}`. First ingestion also
+downloads the YOLOX detector (needs network; without it, object detection is
+silently skipped).
+
+Other flows — ingest from MinIO (`POST /videos/minio`), text summaries
+(`POST /summary`), RTSP, detection tuning:
+`docs/user-guide/api-reference.md`.
+
+## 4. Manage & observe
+
+```bash
+curl -s 'http://localhost:6007/v1/dataprep/videos'              # list (default bucket vdms-bucket)
+curl -s 'http://localhost:6007/v1/dataprep/telemetry?limit=5'   # ingestion timings
+```
+
+Download: `GET /videos/download?video_id=…`. Delete:
+`DELETE /videos/{bucket_name}/{video_id}[?video_name=…]` — without
+`video_name` it deletes the **whole video directory**; destructive, **confirm
+with the user first**. MinIO console: `http://localhost:6011`.
+
+## Troubleshooting
+
+| Symptom | Likely cause → action |
+|---|---|
+| Health never responds on 6007 | still pulling/downloading models → `docker compose -f docker/compose.yaml logs -f vdms-dataprep` |
+| `setup.sh` errors about MINIO_ROOT_USER/PASSWORD | export them before sourcing |
+| Startup error "model name must be provided" | `EMBEDDING_MODEL_NAME` unset → export and redeploy |
+| Ingestion fails with "Dimensions mismatch" | collection was built with a different embedding model → new `VS_INDEX_NAME` or wipe (destructive — confirm) and re-ingest |
+| 413 on upload | file >500 MB → put it in MinIO (console :6011) and use `POST /videos/minio` |
+| Detected objects missing from results | YOLOX download failed on first run (no network) → restart with network access |
+| MinIO auth errors after re-deploy | creds differ from the ones the MinIO volume was created with → reuse originals |
+| MinIO bind-mount errors at start | default `MINIO_MOUNT_PATH=/mnt/miniodata` not writable → export a writable path first |

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/evals/evals.json
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/evals/evals.json
@@ -4,48 +4,53 @@
   "skill_name": "vdms-dataprep-user",
   "evals": [
     {
-      "id": "bringup-and-health",
+      "id": 1,
+      "name": "bringup-and-health",
       "prompt": "Get Intel's VDMS dataprep stack (dataprep API, vector DB, object storage) running locally from prebuilt images and prove it's healthy.",
       "expected_output": "Brings up all three services (vdms-dataprep + VDMS + MinIO) from prebuilt images with MINIO_ROOT_USER/MINIO_ROOT_PASSWORD and MULTIMODAL_EMBEDDING_MODEL_NAME exported, then polls GET http://localhost:6007/v1/dataprep/health until it returns ok.",
-      "assertions": [
+      "expectations": [
         "Starts all three services (dataprep, VDMS, MinIO) from prebuilt images without building from source",
         "Exports MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, and MULTIMODAL_EMBEDDING_MODEL_NAME before launch",
         "Verifies readiness via GET /v1/dataprep/health on port 6007"
       ]
     },
     {
-      "id": "upload-video",
+      "id": 2,
+      "name": "upload-video",
       "prompt": "The vdms dataprep service is healthy on localhost:6007. Ingest my file /data/forklift.mp4 sampling every 10th frame.",
       "expected_output": "A multipart POST to http://localhost:6007/v1/dataprep/videos/upload with the file form field and frame_interval=10.",
-      "assertions": [
+      "expectations": [
         "Uploads via multipart POST to /v1/dataprep/videos/upload with a file form field",
         "Sets frame_interval=10 as a form/query parameter, not a JSON body",
         "Uses the /v1/dataprep prefix on port 6007"
       ]
     },
     {
-      "id": "attach-summary",
+      "id": 3,
+      "name": "attach-summary",
       "prompt": "Video 'forklift' is already ingested in the dataprep stack. Attach the summary 'forklift narrowly misses pedestrian' covering seconds 33 to 41.",
       "expected_output": "A POST to /v1/dataprep/summary with a JSON body containing bucket_name, video_id, video_summary, video_start_time: 33, and video_end_time: 41.",
-      "assertions": [
+      "expectations": [
         "Posts to /v1/dataprep/summary with a JSON body (not multipart)",
         "Includes video_summary, video_start_time: 33, and video_end_time: 41 referencing the ingested video's bucket/video_id"
       ]
     },
     {
-      "id": "oversize-upload-routing",
+      "id": 4,
+      "name": "oversize-upload-routing",
       "prompt": "My 2 GB MP4 gets rejected with HTTP 413 when I POST it to the dataprep upload endpoint. How do I ingest it?",
       "expected_output": "Explains the 500 MB upload limit and routes to the supported path: stage the file in MinIO directly, then trigger ingestion with POST /v1/dataprep/videos/minio referencing the bucket and video_id.",
-      "assertions": [
+      "expectations": [
         "Attributes the 413 to the 500 MB limit on /videos/upload",
         "Recommends staging the file in MinIO and ingesting via POST /v1/dataprep/videos/minio"
       ]
     },
     {
-      "id": "negative-search-routing",
+      "id": 5,
+      "name": "negative-search-routing",
       "prompt": "Using the vdms dataprep API, search my ingested videos for clips where a red truck appears.",
       "expected_output": "Clarifies that dataprep only ingests (video to embeddings to VDMS) and has no search endpoint; querying is done by a separate search component reading the same VDMS collection.",
-      "assertions": [
+      "expectations": [
         "Does not fabricate a search or query endpoint on the dataprep API",
         "States that dataprep is ingestion-only and search is handled by a separate component"
       ]

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/evals/evals.json
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/evals/evals.json
@@ -6,18 +6,19 @@
     {
       "id": 1,
       "name": "bringup-and-health",
-      "prompt": "Get Intel's VDMS dataprep stack (dataprep API, vector DB, object storage) running locally from prebuilt images and prove it's healthy.",
-      "expected_output": "Brings up all three services (vdms-dataprep + VDMS + MinIO) from prebuilt images with MINIO_ROOT_USER/MINIO_ROOT_PASSWORD and MULTIMODAL_EMBEDDING_MODEL_NAME exported, then polls GET http://localhost:6007/v1/dataprep/health until it returns ok.",
+      "prompt": "Give me an exact runbook to start Intel's VDMS dataprep stack (dataprep API, vector DB, object storage) from prebuilt images and verify each dependency. Do not actually launch containers in this environment.",
+      "expected_output": "Provides a prebuilt-image runbook with required MinIO/model variables, setup.sh --nosetup plus docker compose --no-build, API readiness with sdk_client_status=preloaded in SDK mode, a MinIO liveness probe, and a separate VDMS service/TCP check.",
       "expectations": [
-        "Starts all three services (dataprep, VDMS, MinIO) from prebuilt images without building from source",
-        "Exports MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, and MULTIMODAL_EMBEDDING_MODEL_NAME before launch",
-        "Verifies readiness via GET /v1/dataprep/health on port 6007"
+        "Uses setup.sh --nosetup plus docker compose --no-build (or equivalent) with prebuilt dataprep, VDMS, and MinIO images",
+        "Exports MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, and EMBEDDING_MODEL_NAME without embedding real credentials",
+        "Checks GET /v1/dataprep/health on port 6007 and requires sdk_client_status=preloaded in SDK mode",
+        "Separately checks MinIO liveness and VDMS service/TCP reachability rather than treating dataprep /health as proof of both"
       ]
     },
     {
       "id": 2,
       "name": "upload-video",
-      "prompt": "The vdms dataprep service is healthy on localhost:6007. Ingest my file /data/forklift.mp4 sampling every 10th frame.",
+      "prompt": "The vdms dataprep service is healthy on localhost:6007. Give me the exact request to ingest /data/forklift.mp4 while sampling every 10th frame; do not claim the file was uploaded from this environment.",
       "expected_output": "A multipart POST to http://localhost:6007/v1/dataprep/videos/upload with the file form field and frame_interval=10.",
       "expectations": [
         "Uploads via multipart POST to /v1/dataprep/videos/upload with a file form field",
@@ -28,8 +29,8 @@
     {
       "id": 3,
       "name": "attach-summary",
-      "prompt": "Video 'forklift' is already ingested in the dataprep stack. Attach the summary 'forklift narrowly misses pedestrian' covering seconds 33 to 41.",
-      "expected_output": "A POST to /v1/dataprep/summary with a JSON body containing bucket_name, video_id, video_summary, video_start_time: 33, and video_end_time: 41.",
+      "prompt": "In bucket vdms-bucket, video_id dp_video_1730000000 is already ingested. Give me the exact request to attach the summary 'forklift narrowly misses pedestrian' covering seconds 33 to 41; do not call the live API.",
+      "expected_output": "A POST to /v1/dataprep/summary with a JSON body containing bucket_name=vdms-bucket, video_id=dp_video_1730000000, video_summary, video_start_time: 33, and video_end_time: 41.",
       "expectations": [
         "Posts to /v1/dataprep/summary with a JSON body (not multipart)",
         "Includes video_summary, video_start_time: 33, and video_end_time: 41 referencing the ingested video's bucket/video_id"
@@ -38,21 +39,21 @@
     {
       "id": 4,
       "name": "oversize-upload-routing",
-      "prompt": "My 2 GB MP4 gets rejected with HTTP 413 when I POST it to the dataprep upload endpoint. How do I ingest it?",
-      "expected_output": "Explains the 500 MB upload limit and routes to the supported path: stage the file in MinIO directly, then trigger ingestion with POST /v1/dataprep/videos/minio referencing the bucket and video_id.",
+      "prompt": "My 2 GB MP4 gets HTTP 413 when sent toward the dataprep upload endpoint. Diagnose what to check and give me the supported large-file ingestion workaround.",
+      "expected_output": "Does not claim the source endpoint enforces a 500 MB limit because it currently reads the full body without a size check. Identifies the rejecting proxy/server using headers and logs, then recommends staging the file in MinIO and POST /v1/dataprep/videos/minio.",
       "expectations": [
-        "Attributes the 413 to the 500 MB limit on /videos/upload",
+        "Does not attribute the 413 to a source-enforced 500 MB limit and recommends checking proxy/server headers and logs",
         "Recommends staging the file in MinIO and ingesting via POST /v1/dataprep/videos/minio"
       ]
     },
     {
       "id": 5,
-      "name": "negative-search-routing",
-      "prompt": "Using the vdms dataprep API, search my ingested videos for clips where a red truck appears.",
-      "expected_output": "Clarifies that dataprep only ingests (video to embeddings to VDMS) and has no search endpoint; querying is done by a separate search component reading the same VDMS collection.",
+      "name": "single-file-delete-safety",
+      "prompt": "In bucket vdms-bucket, video directory dp_video_1730000000 contains forklift.mp4 plus metadata. Give me the exact request that deletes only forklift.mp4 and preserves the rest of the directory.",
+      "expected_output": "Uses DELETE /v1/dataprep/videos/vdms-bucket/dp_video_1730000000?video_name=forklift.mp4 and warns that omitting video_name deletes the entire video directory.",
       "expectations": [
-        "Does not fabricate a search or query endpoint on the dataprep API",
-        "States that dataprep is ingestion-only and search is handled by a separate component"
+        "Uses DELETE /v1/dataprep/videos/vdms-bucket/dp_video_1730000000 with video_name=forklift.mp4",
+        "Warns that omitting video_name deletes the whole video directory and does not recommend that broader deletion"
       ]
     }
   ]

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/evals/evals.json
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/evals/evals.json
@@ -4,56 +4,50 @@
   "skill_name": "vdms-dataprep-user",
   "evals": [
     {
-      "id": "standalone-bringup",
-      "prompt": "I'm building a video retrieval demo and need Intel's VDMS-based data preparation stack running locally. I don't have the edge-ai-libraries repo. Get the whole thing up (vector DB, object storage, the dataprep API) and prove it's healthy.",
-      "expected_output": "A 3-container bring-up (vdms-dataprep + intellabs/vdms + MinIO) from prebuilt images — e.g. fetching setup.sh + docker/compose.yaml from GitHub raw, then source ./setup.sh --nosetup and docker compose up -d --no-build with REGISTRY_URL=intel — with MinIO credentials exported in-shell (not hardcoded in committed files), and readiness proven by polling GET /v1/dataprep/health on port 6007.",
+      "id": "bringup-and-health",
+      "prompt": "Get Intel's VDMS dataprep stack (dataprep API, vector DB, object storage) running locally from prebuilt images and prove it's healthy.",
+      "expected_output": "Brings up all three services (vdms-dataprep + VDMS + MinIO) from prebuilt images with MINIO_ROOT_USER/MINIO_ROOT_PASSWORD and MULTIMODAL_EMBEDDING_MODEL_NAME exported, then polls GET http://localhost:6007/v1/dataprep/health until it returns ok.",
       "assertions": [
-        "Starts all three services (dataprep, VDMS vector DB, MinIO) from prebuilt images without cloning the repo or building from source",
-        "Exports MINIO_ROOT_USER and MINIO_ROOT_PASSWORD as environment variables rather than writing credentials into committed files",
-        "Polls http://localhost:6007/v1/dataprep/health (the /v1/dataprep prefix present) until it returns ok",
-        "Mentions the first start is slow due to image pulls and embedding/YOLOX model downloads"
+        "Starts all three services (dataprep, VDMS, MinIO) from prebuilt images without building from source",
+        "Exports MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, and MULTIMODAL_EMBEDDING_MODEL_NAME before launch",
+        "Verifies readiness via GET /v1/dataprep/health on port 6007"
       ]
     },
     {
-      "id": "upload-and-summary-flow",
-      "prompt": "The vdms dataprep service is healthy on localhost:6007. Ingest my file /data/forklift.mp4 sampling every 10th frame, then attach the summary 'forklift narrowly misses pedestrian near bay 4' covering seconds 33 to 41 of that video.",
-      "expected_output": "Two correct API calls: a multipart POST to /v1/dataprep/videos/upload with frame_interval=10, then a POST /v1/dataprep/summary whose JSON body references the same bucket/video_id with video_start_time 33 and video_end_time 41.",
+      "id": "upload-video",
+      "prompt": "The vdms dataprep service is healthy on localhost:6007. Ingest my file /data/forklift.mp4 sampling every 10th frame.",
+      "expected_output": "A multipart POST to http://localhost:6007/v1/dataprep/videos/upload with the file form field and frame_interval=10.",
       "assertions": [
-        "Uploads via multipart POST to /v1/dataprep/videos/upload with a file form field and frame_interval=10 as a query parameter (not JSON body)",
-        "Posts the summary to /v1/dataprep/summary with JSON fields video_summary, video_start_time: 33, video_end_time: 41",
-        "The summary call references the same video_id (and bucket) that the upload produced",
-        "Both calls use the /v1/dataprep prefix on port 6007"
+        "Uploads via multipart POST to /v1/dataprep/videos/upload with a file form field",
+        "Sets frame_interval=10 as a form/query parameter, not a JSON body",
+        "Uses the /v1/dataprep prefix on port 6007"
       ]
     },
     {
-      "id": "dimension-mismatch-edge",
-      "prompt": "We had the dataprep stack running with CLIP/clip-vit-b-32 and ingested 200 videos. Yesterday someone switched EMBEDDING_MODEL_NAME to SigLIP/siglip2-vit-b-16 and now every ingestion fails with 'Dimensions mismatch'. What happened and how do we recover?",
-      "expected_output": "Diagnosis: the VDMS collection was created with 512-dim CLIP vectors; SigLIP produces different-dimension vectors, so inserts fail. Recovery options: switch back to the original model, or use a new collection/INDEX_NAME (or wipe the VDMS data — destructive, requires explicit confirmation) and re-ingest all videos with the new model.",
+      "id": "attach-summary",
+      "prompt": "Video 'forklift' is already ingested in the dataprep stack. Attach the summary 'forklift narrowly misses pedestrian' covering seconds 33 to 41.",
+      "expected_output": "A POST to /v1/dataprep/summary with a JSON body containing bucket_name, video_id, video_summary, video_start_time: 33, and video_end_time: 41.",
       "assertions": [
-        "Explains the collection is bound to the embedding dimension of the model it was created with",
-        "Offers switching back to the original model as the non-destructive option",
-        "Offers a new collection name (INDEX_NAME/DB_COLLECTION) or a wipe plus full re-ingestion for adopting the new model",
-        "Flags wiping existing vectors as destructive and requiring user confirmation, not something to just execute"
+        "Posts to /v1/dataprep/summary with a JSON body (not multipart)",
+        "Includes video_summary, video_start_time: 33, and video_end_time: 41 referencing the ingested video's bucket/video_id"
       ]
     },
     {
       "id": "oversize-upload-routing",
-      "prompt": "My 2 GB warehouse-camera MP4 gets rejected with HTTP 413 when I POST it to the dataprep upload endpoint. Is there a way to ingest it anyway?",
-      "expected_output": "Explains the 500 MB multipart upload limit, and routes to the supported path: stage the file in MinIO directly (console on 6011 or S3 API on 6010), then trigger ingestion with POST /v1/dataprep/videos/minio referencing the bucket/video_id.",
+      "prompt": "My 2 GB MP4 gets rejected with HTTP 413 when I POST it to the dataprep upload endpoint. How do I ingest it?",
+      "expected_output": "Explains the 500 MB upload limit and routes to the supported path: stage the file in MinIO directly, then trigger ingestion with POST /v1/dataprep/videos/minio referencing the bucket and video_id.",
       "assertions": [
         "Attributes the 413 to the 500 MB limit on /videos/upload",
-        "Recommends staging the file in MinIO (console/S3 API) instead of working around the limit",
-        "Uses POST /v1/dataprep/videos/minio with a JSON body to ingest the staged file"
+        "Recommends staging the file in MinIO and ingesting via POST /v1/dataprep/videos/minio"
       ]
     },
     {
       "id": "negative-search-routing",
-      "prompt": "Using the vdms dataprep API, search my ingested videos for clips where a red truck appears at the loading dock.",
-      "expected_output": "Clarifies that DataPrep only ingests (video to embeddings to VDMS) and exposes no search/query endpoint; querying the stored embeddings is done by a separate search component (e.g. a video search microservice/app reading the same VDMS). Does not invent a dataprep search endpoint.",
+      "prompt": "Using the vdms dataprep API, search my ingested videos for clips where a red truck appears.",
+      "expected_output": "Clarifies that dataprep only ingests (video to embeddings to VDMS) and has no search endpoint; querying is done by a separate search component reading the same VDMS collection.",
       "assertions": [
         "Does not fabricate a search or query endpoint on the dataprep API",
-        "States that dataprep is ingestion-only and search is a separate component that reads the same VDMS collection",
-        "Optionally points to listing endpoints (/videos) as the only browse capability dataprep itself offers"
+        "States that dataprep is ingestion-only and search is handled by a separate component"
       ]
     }
   ]

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/evals/evals.json
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "SPDX-FileCopyrightText": "(C) 2026 Intel Corporation",
+  "SPDX-License-Identifier": "Apache-2.0",
+  "skill_name": "vdms-dataprep-user",
+  "evals": [
+    {
+      "id": "standalone-bringup",
+      "prompt": "I'm building a video retrieval demo and need Intel's VDMS-based data preparation stack running locally. I don't have the edge-ai-libraries repo. Get the whole thing up (vector DB, object storage, the dataprep API) and prove it's healthy.",
+      "expected_output": "A 3-container bring-up (vdms-dataprep + intellabs/vdms + MinIO) from prebuilt images — e.g. fetching setup.sh + docker/compose.yaml from GitHub raw, then source ./setup.sh --nosetup and docker compose up -d --no-build with REGISTRY_URL=intel — with MinIO credentials exported in-shell (not hardcoded in committed files), and readiness proven by polling GET /v1/dataprep/health on port 6007.",
+      "assertions": [
+        "Starts all three services (dataprep, VDMS vector DB, MinIO) from prebuilt images without cloning the repo or building from source",
+        "Exports MINIO_ROOT_USER and MINIO_ROOT_PASSWORD as environment variables rather than writing credentials into committed files",
+        "Polls http://localhost:6007/v1/dataprep/health (the /v1/dataprep prefix present) until it returns ok",
+        "Mentions the first start is slow due to image pulls and embedding/YOLOX model downloads"
+      ]
+    },
+    {
+      "id": "upload-and-summary-flow",
+      "prompt": "The vdms dataprep service is healthy on localhost:6007. Ingest my file /data/forklift.mp4 sampling every 10th frame, then attach the summary 'forklift narrowly misses pedestrian near bay 4' covering seconds 33 to 41 of that video.",
+      "expected_output": "Two correct API calls: a multipart POST to /v1/dataprep/videos/upload with frame_interval=10, then a POST /v1/dataprep/summary whose JSON body references the same bucket/video_id with video_start_time 33 and video_end_time 41.",
+      "assertions": [
+        "Uploads via multipart POST to /v1/dataprep/videos/upload with a file form field and frame_interval=10 as a query parameter (not JSON body)",
+        "Posts the summary to /v1/dataprep/summary with JSON fields video_summary, video_start_time: 33, video_end_time: 41",
+        "The summary call references the same video_id (and bucket) that the upload produced",
+        "Both calls use the /v1/dataprep prefix on port 6007"
+      ]
+    },
+    {
+      "id": "dimension-mismatch-edge",
+      "prompt": "We had the dataprep stack running with CLIP/clip-vit-b-32 and ingested 200 videos. Yesterday someone switched EMBEDDING_MODEL_NAME to SigLIP/siglip2-vit-b-16 and now every ingestion fails with 'Dimensions mismatch'. What happened and how do we recover?",
+      "expected_output": "Diagnosis: the VDMS collection was created with 512-dim CLIP vectors; SigLIP produces different-dimension vectors, so inserts fail. Recovery options: switch back to the original model, or use a new collection/INDEX_NAME (or wipe the VDMS data — destructive, requires explicit confirmation) and re-ingest all videos with the new model.",
+      "assertions": [
+        "Explains the collection is bound to the embedding dimension of the model it was created with",
+        "Offers switching back to the original model as the non-destructive option",
+        "Offers a new collection name (INDEX_NAME/DB_COLLECTION) or a wipe plus full re-ingestion for adopting the new model",
+        "Flags wiping existing vectors as destructive and requiring user confirmation, not something to just execute"
+      ]
+    },
+    {
+      "id": "oversize-upload-routing",
+      "prompt": "My 2 GB warehouse-camera MP4 gets rejected with HTTP 413 when I POST it to the dataprep upload endpoint. Is there a way to ingest it anyway?",
+      "expected_output": "Explains the 500 MB multipart upload limit, and routes to the supported path: stage the file in MinIO directly (console on 6011 or S3 API on 6010), then trigger ingestion with POST /v1/dataprep/videos/minio referencing the bucket/video_id.",
+      "assertions": [
+        "Attributes the 413 to the 500 MB limit on /videos/upload",
+        "Recommends staging the file in MinIO (console/S3 API) instead of working around the limit",
+        "Uses POST /v1/dataprep/videos/minio with a JSON body to ingest the staged file"
+      ]
+    },
+    {
+      "id": "negative-search-routing",
+      "prompt": "Using the vdms dataprep API, search my ingested videos for clips where a red truck appears at the loading dock.",
+      "expected_output": "Clarifies that DataPrep only ingests (video to embeddings to VDMS) and exposes no search/query endpoint; querying the stored embeddings is done by a separate search component (e.g. a video search microservice/app reading the same VDMS). Does not invent a dataprep search endpoint.",
+      "assertions": [
+        "Does not fabricate a search or query endpoint on the dataprep API",
+        "States that dataprep is ingestion-only and search is a separate component that reads the same VDMS collection",
+        "Optionally points to listing endpoints (/videos) as the only browse capability dataprep itself offers"
+      ]
+    }
+  ]
+}

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/example-prompts/edge-video-preprocessing-box.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/example-prompts/edge-video-preprocessing-box.md
@@ -1,0 +1,14 @@
+Build an edge video preprocessing box: a small watcher that runs near the cameras and turns each new MP4 into retrieval-ready data locally, before any central sync.
+
+- Bring the full stack up on the edge host (dataprep + VDMS + MinIO, all local); export strong MinIO credentials in-shell and reuse the same pair across restarts.
+- Watch a drop folder; on each new MP4, POST /videos/upload with a moderate frame_interval and a per-camera tag (e.g. tags=camera-1).
+- Raw MP4s land in MinIO (console on :6011), embeddings and metadata in the local VDMS collection — everything stays on the box; a later sync job can read MinIO and VDMS directly.
+- Report per-file ingestion status and rolling GET /telemetry timings.
+
+Validate the application using:
+- Embedding model CLIP/clip-vit-b-32; API base http://localhost:6007/v1/dataprep.
+- Two clips from Intel's sample-videos repo (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4) dropped one after another: car-detection.mp4 (tag camera-1) and people-detection.mp4 (tag camera-2).
+
+Expected results:
+- Each drop returns 201 and the clip appears in GET /videos; the MinIO console shows the raw files; GET /telemetry shows two ingestion entries.
+- Stopping and restarting the stack with the same credentials keeps the library intact (the MinIO volume and VDMS collection persist).

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/example-prompts/manufacturing-inspection-archive.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/example-prompts/manufacturing-inspection-archive.md
@@ -1,0 +1,15 @@
+Build a manufacturing inspection archive that stores production-line clips with frame and object-crop metadata using the VDMS DataPrep stack.
+
+- Bring the stack up if it isn't already (dataprep + VDMS + MinIO from the prebuilt image); reuse the MinIO credentials and embedding model it was started with.
+- Ingest each line clip via POST /videos/upload with a small frame_interval (dense sampling for inspection), enable_object_detection=true, a detection_confidence tuned for the line (default 0.85), and tags identifying line and shift (e.g. tags=line-a&tags=shift-1).
+- Each sampled frame gets its own embedding in VDMS; detected-object crops are embedded too; the raw MP4 stays in MinIO.
+- Show the archive with GET /videos and per-ingestion timings with GET /telemetry.
+
+Validate the application using:
+- Embedding model CLIP/clip-vit-b-32; API base http://localhost:6007/v1/dataprep.
+- bottle-detection.mp4 from Intel's sample-videos repo (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4) — bottles on a conveyor, and "bottle" is a class the YOLOX detector knows.
+- frame_interval=10, detection enabled, tags line-a.
+
+Expected results:
+- The upload returns 201 with status success; GET /videos lists the clip and GET /telemetry shows the ingestion entry.
+- The first ingestion downloads the YOLOX model (needs network access — without it, object detection is silently skipped and only frame embeddings are stored).

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/example-prompts/object-aware-video-catalog.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.github/skills/vdms-dataprep-user/example-prompts/object-aware-video-catalog.md
@@ -1,0 +1,15 @@
+Build an object-aware video catalog that creates retrieval-ready records for clips containing detected objects, using the VDMS DataPrep stack.
+
+- Bring the stack up if it isn't already; reuse the MinIO credentials and embedding model it was started with.
+- Ingest each clip via POST /videos/upload with enable_object_detection=true, a detection_confidence threshold suited to the footage (lower catches more objects, higher favors precision), and content tags for later filtering (e.g. tags=street&tags=vehicles).
+- Detected-object crops get their own embeddings in VDMS alongside the frame embeddings, so a separate search layer reading the same VDMS collection can later match queries like "bicycle" against crops and filter by tags — dataprep itself exposes no search endpoint.
+- Verify the catalog with GET /videos and GET /telemetry.
+
+Validate the application using:
+- Embedding model CLIP/clip-vit-b-32; API base http://localhost:6007/v1/dataprep.
+- person-bicycle-car-detection.mp4 from Intel's sample-videos repo (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4) — person, bicycle, and car are all classes the YOLOX detector knows.
+- Two ingestions of the clip: detection_confidence=0.85, then 0.5 (renamed copy so the video_id differs), both tagged street.
+
+Expected results:
+- Both ingestions return 201 and appear in GET /videos; GET /telemetry records both, with the lower-threshold run generally taking longer since more crops are embedded.
+- Detection requires the YOLOX model to have downloaded on first run (network needed); otherwise crops are silently skipped.

--- a/microservices/visual-data-preparation-for-retrieval/vdms/.gitignore
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/.gitignore
@@ -23,4 +23,4 @@ dist/
 ov_model_venv
 ovms_config
 docs/implementation-history
-.github
+# .github is tracked: it holds the agent scaffolding (copilot-instructions.md, skills/)

--- a/microservices/visual-data-preparation-for-retrieval/vdms/AGENTS.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/AGENTS.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# VDMS DataPrep — AI agents
+
+**Do not add project policy here.**
+
+- **All tools:** [`.github/copilot-instructions.md`](.github/copilot-instructions.md)
+- **Claude:** [`CLAUDE.md`](CLAUDE.md)
+- **Cursor:** [`.cursor/rules/vdms-dataprep.mdc`](.cursor/rules/vdms-dataprep.mdc)

--- a/microservices/visual-data-preparation-for-retrieval/vdms/CLAUDE.md
+++ b/microservices/visual-data-preparation-for-retrieval/vdms/CLAUDE.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# VDMS DataPrep — Claude
+
+**Do not add project policy here.**
+
+- **Canonical instructions:** [`.github/copilot-instructions.md`](.github/copilot-instructions.md)
+- **Skills:** [`.github/skills/`](.github/skills/)

--- a/microservices/vlm-openvino-serving/.cursor/rules/vlm-openvino-serving.mdc
+++ b/microservices/vlm-openvino-serving/.cursor/rules/vlm-openvino-serving.mdc
@@ -1,0 +1,28 @@
+---
+description: VLM OpenVINO Serving Cursor agent router — canonical instructions and workflow skills
+alwaysApply: true
+---
+
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+## Canonical instructions
+
+Read [.github/copilot-instructions.md](../../.github/copilot-instructions.md)
+first. Do not duplicate policy here.
+
+## Skills
+
+Discover workflow skills by reading the `SKILL.md` files under
+[.github/skills/](../../.github/skills/); prefer
+[skill-catalog.json](../../.github/skills/skill-catalog.json) for routing and
+do not assume a fixed list.
+
+## Cursor workflow
+
+- Prefer the service's real interfaces: `source setup.sh`,
+  `docker compose -f docker/compose.yaml`, and the REST API on port `9764`.
+- Run commands yourself and relay results; keep changes minimal.
+- Commit or open PRs only when explicitly asked.

--- a/microservices/vlm-openvino-serving/.github/copilot-instructions.md
+++ b/microservices/vlm-openvino-serving/.github/copilot-instructions.md
@@ -1,0 +1,109 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# VLM OpenVINO Serving — AI agents
+
+## Canonical Instructions
+
+Use this file as the canonical router for coding agents. Keep tool-specific
+files such as `AGENTS.md`, `CLAUDE.md`, and
+`.cursor/rules/vlm-openvino-serving.mdc` as short pointers to this file.
+
+## What This Service Is
+
+VLM OpenVINO Serving is an **OpenAI-API-compatible** microservice (FastAPI +
+OpenVINO GenAI) that serves Vision Language Models — image and video chat
+completions — on Intel CPUs and GPUs. It targets VLMs not yet supported by
+OpenVINO Model Server. A prebuilt image is published as
+`intel/vlm-openvino-serving:latest` on Docker Hub. Deeper user docs live under
+[`docs/user-guide/`](../docs/user-guide/); this file is the agent-facing map.
+
+## Run Interfaces
+
+- `setup.sh` must be **sourced**, never executed (it exports env vars and uses
+  `return`). It requires `VLM_MODEL_NAME` to be exported first and creates the
+  external Docker volume `ov-models`.
+- Deploy: `export VLM_MODEL_NAME=... && source setup.sh && docker compose -f
+  docker/compose.yaml up -d`. Host port `VLM_SERVICE_PORT` (default **9764**)
+  maps to container port 8000.
+- The first start downloads and converts the model (long); the `ov-models`
+  volume caches both the HF download and the converted OpenVINO model.
+
+## API Surface
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/v1/chat/completions` | Chat completion (OpenAI-compatible; streaming; text/image/video content) |
+| GET | `/v1/models` | The single configured model |
+| GET | `/v1/telemetry?limit=N` | Recent inference telemetry |
+| GET | `/v1/queue-status` | Active/queued request counts |
+| GET | `/device`, `/device/{device}` | OpenVINO devices and properties |
+| GET | `/health` | 200 healthy / 503 model not ready |
+
+## Repository Map
+
+| Path | Contents |
+|---|---|
+| `setup.sh` | Env export + `ov-models` volume creation (source it). |
+| `docker/` | `compose.yaml` + `Dockerfile` (two-stage, non-root `appuser`). |
+| `src/app.py` | All routes + model lifecycle (~1600 lines; model loads at import). |
+| `src/utils/` | Settings, data models, telemetry, model conversion helpers. |
+| `src/config/model_config.yaml` | Per-model pixel limits + video-capable model list. |
+| `scripts/compress_model.sh` | `optimum-cli` export/compression at container start. |
+| `tests/` | Pytest suite (~50 tests, model init mocked). |
+| `docs/user-guide/` | get-started, environment-variables, api-reference (OpenAPI). |
+
+## Tech Stack
+
+Python 3.11+ with Poetry, FastAPI + Gunicorn/Uvicorn, OpenVINO GenAI /
+optimum-intel, Docker Compose for deploy.
+
+## Conventions
+
+- Run commands from this microservice's root unless a skill says otherwise.
+- `setup.sh` is **sourced**, never executed directly.
+- Every new source/config/doc file carries the repo SPDX header
+  (`SPDX-FileCopyrightText: (C) 2026 Intel Corporation` / `Apache-2.0`).
+- Probe `GET http://localhost:9764/health` before any API workflow.
+- Destructive operations (removing the `ov-models` volume, `docker compose
+  down -v`) need explicit user confirmation.
+
+## Gotchas
+
+- `VLM_DEVICE=GPU` forces `VLM_COMPRESSION_WEIGHT_FORMAT=int4` and `WORKERS=1`
+  (in `setup.sh`).
+- GPU OOM surfaces as `error code: -5`; the server self-restarts via
+  `os.execv`.
+- `video`/`video_url` content is only truly supported on Qwen models; SmolVLM
+  reports no telemetry.
+- Importing `src.app` triggers a full model download/convert — tests must mock
+  `initialize_model`.
+
+## Skills
+
+Reusable workflow skills live under [`.github/skills/`](skills/). Use
+[`skill-catalog.json`](skills/skill-catalog.json) to pick the relevant skill,
+then read that skill's `SKILL.md`.
+
+| User intent | Skill |
+|---|---|
+| Deploy, query, or troubleshoot the running service (consume it) | `vlm-openvino-serving-user` |
+| Build from source, run tests, navigate/modify the code | `vlm-openvino-serving-dev` |
+
+## Skill Loading Rules
+
+- Load only the skill needed for the current request.
+- Open a skill's linked docs or `references/` files only when its `SKILL.md`
+  points to them.
+- Run commands yourself when the harness permits it and relay the result.
+
+## Path Conventions
+
+All paths in the skill catalog are relative to this microservice's root
+(`microservices/vlm-openvino-serving/`). The skills live in `.github/skills`
+as the shared location for Codex, Copilot CLI, Claude Code, Cursor, and local
+agent scripts. Skills also work without a repo clone — the `-user` skill
+fetches the same `setup.sh`/compose files and docs from GitHub and uses the
+prebuilt image.

--- a/microservices/vlm-openvino-serving/.github/copilot-instructions.md
+++ b/microservices/vlm-openvino-serving/.github/copilot-instructions.md
@@ -52,7 +52,7 @@ OpenVINO Model Server. A prebuilt image is published as
 | `src/utils/` | Settings, data models, telemetry, model conversion helpers. |
 | `src/config/model_config.yaml` | Per-model pixel limits + video-capable model list. |
 | `scripts/compress_model.sh` | `optimum-cli` export/compression at container start. |
-| `tests/` | Pytest suite (~50 tests, model init mocked). |
+| `tests/` | Four-module Pytest suite with model initialization mocked before import. |
 | `docs/user-guide/` | get-started, environment-variables, api-reference (OpenAPI). |
 
 ## Tech Stack
@@ -72,8 +72,8 @@ optimum-intel, Docker Compose for deploy.
 
 ## Gotchas
 
-- `VLM_DEVICE=GPU` forces `VLM_COMPRESSION_WEIGHT_FORMAT=int4` and `WORKERS=1`
-  (in `setup.sh`).
+- Exact `VLM_DEVICE=GPU` forces `VLM_COMPRESSION_WEIGHT_FORMAT=int4` and
+  `WORKERS=1`; qualified values such as `GPU.0` bypass that exact check.
 - GPU OOM surfaces as `error code: -5`; the server self-restarts via
   `os.execv`.
 - `video`/`video_url` content is only truly supported on Qwen models; SmolVLM

--- a/microservices/vlm-openvino-serving/.github/skills/skill-catalog.json
+++ b/microservices/vlm-openvino-serving/.github/skills/skill-catalog.json
@@ -1,0 +1,47 @@
+{
+  "SPDX-FileCopyrightText": "(C) 2026 Intel Corporation",
+  "SPDX-License-Identifier": "Apache-2.0",
+  "schemaVersion": "1.0",
+  "description": "Harness-neutral discovery catalog for VLM OpenVINO Serving workflow skills. Paths are relative to the microservice root.",
+  "skillsRoot": ".github/skills",
+  "skills": [
+    {
+      "name": "vlm-openvino-serving-user",
+      "path": ".github/skills/vlm-openvino-serving-user/SKILL.md",
+      "description": "Deploy and consume the OpenAI-compatible VLM service: bring it up from a repo clone (setup.sh + compose) or standalone (prebuilt intel/vlm-openvino-serving image), send chat completions with text, images, or video, stream responses, and read telemetry. Not for modifying the service's source (use vlm-openvino-serving-dev).",
+      "triggers": [
+        "run the vlm service",
+        "start vlm serving",
+        "chat completions",
+        "caption this image",
+        "describe this video",
+        "vlm inference",
+        "openai compatible vlm",
+        "query the vlm",
+        "vlm telemetry"
+      ],
+      "requires": [
+        "docker",
+        "curl"
+      ]
+    },
+    {
+      "name": "vlm-openvino-serving-dev",
+      "path": ".github/skills/vlm-openvino-serving-dev/SKILL.md",
+      "description": "Develop the VLM service itself: install with Poetry, run the mocked pytest suite, navigate src/app.py and the model dispatch, build the image from source, and debug via logs and telemetry. Not for merely deploying or calling the API (use vlm-openvino-serving-user).",
+      "triggers": [
+        "run the vlm tests",
+        "add an endpoint to vlm serving",
+        "debug vlm serving code",
+        "build vlm from source",
+        "pytest hangs downloading a model",
+        "modify vlm serving"
+      ],
+      "requires": [
+        "repo clone",
+        "poetry",
+        "docker"
+      ]
+    }
+  ]
+}

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/SKILL.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/SKILL.md
@@ -7,9 +7,6 @@ description: >
   debug via logs and telemetry. Use when modifying, testing, or debugging this
   service's code. Not for merely deploying or calling the API — that is
   vlm-openvino-serving-user.
-argument-hint: >
-  Describe what you want to build, test, or debug (e.g. "add a dispatch branch
-  for a new VLM family", or "run the pytest suite without downloading a model")
 ---
 
 # VLM OpenVINO Serving — Dev

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/SKILL.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/SKILL.md
@@ -54,24 +54,28 @@ collection against real settings. Details:
 ## Environment setup
 
 ```bash
-poetry install --with test    # Python ^3.11,<3.14
+poetry install --with test    # Python >=3.11,<3.14
 ```
 
 ## Test / verify loop
 
 ```bash
-cd tests && poetry run pytest            # pytest.ini lives in tests/
-poetry run coverage run --source=src -m pytest && poetry run coverage report
+poetry run pytest -c tests/pytest.ini tests
+poetry run coverage run --source=src -m pytest -c tests/pytest.ini tests
+poetry run coverage report
 ```
 
-~50 tests, all model interactions mocked (no downloads, CPU-only, fast).
+The suite spans four test modules. Keep model-loading dependencies patched
+before importing `src.app`; do not add an eager import in a new test module.
 
 ## Source map (summary)
 
 - `src/app.py` (~1600 lines) — **everything routes through here**: FastAPI
   routes, model lifecycle, per-model prompt branches (Qwen / Phi / SmolVLM /
   default, dispatched by substring on the model name), streaming, GPU-OOM
-  self-restart.
+  self-restart. Runtime configuration such as compression format comes from
+  the module-level `settings` object; model state such as `pipe`,
+  `model_config`, and `model_ready` is initialized separately.
 - `src/utils/` — `common.py` (pydantic Settings, error strings), `utils.py`
   (model conversion, image/video loading), `data_models.py` (request/response
   schemas), `telemetry*.py`.
@@ -107,7 +111,7 @@ in the `ov-models` volume.
 | Gotcha | Consequence |
 |---|---|
 | Model dispatch is substring-based (`qwen2`, `phi-3.5-vision`, `smolvlm` in `src/utils/common.py`) | new model families need a dispatch branch + `model_config.yaml` entry |
-| `VLM_DEVICE=GPU` forces int4 + 1 worker in `setup.sh` | keep that invariant when touching setup/compose |
+| Exact `VLM_DEVICE=GPU` forces int4 + 1 worker in `setup.sh` | qualified names such as `GPU.0` currently bypass that exact string check; verify effective settings |
 | GPU OOM (`error code: -5`) triggers `os.execv` self-restart in `app.py` | don't "fix" restarts away; it's deliberate recovery |
 | SmolVLM uses optimum-intel, not openvino_genai | no PerfMetrics → no telemetry for it; guard telemetry code paths |
 | Every new file needs the SPDX header | CI/license scans fail otherwise |

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/SKILL.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: vlm-openvino-serving-dev
+description: >
+  Develop the VLM OpenVINO Serving microservice itself — Poetry install, run
+  the mocked pytest suite safely (model loads at import time), navigate
+  src/app.py and the per-model dispatch, build the image from source, and
+  debug via logs and telemetry. Use when modifying, testing, or debugging this
+  service's code. Not for merely deploying or calling the API — that is
+  vlm-openvino-serving-user.
+argument-hint: >
+  Describe what you want to build, test, or debug (e.g. "add a dispatch branch
+  for a new VLM family", or "run the pytest suite without downloading a model")
+---
+
+# VLM OpenVINO Serving — Dev
+
+Work on the service's source. **This skill assumes a repo clone** of
+`edge-ai-libraries` with this microservice at
+`microservices/vlm-openvino-serving/`; if there is no clone, clone the repo
+first (`git clone https://github.com/open-edge-platform/edge-ai-libraries.git`)
+or — if the user only wants to *use* the service — switch to
+[`../vlm-openvino-serving-user/SKILL.md`](../vlm-openvino-serving-user/SKILL.md).
+Run all commands from the microservice root.
+
+## When to Use
+
+- Add or modify a per-model prompt/dispatch branch in `src/app.py`
+- Run or extend the mocked pytest suite (safe against the import-time model load)
+- Navigate routes, model lifecycle, or conversion helpers before editing
+- Build the image from source
+- Debug startup, GPU OOM self-restart, or missing telemetry
+
+## Example Prompts
+
+Sample Problem-solving scenarios this skill handles end-to-end:
+
+| Example | Problem it solves |
+|---|---|
+| [onboard-new-model.md](./example-prompts/onboard-new-model.md) | Onboard a new VLM family (dispatch + config + capabilities) |
+| [update-test-cases.md](./example-prompts/update-test-cases.md) | Update the mocked test suite to cover a new model |
+
+## Reference Lookup
+
+| File | Load when… |
+|---|---|
+| [`references/source-map.md`](./references/source-map.md) | locating where a route, model branch, or utility lives before editing |
+| [`references/testing.md`](./references/testing.md) | writing new tests, running subsets, or debugging test failures/hangs |
+
+## The one gotcha to know first
+
+`src/app.py` calls `initialize_model()` **at import time** — importing it
+without mocks downloads and converts a multi-GB model. The test suite mocks
+this; never run a bare `python -c "import src.app"` or an unmocked pytest
+collection against real settings. Details:
+[`references/testing.md`](./references/testing.md).
+
+## Environment setup
+
+```bash
+poetry install --with test    # Python ^3.11,<3.14
+```
+
+## Test / verify loop
+
+```bash
+cd tests && poetry run pytest            # pytest.ini lives in tests/
+poetry run coverage run --source=src -m pytest && poetry run coverage report
+```
+
+~50 tests, all model interactions mocked (no downloads, CPU-only, fast).
+
+## Source map (summary)
+
+- `src/app.py` (~1600 lines) — **everything routes through here**: FastAPI
+  routes, model lifecycle, per-model prompt branches (Qwen / Phi / SmolVLM /
+  default, dispatched by substring on the model name), streaming, GPU-OOM
+  self-restart.
+- `src/utils/` — `common.py` (pydantic Settings, error strings), `utils.py`
+  (model conversion, image/video loading), `data_models.py` (request/response
+  schemas), `telemetry*.py`.
+- `src/config/model_config.yaml` — per-model pixel limits + the
+  `video_supported_models` list.
+- Full annotated map: [`references/source-map.md`](./references/source-map.md).
+
+## Build from source
+
+```bash
+export VLM_MODEL_NAME="Qwen/Qwen2.5-VL-3B-Instruct"
+source setup.sh                                   # sourced, never executed
+docker compose -f docker/compose.yaml build       # image ${REGISTRY:-}vlm-openvino-serving:${TAG:-latest}
+docker compose -f docker/compose.yaml up -d
+```
+
+Model export/compression at container start is `scripts/compress_model.sh`
+(`optimum-cli export openvino`); it skips work if the model dir already exists
+in the `ov-models` volume.
+
+## Debug a running instance
+
+1. `docker logs -f vlm-openvino-serving` — startup, conversion, request logs.
+2. `curl -s localhost:9764/health` (503 = model not ready) and
+   `curl -s localhost:9764/v1/queue-status`.
+3. `curl -s 'localhost:9764/v1/telemetry?limit=5'` — per-request perf metrics
+   (absent for SmolVLM).
+4. More logs: `export VLM_LOG_LEVEL=debug` before `source setup.sh` (also
+   raises the OpenVINO log level), then recreate the container.
+
+## Contribution gotchas
+
+| Gotcha | Consequence |
+|---|---|
+| Model dispatch is substring-based (`qwen2`, `phi-3.5-vision`, `smolvlm` in `src/utils/common.py`) | new model families need a dispatch branch + `model_config.yaml` entry |
+| `VLM_DEVICE=GPU` forces int4 + 1 worker in `setup.sh` | keep that invariant when touching setup/compose |
+| GPU OOM (`error code: -5`) triggers `os.execv` self-restart in `app.py` | don't "fix" restarts away; it's deliberate recovery |
+| SmolVLM uses optimum-intel, not openvino_genai | no PerfMetrics → no telemetry for it; guard telemetry code paths |
+| Every new file needs the SPDX header | CI/license scans fail otherwise |

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/evals/evals.json
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/evals/evals.json
@@ -6,46 +6,37 @@
     {
       "id": 1,
       "name": "run-test-suite",
-      "prompt": "I'm in a checkout of edge-ai-libraries at microservices/vlm-openvino-serving. Run the service's test suite with coverage and tell me if anything fails.",
-      "expected_output": "Installs with poetry (test group), runs pytest from the tests/ directory (where pytest.ini lives) plus the documented coverage commands, and reports pass/fail counts. No model downloads are triggered.",
+      "prompt": "I'm in a checkout of edge-ai-libraries at microservices/vlm-openvino-serving. Give me the exact project-supported commands to install test dependencies, run the service test suite, and collect coverage without triggering a model download.",
+      "expected_output": "Provides Poetry test-group installation and pytest/coverage commands that explicitly load tests/pytest.ini and target tests while measuring src. It warns that src.app initializes a model at import time and relies on the repository's pre-import mock pattern rather than setting a real model name.",
       "expectations": [
-        "Uses poetry install --with test (or equivalent poetry-managed env) before running tests",
-        "Runs pytest from the tests/ directory or with explicit awareness that pytest.ini lives in tests/",
-        "Runs coverage via coverage run --source=src -m pytest (or poetry run coverage equivalents)",
-        "Does not set a real VLM_MODEL_NAME or trigger any model download to run unit tests"
+        "Provides poetry install --with test (or an equivalent Poetry-managed test environment)",
+        "Runs pytest with tests/pytest.ini explicitly selected or from the tests directory",
+        "Provides a coverage command that measures src while running the tests",
+        "Warns against importing src.app with a real model configuration and does not recommend downloading a model for unit tests"
       ]
     },
     {
       "id": 2,
       "name": "locate-endpoint-code",
-      "prompt": "Where in the vlm-openvino-serving codebase would I add a new GET endpoint that reports the loaded model's compression format, and what existing code should I follow as a pattern?",
-      "expected_output": "Points to src/app.py as the single-file location of all routes, suggests following an existing simple GET route (e.g. /v1/models or /device) as the pattern, and notes model state lives in module globals set by initialize_model().",
+      "prompt": "Where in vlm-openvino-serving should I add a GET endpoint that reports the configured VLM compression weight format, and what existing code should I follow?",
+      "expected_output": "Points to src/app.py for the route, follows /v1/models as the simple GET pattern, reads settings.VLM_COMPRESSION_WEIGHT_FORMAT, extends a response model in src/utils/data_models.py if returning structured data, and adds a route test. Clarifies this is configured intent, not proof of a preconverted artifact's actual compression.",
       "expectations": [
         "Names src/app.py as the file where routes are added",
-        "References at least one existing GET route (such as /v1/models, /device, or /health) as the pattern to copy",
-        "Mentions that model state (pipe/model_config/model_ready) lives in module-level globals initialized by initialize_model()"
+        "References /v1/models or another existing simple GET route as the pattern to copy",
+        "Reads the compression format from settings.VLM_COMPRESSION_WEIGHT_FORMAT rather than pipe/model_config/model_ready",
+        "Mentions the relevant response model in src/utils/data_models.py and adding a route test",
+        "Clarifies that the configured value is not proof of a preconverted artifact's actual compression"
       ]
     },
     {
       "id": 3,
       "name": "pytest-hang-diagnosis",
-      "prompt": "When I run pytest against vlm-openvino-serving, collection seems to hang and my network monitor shows downloads from huggingface.co. The tests themselves are supposedly all mocked. What's wrong?",
-      "expected_output": "Diagnosis: src/app.py calls initialize_model() at module import time, so importing it without the module-level mock stack (env vars + convert_model + VLMPipeline + is_model_ready + initialize_model patched before the import) triggers a real model download. Fix: mock before import, as tests/test_app.py does.",
+      "prompt": "Suppose I add tests/test_compression.py with `from src.app import app` at top level. The stock tests were offline, but collecting only that new module with `poetry run pytest tests/test_compression.py --collect-only` downloads from huggingface.co. Diagnose it and give me a safe targeted collection command.",
+      "expected_output": "Explains that src.app calls initialize_model at import and the targeted new module imports it before the established pre-import mock stack. Reuses the tests/test_app.py pattern or sets VLM_SKIP_MODEL_INIT=1 before import, then gives a targeted pytest --collect-only -vv command with offline Hugging Face variables.",
       "expectations": [
-        "Identifies the import-time initialize_model() call in src/app.py as the root cause",
-        "Explains mocks must be applied before importing src.app (module-level patching), not inside individual tests",
-        "References the existing pattern in tests/test_app.py rather than inventing a new conftest mechanism as the primary fix"
-      ]
-    },
-    {
-      "id": 4,
-      "name": "negative-deploy-routing",
-      "prompt": "Stand up the VLM serving container so my teammate's app can start sending it chat completion requests this afternoon.",
-      "expected_output": "Recognizes this is a deployment/consumption task, not development: uses the user-skill bring-up flow (setup.sh + compose or prebuilt image) and does not modify source, run tests, or rebuild from source unnecessarily.",
-      "expectations": [
-        "Does not edit service source code or run the pytest suite for this request",
-        "Brings the service up via setup.sh + docker compose or the prebuilt intel/vlm-openvino-serving image",
-        "Verifies the service is reachable (health endpoint) so the teammate's app can use it"
+        "Identifies the new test's eager src.app import and app.py's import-time initialize_model call as the collection-time download path",
+        "Reuses the pre-import loader mock pattern from tests/test_app.py or sets VLM_SKIP_MODEL_INIT=1 before importing src.app",
+        "Provides a targeted tests/test_compression.py pytest --collect-only -vv command with offline Hugging Face/Transformers environment settings"
       ]
     }
   ]

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/evals/evals.json
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/evals/evals.json
@@ -1,0 +1,48 @@
+{
+  "SPDX-FileCopyrightText": "(C) 2026 Intel Corporation",
+  "SPDX-License-Identifier": "Apache-2.0",
+  "skill_name": "vlm-openvino-serving-dev",
+  "evals": [
+    {
+      "id": "run-test-suite",
+      "prompt": "I'm in a checkout of edge-ai-libraries at microservices/vlm-openvino-serving. Run the service's test suite with coverage and tell me if anything fails.",
+      "expected_output": "Installs with poetry (test group), runs pytest from the tests/ directory (where pytest.ini lives) plus the documented coverage commands, and reports pass/fail counts. No model downloads are triggered.",
+      "assertions": [
+        "Uses poetry install --with test (or equivalent poetry-managed env) before running tests",
+        "Runs pytest from the tests/ directory or with explicit awareness that pytest.ini lives in tests/",
+        "Runs coverage via coverage run --source=src -m pytest (or poetry run coverage equivalents)",
+        "Does not set a real VLM_MODEL_NAME or trigger any model download to run unit tests"
+      ]
+    },
+    {
+      "id": "locate-endpoint-code",
+      "prompt": "Where in the vlm-openvino-serving codebase would I add a new GET endpoint that reports the loaded model's compression format, and what existing code should I follow as a pattern?",
+      "expected_output": "Points to src/app.py as the single-file location of all routes, suggests following an existing simple GET route (e.g. /v1/models or /device) as the pattern, and notes model state lives in module globals set by initialize_model().",
+      "assertions": [
+        "Names src/app.py as the file where routes are added",
+        "References at least one existing GET route (such as /v1/models, /device, or /health) as the pattern to copy",
+        "Mentions that model state (pipe/model_config/model_ready) lives in module-level globals initialized by initialize_model()"
+      ]
+    },
+    {
+      "id": "pytest-hang-diagnosis",
+      "prompt": "When I run pytest against vlm-openvino-serving, collection seems to hang and my network monitor shows downloads from huggingface.co. The tests themselves are supposedly all mocked. What's wrong?",
+      "expected_output": "Diagnosis: src/app.py calls initialize_model() at module import time, so importing it without the module-level mock stack (env vars + convert_model + VLMPipeline + is_model_ready + initialize_model patched before the import) triggers a real model download. Fix: mock before import, as tests/test_app.py does.",
+      "assertions": [
+        "Identifies the import-time initialize_model() call in src/app.py as the root cause",
+        "Explains mocks must be applied before importing src.app (module-level patching), not inside individual tests",
+        "References the existing pattern in tests/test_app.py rather than inventing a new conftest mechanism as the primary fix"
+      ]
+    },
+    {
+      "id": "negative-deploy-routing",
+      "prompt": "Stand up the VLM serving container so my teammate's app can start sending it chat completion requests this afternoon.",
+      "expected_output": "Recognizes this is a deployment/consumption task, not development: uses the user-skill bring-up flow (setup.sh + compose or prebuilt image) and does not modify source, run tests, or rebuild from source unnecessarily.",
+      "assertions": [
+        "Does not edit service source code or run the pytest suite for this request",
+        "Brings the service up via setup.sh + docker compose or the prebuilt intel/vlm-openvino-serving image",
+        "Verifies the service is reachable (health endpoint) so the teammate's app can use it"
+      ]
+    }
+  ]
+}

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/evals/evals.json
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/evals/evals.json
@@ -4,10 +4,11 @@
   "skill_name": "vlm-openvino-serving-dev",
   "evals": [
     {
-      "id": "run-test-suite",
+      "id": 1,
+      "name": "run-test-suite",
       "prompt": "I'm in a checkout of edge-ai-libraries at microservices/vlm-openvino-serving. Run the service's test suite with coverage and tell me if anything fails.",
       "expected_output": "Installs with poetry (test group), runs pytest from the tests/ directory (where pytest.ini lives) plus the documented coverage commands, and reports pass/fail counts. No model downloads are triggered.",
-      "assertions": [
+      "expectations": [
         "Uses poetry install --with test (or equivalent poetry-managed env) before running tests",
         "Runs pytest from the tests/ directory or with explicit awareness that pytest.ini lives in tests/",
         "Runs coverage via coverage run --source=src -m pytest (or poetry run coverage equivalents)",
@@ -15,30 +16,33 @@
       ]
     },
     {
-      "id": "locate-endpoint-code",
+      "id": 2,
+      "name": "locate-endpoint-code",
       "prompt": "Where in the vlm-openvino-serving codebase would I add a new GET endpoint that reports the loaded model's compression format, and what existing code should I follow as a pattern?",
       "expected_output": "Points to src/app.py as the single-file location of all routes, suggests following an existing simple GET route (e.g. /v1/models or /device) as the pattern, and notes model state lives in module globals set by initialize_model().",
-      "assertions": [
+      "expectations": [
         "Names src/app.py as the file where routes are added",
         "References at least one existing GET route (such as /v1/models, /device, or /health) as the pattern to copy",
         "Mentions that model state (pipe/model_config/model_ready) lives in module-level globals initialized by initialize_model()"
       ]
     },
     {
-      "id": "pytest-hang-diagnosis",
+      "id": 3,
+      "name": "pytest-hang-diagnosis",
       "prompt": "When I run pytest against vlm-openvino-serving, collection seems to hang and my network monitor shows downloads from huggingface.co. The tests themselves are supposedly all mocked. What's wrong?",
       "expected_output": "Diagnosis: src/app.py calls initialize_model() at module import time, so importing it without the module-level mock stack (env vars + convert_model + VLMPipeline + is_model_ready + initialize_model patched before the import) triggers a real model download. Fix: mock before import, as tests/test_app.py does.",
-      "assertions": [
+      "expectations": [
         "Identifies the import-time initialize_model() call in src/app.py as the root cause",
         "Explains mocks must be applied before importing src.app (module-level patching), not inside individual tests",
         "References the existing pattern in tests/test_app.py rather than inventing a new conftest mechanism as the primary fix"
       ]
     },
     {
-      "id": "negative-deploy-routing",
+      "id": 4,
+      "name": "negative-deploy-routing",
       "prompt": "Stand up the VLM serving container so my teammate's app can start sending it chat completion requests this afternoon.",
       "expected_output": "Recognizes this is a deployment/consumption task, not development: uses the user-skill bring-up flow (setup.sh + compose or prebuilt image) and does not modify source, run tests, or rebuild from source unnecessarily.",
-      "assertions": [
+      "expectations": [
         "Does not edit service source code or run the pytest suite for this request",
         "Brings the service up via setup.sh + docker compose or the prebuilt intel/vlm-openvino-serving image",
         "Verifies the service is reachable (health endpoint) so the teammate's app can use it"

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/example-prompts/onboard-new-model.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/example-prompts/onboard-new-model.md
@@ -1,0 +1,14 @@
+Onboard a new vision-language model family so it can be served with the correct prompt formatting and capabilities.
+
+- Add a dispatch branch for the family's prompt formatting (dispatch is substring-based in src/utils/common.py, routed through src/app.py).
+- Add a src/config/model_config.yaml entry with the model's pixel limits and, if applicable, add it to the video_supported_models list.
+- Guard telemetry code paths if the backend has no PerfMetrics (as with SmolVLM/optimum-intel). Add the SPDX header to any new file.
+
+Validate the change using:
+- Set VLM_MODEL_NAME to the new model and confirm it appears in GET /v1/models on http://localhost:9764.
+- Send one text+image chat completion and confirm it routes to the new prompt path.
+- Run the test suite with model interactions mocked (no real download).
+
+Expected results:
+- The new model is selectable, dispatched correctly, and reports the right image/video capabilities.
+- Tests pass offline with initialize_model mocked — no multi-GB download is triggered.

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/example-prompts/update-test-cases.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/example-prompts/update-test-cases.md
@@ -1,0 +1,13 @@
+Update the mocked pytest suite to cover a newly onboarded VLM family without triggering a real model download.
+
+- Add tests for the new model's dispatch branch and its model_config.yaml entry (pixel limits, video capability).
+- Mock initialize_model — importing src/app.py loads the model at import time, so unmocked collection would download a multi-GB model.
+- Keep the tests offline and CPU-only, matching the existing ~50-test suite. Add the SPDX header to any new test file.
+
+Validate the change using:
+- Run from where pytest.ini lives: cd tests && poetry run pytest
+- Produce a coverage report: poetry run coverage run --source=src -m pytest && poetry run coverage report
+
+Expected results:
+- New tests pass with no model download; the new dispatch branch and config entry are covered.
+- The full suite still runs fast and offline.

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/example-prompts/update-test-cases.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/example-prompts/update-test-cases.md
@@ -2,7 +2,7 @@ Update the mocked pytest suite to cover a newly onboarded VLM family without tri
 
 - Add tests for the new model's dispatch branch and its model_config.yaml entry (pixel limits, video capability).
 - Mock initialize_model — importing src/app.py loads the model at import time, so unmocked collection would download a multi-GB model.
-- Keep the tests offline and CPU-only, matching the existing ~50-test suite. Add the SPDX header to any new test file.
+- Keep the tests offline and CPU-only, matching the existing four-module suite. Add the SPDX header to any new test file.
 
 Validate the change using:
 - Run from where pytest.ini lives: cd tests && poetry run pytest

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/references/source-map.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/references/source-map.md
@@ -1,0 +1,50 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Source map — VLM OpenVINO Serving
+
+## `src/app.py` — the whole service (~1600 lines)
+
+| Area | Symbols | Notes |
+|---|---|---|
+| App + lifecycle | `lifespan()`, `app = FastAPI(...)`, CORS middleware | lifespan only starts a request-count logger; the heavy init is import-time |
+| **Model init (import time!)** | `initialize_model()` (~line 460) — **called at module level** right after its definition | sets globals `pipe`, `processor`, `model_dir`, `model_config`, `model_ready`; SmolVLM → `OVModelForVisualCausalLM` (optimum-intel) + `AutoProcessor`, everything else → `openvino_genai.VLMPipeline` |
+| Chat route | `@app.post("/v1/chat/completions")` → `chat_completions()` (~line 627) | per-model prompt branches: Qwen (`qwen_vl_utils.process_vision_info`, video kwargs), Phi (ChatML + `<|image_i|>` markers), SmolVLM (HF chat template), default |
+| Generation | `run_generation()`, `safe_generate()`, `launch_streaming_generation()`, `create_streaming_response()`, `collect_streamer_output()` | non-stream = `asyncio.to_thread(pipe.generate, ...)`; stream = background `Thread` + queue streamer feeding SSE |
+| OOM recovery | `restart_server()` (~line 408), `cleanup_pipeline_state()` | on GPU OOM (`error code: -5`) the process re-execs itself via `os.execv` |
+| Observability | `/v1/telemetry` → `list_telemetry()`, `/v1/queue-status`, `log_telemetry()` | telemetry persisted through `src/utils/telemetry_store.py` (file-locked JSONL) |
+| Introspection | `/v1/models`, `/device`, `/device/{device}`, `/health` | device info via `ov.Core()` helpers in `src/utils/utils.py` |
+
+## `src/utils/`
+
+| File | Contents |
+|---|---|
+| `common.py` | `Settings` (pydantic-settings; env vars), `ErrorMessages` (incl. `GPU_OOM_ERROR_MESSAGE = "error code: -5"`), `ModelNames` — the **substring dispatch constants** (`qwen2`, `phi-3.5-vision`, `smolvlm`), logger |
+| `utils.py` | `convert_model()` (optimum export), `load_images()` (async, proxy-aware), `get_devices()`/`get_device_property()`, `is_model_ready()`, `load_model_config()`, qwen tensor helpers, `decode_and_save_video()`, `validate_video_inputs()`, `setup_seed()` |
+| `data_models.py` | Pydantic schemas: `ChatRequest`, `Message` + content union (`MessageContentText/ImageUrl/Video/VideoUrl`), responses, telemetry models |
+| `telemetry.py` / `telemetry_store.py` | build usage+telemetry from openvino_genai `PerfMetrics`; JSONL ring buffer shared across workers |
+
+## Config & scripts
+
+- `src/config/model_config.yaml` — per-model `min_pixels`/`max_pixels` (Qwen
+  processors) and the `video_supported_models` substring list.
+- `scripts/compress_model.sh` — container-start model export:
+  `optimum-cli export openvino --trust-remote-code --weight-format <fmt>` into
+  `ov-model/<model-basename>/<fmt>`; skips if present; special-cases
+  MiniCPM-o (`--task image-text-to-text`).
+- `docker/Dockerfile` — two-stage python:3.12-slim, Poetry with
+  `virtualenvs.create false`, non-root `appuser` (uid 1000), `EXPOSE 8000`;
+  GPU drivers via `scripts/install_ubuntu_gpu_drivers.sh`
+  (`INSTALL_DRIVER_VERSION` build arg).
+
+## Adding a model family (checklist)
+
+1. Add a dispatch constant in `src/utils/common.py` (`ModelNames`) — matching
+   is by substring of the lowercased model name.
+2. Add the prompt/processing branch in `chat_completions()` in `src/app.py`
+   (and in `initialize_model()` if it needs a non-`VLMPipeline` loader).
+3. Add pixel limits / video support to `src/config/model_config.yaml`.
+4. Mock-test it in `tests/test_app.py` (copy an existing per-model test class).
+5. Update `docs/user-guide/Overview.md` supported-models table.

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/references/testing.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/references/testing.md
@@ -9,17 +9,19 @@ SPDX-License-Identifier: Apache-2.0
 
 ```bash
 poetry install --with test
-cd tests && poetry run pytest                    # config: tests/pytest.ini
-poetry run pytest test_app.py -k streaming -x    # subset
-poetry run coverage run --source=src -m pytest && poetry run coverage report
+poetry run pytest -c tests/pytest.ini tests
+poetry run pytest -c tests/pytest.ini tests/test_app.py -k streaming -x
+poetry run coverage run --source=src -m pytest -c tests/pytest.ini tests
+poetry run coverage report
 ```
 
-`tests/pytest.ini` sets `testpaths = .` — run pytest **from `tests/`** (or
-pass explicit paths) so config and filterwarnings apply.
+`tests/pytest.ini` sets `testpaths = .`; pass it explicitly when running from
+the service root so config and filterwarnings apply without making subsequent
+coverage paths depend on the shell's current directory.
 `pyproject.toml` sets `asyncio_default_fixture_loop_scope = module` for
 `pytest-asyncio`.
 
-## The import-time trap (why unmocked tests hang or download models)
+## Model-loading traps (why tests hang or download models)
 
 `src/app.py` executes `initialize_model()` **at module import**. Any test file
 importing `src.app` must first patch the environment and the loaders —
@@ -38,11 +40,26 @@ Symptoms of getting this wrong: pytest "hangs" during collection, network
 downloads from huggingface.co, or `RuntimeError: Error initializing the
 model`. Fix: mock **before** import, never after.
 
+The stock `test_app.py` import captures mocked loader symbols in `src.app`, so
+the existing suite should not download models. If downloads begin after adding
+a test, first check whether the new module imports `src.app` before that mock
+stack. Isolate collection with `poetry run pytest -c tests/pytest.ini
+--collect-only -vv tests`. Patch loaders before the first import, or set the
+project-supported `VLM_SKIP_MODEL_INIT=1` for collection-only diagnosis.
+
+For a newly added module, target it directly so collection order cannot be
+masked by `test_app.py` importing `src.app` safely first:
+
+```bash
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 VLM_SKIP_MODEL_INIT=1 \
+  poetry run pytest -c tests/pytest.ini --collect-only -vv tests/test_compression.py
+```
+
 ## What the suite covers (`tests/`)
 
 | File | Coverage |
 |---|---|
-| `test_app.py` | ~50 tests: health/device/models routes, per-model chat flows (qwen / phi / smolvlm / default), streaming, queue status, GPU-OOM restart path |
+| `test_app.py` | health/device/models routes, per-model chat flows (qwen / phi / smolvlm / default), streaming, queue status, GPU-OOM restart path |
 | `test_utils.py` | conversion, image/video loading, device helpers |
 | `test_common.py` | Settings parsing, error strings |
 | `test_data_models.py` | request/response schema validation |

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/references/testing.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-dev/references/testing.md
@@ -1,0 +1,59 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Testing — VLM OpenVINO Serving
+
+## Run
+
+```bash
+poetry install --with test
+cd tests && poetry run pytest                    # config: tests/pytest.ini
+poetry run pytest test_app.py -k streaming -x    # subset
+poetry run coverage run --source=src -m pytest && poetry run coverage report
+```
+
+`tests/pytest.ini` sets `testpaths = .` — run pytest **from `tests/`** (or
+pass explicit paths) so config and filterwarnings apply.
+`pyproject.toml` sets `asyncio_default_fixture_loop_scope = module` for
+`pytest-asyncio`.
+
+## The import-time trap (why unmocked tests hang or download models)
+
+`src/app.py` executes `initialize_model()` **at module import**. Any test file
+importing `src.app` must first patch the environment and the loaders —
+`tests/test_app.py` does this at module level, before the import:
+
+```python
+with mock.patch.dict(os.environ, {..., "VLM_MODEL_NAME": "mock_model"}):
+    with mock.patch("src.utils.utils.convert_model", return_value=None):
+        with mock.patch("openvino_genai.VLMPipeline", return_value=mock.Mock()):
+            with mock.patch("src.utils.utils.is_model_ready", return_value=True):
+                with mock.patch("src.app.initialize_model"):
+                    from src.app import app   # only now is the import safe
+```
+
+Symptoms of getting this wrong: pytest "hangs" during collection, network
+downloads from huggingface.co, or `RuntimeError: Error initializing the
+model`. Fix: mock **before** import, never after.
+
+## What the suite covers (`tests/`)
+
+| File | Coverage |
+|---|---|
+| `test_app.py` | ~50 tests: health/device/models routes, per-model chat flows (qwen / phi / smolvlm / default), streaming, queue status, GPU-OOM restart path |
+| `test_utils.py` | conversion, image/video loading, device helpers |
+| `test_common.py` | Settings parsing, error strings |
+| `test_data_models.py` | request/response schema validation |
+
+## Adding a test for a new endpoint or model branch
+
+1. Reuse the module-level mock stack from `test_app.py` (import once, reuse
+   its `TestClient`).
+2. For a new model family, patch the pipeline/processor the branch uses and
+   assert on the prompt construction, not the mocked output.
+3. Keep tests offline: any code path that would touch huggingface.co or
+   OpenVINO device enumeration must be patched
+   (`src.utils.utils.get_devices`, `is_model_ready`, `convert_model`).
+4. Gate coverage locally with the `coverage` commands above before pushing.

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/SKILL.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/SKILL.md
@@ -8,9 +8,6 @@ description: >
   images, or video, stream responses, and read telemetry. Use when the user
   wants to run or call the VLM service from their app. Not for modifying the
   service's source — that is vlm-openvino-serving-dev.
-argument-hint: >
-  Describe what you want to deploy or ask the model (e.g. "start Qwen2.5-VL-3B
-  and describe this image", or "give me a streaming chat-completions curl")
 ---
 
 # VLM OpenVINO Serving — User

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/SKILL.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: vlm-openvino-serving-user
+description: >
+  Deploy and consume the OpenAI-compatible VLM OpenVINO Serving microservice —
+  bring it up with setup.sh + docker compose (from a repo clone, or by
+  fetching those same files from GitHub when no clone exists) using the
+  prebuilt intel/vlm-openvino-serving image, send chat completions with text,
+  images, or video, stream responses, and read telemetry. Use when the user
+  wants to run or call the VLM service from their app. Not for modifying the
+  service's source — that is vlm-openvino-serving-dev.
+argument-hint: >
+  Describe what you want to deploy or ask the model (e.g. "start Qwen2.5-VL-3B
+  and describe this image", or "give me a streaming chat-completions curl")
+---
+
+# VLM OpenVINO Serving — User
+
+Run and call the VLM service. **Run commands yourself** and relay output. The
+service speaks the OpenAI chat-completions dialect on host port **9764**
+(container 8000), so any OpenAI client works against
+`http://localhost:9764/v1` with a dummy API key.
+
+## When to Use
+
+- Deploy the VLM service (Docker Compose or standalone) and confirm health
+- Send text/image/video chat completions (OpenAI-compatible) on port 9764
+- Stream responses or drive the service with the `openai` Python client
+- Read telemetry, queue status, or available devices
+- Diagnose 404/503 errors, GPU OOM restarts, or gated-model download failures
+
+## Example Prompts
+
+Sample Problem-solving scenarios this skill handles end-to-end:
+
+| Example | Problem it solves |
+|---|---|
+| [safety-inspection-assistant.md](./example-prompts/safety-inspection-assistant.md) | Check camera frames for PPE and unsafe scenes against stated rules |
+| [retail-shelf-assistant.md](./example-prompts/retail-shelf-assistant.md) | Report empty/misplaced stock from shelf and aisle images |
+| [screenshot-understanding.md](./example-prompts/screenshot-understanding.md) | Answer questions about UI screenshots, forms, charts, dashboards |
+| [compliance-checker.md](./example-prompts/compliance-checker.md) | Grade an image against a checklist with pass/fail + evidence JSON |
+| [image-to-json-extractor.md](./example-prompts/image-to-json-extractor.md) | Turn a visual scene into structured JSON (objects, counts, text, risks) |
+| [smart-camera-operator-console.md](./example-prompts/smart-camera-operator-console.md) | Ask live-frame questions like "is the loading bay clear?" |
+
+## Docs & deploy files — with or without a clone
+
+All paths below are relative to `microservices/vlm-openvino-serving/` in the
+[edge-ai-libraries](https://github.com/open-edge-platform/edge-ai-libraries)
+repo. **No clone?** Fetch any of them from GitHub raw:
+
+```
+https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/main/microservices/vlm-openvino-serving/<path>
+```
+
+Load these existing docs only when needed:
+
+| Resource | Load when… |
+|---|---|
+| `docs/user-guide/api-reference.md` + `docs/user-guide/api-docs/openapi.yaml` | building non-trivial payloads (multi-image, video, base64, streaming) or parsing responses |
+| `docs/user-guide/get-started.md` | you want ready-made curl examples (base64 image/video, telemetry, device) |
+| `docs/user-guide/environment-variables.md` | tuning: device/GPU, ports, compression, log levels, proxies, gated models |
+| `docs/user-guide/Overview.md` | choosing a model (capability matrix: image/video per model) |
+| `setup.sh`, `docker/compose.yaml` | the deploy artifacts used below |
+
+## 1. Context routing — repo clone or standalone?
+
+```bash
+[ -f setup.sh ] && grep -q 'vlm-openvino-serving' pyproject.toml 2>/dev/null \
+  && echo REPO || echo STANDALONE
+```
+
+- **REPO** → run Step 2 from the microservice root.
+- **STANDALONE** → fetch the two deploy files into a fresh directory, then run
+  the exact same Step 2 from there:
+  ```bash
+  RAW=https://raw.githubusercontent.com/open-edge-platform/edge-ai-libraries/main/microservices/vlm-openvino-serving
+  mkdir -p vlm-serving/docker && cd vlm-serving
+  curl -fsSL $RAW/setup.sh -o setup.sh
+  curl -fsSL $RAW/docker/compose.yaml -o docker/compose.yaml
+  ```
+- Service already running (`curl -sf http://localhost:9764/health`) → skip to
+  Step 3.
+
+## 2. Bring-up (identical in both contexts)
+
+1. Pick a model — default `Qwen/Qwen2.5-VL-3B-Instruct` (image + multi-image +
+   video). Full list: `docs/user-guide/Overview.md`.
+2. `setup.sh` must be **sourced** (it exports env and uses `return`) and
+   requires `VLM_MODEL_NAME`. `REGISTRY_URL=intel` selects the prebuilt Docker
+   Hub image and `--no-build` prevents a source build (that's the `-dev`
+   skill's job). Run in the background — the first start downloads and
+   converts the model, which can take many minutes:
+   ```bash
+   bash -c 'export VLM_MODEL_NAME="Qwen/Qwen2.5-VL-3B-Instruct" REGISTRY_URL=intel TAG=latest \
+     && source setup.sh && docker compose -f docker/compose.yaml up -d --no-build'
+   ```
+   For Intel GPU: also `export VLM_DEVICE=GPU` (setup.sh then forces int4
+   weights and 1 worker). Everything else:
+   `docs/user-guide/environment-variables.md`.
+3. Wait for health before any request:
+   ```bash
+   until curl -sf http://localhost:9764/health; do sleep 10; done
+   ```
+   Watch progress with `docker logs -f vlm-openvino-serving` if it takes long.
+
+## 3. Query the service
+
+Basic text + image chat completion:
+
+```bash
+curl -s http://localhost:9764/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "Qwen/Qwen2.5-VL-3B-Instruct",
+  "messages": [{"role": "user", "content": [
+    {"type": "text", "text": "Describe this image in one sentence."},
+    {"type": "image_url", "image_url": {"url": "https://example.com/dock.jpg"}}
+  ]}],
+  "max_completion_tokens": 100
+}'
+```
+
+- `model` must equal the configured `VLM_MODEL_NAME` (check `GET /v1/models`),
+  otherwise 404.
+- Python: use the `openai` package with
+  `OpenAI(base_url="http://localhost:9764/v1", api_key="EMPTY")`.
+- Streaming: add `"stream": true` (SSE chunks). Video (`video` frame lists /
+  `video_url` mp4, Qwen models only), base64 inputs, and full schemas:
+  `docs/user-guide/api-reference.md`; worked examples:
+  `docs/user-guide/get-started.md`.
+
+## 4. Observe
+
+- `GET /v1/telemetry?limit=5` — per-request latency/token metrics (none for
+  SmolVLM).
+- `GET /v1/queue-status` — active vs queued requests.
+- `GET /device` — OpenVINO devices visible in the container.
+
+## 5. Stop / clean
+
+- `docker compose -f docker/compose.yaml down`
+- The `ov-models` volume keeps model caches so restarts are fast. Removing it
+  (`docker volume rm ov-models`) forces a full re-download — **confirm with
+  the user first**.
+
+## Troubleshooting
+
+| Symptom | Likely cause → action |
+|---|---|
+| `curl` exit 7 / no response on 9764 | not started or still pulling → `docker ps`, `docker logs -f vlm-openvino-serving` |
+| `/health` returns 503 | model still downloading/converting → keep waiting, watch logs |
+| 404 on chat completions | `model` mismatch → `GET /v1/models` and use that exact id |
+| `error code: -5` on GPU | GPU OOM; the service **intentionally restarts itself** (`os.execv`) to recover — not a crash loop → smaller model, int4 weights, fewer concurrent requests |
+| First request very slow | model compile on first inference → expected once per start |
+| Port 9764 busy | `export VLM_SERVICE_PORT=<other>` before bring-up |
+| Gated model download fails | `export HUGGINGFACE_TOKEN=...` — see `docs/user-guide/environment-variables.md` |

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/SKILL.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/SKILL.md
@@ -87,11 +87,13 @@ Load these existing docs only when needed:
    skill's job). Run in the background — the first start downloads and
    converts the model, which can take many minutes:
    ```bash
-   bash -c 'export VLM_MODEL_NAME="Qwen/Qwen2.5-VL-3B-Instruct" REGISTRY_URL=intel TAG=latest \
+   bash -c 'export VLM_MODEL_NAME="Qwen/Qwen2.5-VL-3B-Instruct" VLM_DEVICE=CPU REGISTRY_URL=intel TAG=latest \
      && source setup.sh && docker compose -f docker/compose.yaml up -d --no-build'
    ```
-   For Intel GPU: also `export VLM_DEVICE=GPU` (setup.sh then forces int4
-   weights and 1 worker). Everything else:
+   For Intel GPU: also `export VLM_DEVICE=GPU` (that exact value makes
+   setup.sh force int4 weights and 1 worker). Qualified values such as `GPU.0`
+   currently bypass the exact check, so verify the effective compression and
+   worker environment. Everything else:
    `docs/user-guide/environment-variables.md`.
 3. Wait for health before any request:
    ```bash
@@ -108,7 +110,7 @@ curl -s http://localhost:9764/v1/chat/completions -H 'Content-Type: application/
   "model": "Qwen/Qwen2.5-VL-3B-Instruct",
   "messages": [{"role": "user", "content": [
     {"type": "text", "text": "Describe this image in one sentence."},
-    {"type": "image_url", "image_url": {"url": "https://example.com/dock.jpg"}}
+    {"type": "image_url", "image_url": {"url": "https://storage.openvinotoolkit.org/repositories/openvino_notebooks/data/data/image/coco_bike.jpg"}}
   ]}],
   "max_completion_tokens": 100
 }'
@@ -144,7 +146,7 @@ curl -s http://localhost:9764/v1/chat/completions -H 'Content-Type: application/
 | `curl` exit 7 / no response on 9764 | not started or still pulling → `docker ps`, `docker logs -f vlm-openvino-serving` |
 | `/health` returns 503 | model still downloading/converting → keep waiting, watch logs |
 | 404 on chat completions | `model` mismatch → `GET /v1/models` and use that exact id |
-| `error code: -5` on GPU | GPU OOM; the service **intentionally restarts itself** (`os.execv`) to recover — not a crash loop → smaller model, int4 weights, fewer concurrent requests |
+| `error code: -5` on GPU | GPU OOM; the service **intentionally restarts itself** (`os.execv`) to recover — not a crash loop → verify effective int4/worker settings, then use a smaller model or fewer concurrent requests |
 | First request very slow | model compile on first inference → expected once per start |
 | Port 9764 busy | `export VLM_SERVICE_PORT=<other>` before bring-up |
 | Gated model download fails | `export HUGGINGFACE_TOKEN=...` — see `docs/user-guide/environment-variables.md` |

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/evals/evals.json
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/evals/evals.json
@@ -4,10 +4,11 @@
   "skill_name": "vlm-openvino-serving-user",
   "evals": [
     {
-      "id": "bringup-and-health",
+      "id": 1,
+      "name": "bringup-and-health",
       "prompt": "I need a local vision-language model with an OpenAI-compatible API for my prototype. Set up Intel's VLM OpenVINO serving microservice with Qwen2.5-VL-3B on CPU and make sure it's actually ready to take requests. I don't have the edge-ai-libraries repo checked out.",
       "expected_output": "The service is brought up from the prebuilt intel/vlm-openvino-serving image without a full repo clone or source build — e.g. fetching setup.sh + docker/compose.yaml from GitHub raw, exporting REGISTRY_URL=intel, and running docker compose up -d --no-build (or an equivalent docker run) — and readiness is verified by polling GET /health on port 9764 until 200, not just by starting the container.",
-      "assertions": [
+      "expectations": [
         "Uses the prebuilt intel/vlm-openvino-serving image (e.g. REGISTRY_URL=intel with docker compose --no-build, or docker run) without building the image from source or requiring a full repo clone",
         "Sets VLM_MODEL_NAME to Qwen/Qwen2.5-VL-3B-Instruct via environment variable",
         "Persists model caches via the ov-models volume (through setup.sh/compose or explicit volume mounts)",
@@ -15,10 +16,11 @@
       ]
     },
     {
-      "id": "image-caption-curl",
+      "id": 2,
+      "name": "image-caption-curl",
       "prompt": "The VLM serving container is already running on localhost:9764 with Qwen/Qwen2.5-VL-3B-Instruct. Give me a curl command that sends this image https://example.com/loading-dock.jpg and asks for a one-sentence caption, then show the same call in Python.",
       "expected_output": "A correct POST /v1/chat/completions curl with a content list containing a text block and an image_url block, model matching the loaded model name, plus an equivalent Python snippet using the openai client with base_url http://localhost:9764/v1.",
-      "assertions": [
+      "expectations": [
         "The curl targets POST /v1/chat/completions on localhost:9764 with Content-Type application/json",
         "The messages content is a list with a {type: text} block and a {type: image_url, image_url: {url: ...}} block (not a bare string with the URL pasted in)",
         "The model field is exactly Qwen/Qwen2.5-VL-3B-Instruct",
@@ -26,10 +28,11 @@
       ]
     },
     {
-      "id": "gpu-oom-diagnosis",
+      "id": 3,
+      "name": "gpu-oom-diagnosis",
       "prompt": "Our VLM serving instance runs on an Intel Arc GPU. Under load, responses fail with 'error code: -5' and then the service seems to restart itself. What is going on and what should we change?",
       "expected_output": "Diagnosis: 'error code: -5' is a GPU out-of-memory error from the OpenVINO runtime; the service intentionally restarts itself (os.execv) to recover. Mitigations: int4 weight compression, a single worker (both enforced on GPU by setup.sh), a smaller model, and/or reducing concurrent load; the self-restart explains the perceived restart.",
-      "assertions": [
+      "expectations": [
         "Identifies error code -5 as GPU out-of-memory",
         "Explains the self-restart is intentional recovery behavior of the service, not a crash loop to be 'fixed' by restart policies",
         "Recommends at least two concrete mitigations among: int4 weights, single worker, smaller model, fewer concurrent requests",
@@ -37,10 +40,11 @@
       ]
     },
     {
-      "id": "negative-embeddings-routing",
+      "id": 4,
+      "name": "negative-embeddings-routing",
       "prompt": "I need to generate text embeddings for a few thousand product descriptions so I can do similarity search. Can you set that up with an Intel microservice?",
       "expected_output": "Recognizes that the VLM chat-completions service is the wrong tool: it does not expose an embeddings endpoint. Points to a dedicated embedding service (e.g. Intel's multimodal-embedding-serving) instead, and does not deploy the VLM stack.",
-      "assertions": [
+      "expectations": [
         "Does not deploy or configure vlm-openvino-serving for this request",
         "States that the VLM service has no embeddings endpoint (it serves chat completions)",
         "Suggests a dedicated embedding service such as multimodal-embedding-serving for similarity-search embeddings"

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/evals/evals.json
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/evals/evals.json
@@ -1,0 +1,50 @@
+{
+  "SPDX-FileCopyrightText": "(C) 2026 Intel Corporation",
+  "SPDX-License-Identifier": "Apache-2.0",
+  "skill_name": "vlm-openvino-serving-user",
+  "evals": [
+    {
+      "id": "bringup-and-health",
+      "prompt": "I need a local vision-language model with an OpenAI-compatible API for my prototype. Set up Intel's VLM OpenVINO serving microservice with Qwen2.5-VL-3B on CPU and make sure it's actually ready to take requests. I don't have the edge-ai-libraries repo checked out.",
+      "expected_output": "The service is brought up from the prebuilt intel/vlm-openvino-serving image without a full repo clone or source build — e.g. fetching setup.sh + docker/compose.yaml from GitHub raw, exporting REGISTRY_URL=intel, and running docker compose up -d --no-build (or an equivalent docker run) — and readiness is verified by polling GET /health on port 9764 until 200, not just by starting the container.",
+      "assertions": [
+        "Uses the prebuilt intel/vlm-openvino-serving image (e.g. REGISTRY_URL=intel with docker compose --no-build, or docker run) without building the image from source or requiring a full repo clone",
+        "Sets VLM_MODEL_NAME to Qwen/Qwen2.5-VL-3B-Instruct via environment variable",
+        "Persists model caches via the ov-models volume (through setup.sh/compose or explicit volume mounts)",
+        "Verifies readiness by polling the /health endpoint on port 9764 (or an explicitly overridden port) and explains the first start is slow due to model download/conversion"
+      ]
+    },
+    {
+      "id": "image-caption-curl",
+      "prompt": "The VLM serving container is already running on localhost:9764 with Qwen/Qwen2.5-VL-3B-Instruct. Give me a curl command that sends this image https://example.com/loading-dock.jpg and asks for a one-sentence caption, then show the same call in Python.",
+      "expected_output": "A correct POST /v1/chat/completions curl with a content list containing a text block and an image_url block, model matching the loaded model name, plus an equivalent Python snippet using the openai client with base_url http://localhost:9764/v1.",
+      "assertions": [
+        "The curl targets POST /v1/chat/completions on localhost:9764 with Content-Type application/json",
+        "The messages content is a list with a {type: text} block and a {type: image_url, image_url: {url: ...}} block (not a bare string with the URL pasted in)",
+        "The model field is exactly Qwen/Qwen2.5-VL-3B-Instruct",
+        "The Python example uses an OpenAI-compatible client pointed at http://localhost:9764/v1 (api_key can be any dummy value)"
+      ]
+    },
+    {
+      "id": "gpu-oom-diagnosis",
+      "prompt": "Our VLM serving instance runs on an Intel Arc GPU. Under load, responses fail with 'error code: -5' and then the service seems to restart itself. What is going on and what should we change?",
+      "expected_output": "Diagnosis: 'error code: -5' is a GPU out-of-memory error from the OpenVINO runtime; the service intentionally restarts itself (os.execv) to recover. Mitigations: int4 weight compression, a single worker (both enforced on GPU by setup.sh), a smaller model, and/or reducing concurrent load; the self-restart explains the perceived restart.",
+      "assertions": [
+        "Identifies error code -5 as GPU out-of-memory",
+        "Explains the self-restart is intentional recovery behavior of the service, not a crash loop to be 'fixed' by restart policies",
+        "Recommends at least two concrete mitigations among: int4 weights, single worker, smaller model, fewer concurrent requests",
+        "Does not recommend rebuilding the image or editing service source code as the primary fix"
+      ]
+    },
+    {
+      "id": "negative-embeddings-routing",
+      "prompt": "I need to generate text embeddings for a few thousand product descriptions so I can do similarity search. Can you set that up with an Intel microservice?",
+      "expected_output": "Recognizes that the VLM chat-completions service is the wrong tool: it does not expose an embeddings endpoint. Points to a dedicated embedding service (e.g. Intel's multimodal-embedding-serving) instead, and does not deploy the VLM stack.",
+      "assertions": [
+        "Does not deploy or configure vlm-openvino-serving for this request",
+        "States that the VLM service has no embeddings endpoint (it serves chat completions)",
+        "Suggests a dedicated embedding service such as multimodal-embedding-serving for similarity-search embeddings"
+      ]
+    }
+  ]
+}

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/evals/evals.json
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/evals/evals.json
@@ -6,11 +6,12 @@
     {
       "id": 1,
       "name": "bringup-and-health",
-      "prompt": "I need a local vision-language model with an OpenAI-compatible API for my prototype. Set up Intel's VLM OpenVINO serving microservice with Qwen2.5-VL-3B on CPU and make sure it's actually ready to take requests. I don't have the edge-ai-libraries repo checked out.",
-      "expected_output": "The service is brought up from the prebuilt intel/vlm-openvino-serving image without a full repo clone or source build — e.g. fetching setup.sh + docker/compose.yaml from GitHub raw, exporting REGISTRY_URL=intel, and running docker compose up -d --no-build (or an equivalent docker run) — and readiness is verified by polling GET /health on port 9764 until 200, not just by starting the container.",
+      "prompt": "Give me an exact runbook for Intel's VLM OpenVINO serving microservice with Qwen2.5-VL-3B on CPU using prebuilt images. I don't have edge-ai-libraries checked out, and you must not pull the model or launch containers in this environment.",
+      "expected_output": "Fetches setup.sh and docker/compose.yaml without a full clone, explicitly exports VLM_MODEL_NAME, VLM_DEVICE=CPU, and REGISTRY_URL=intel, uses --no-build/prebuilt image with the ov-models volume, and polls /health while explaining first-start download/conversion.",
       "expectations": [
         "Uses the prebuilt intel/vlm-openvino-serving image (e.g. REGISTRY_URL=intel with docker compose --no-build, or docker run) without building the image from source or requiring a full repo clone",
         "Sets VLM_MODEL_NAME to Qwen/Qwen2.5-VL-3B-Instruct via environment variable",
+        "Explicitly sets VLM_DEVICE=CPU rather than relying on an ambient/default device",
         "Persists model caches via the ov-models volume (through setup.sh/compose or explicit volume mounts)",
         "Verifies readiness by polling the /health endpoint on port 9764 (or an explicitly overridden port) and explains the first start is slow due to model download/conversion"
       ]
@@ -31,23 +32,24 @@
       "id": 3,
       "name": "gpu-oom-diagnosis",
       "prompt": "Our VLM serving instance runs on an Intel Arc GPU. Under load, responses fail with 'error code: -5' and then the service seems to restart itself. What is going on and what should we change?",
-      "expected_output": "Diagnosis: 'error code: -5' is a GPU out-of-memory error from the OpenVINO runtime; the service intentionally restarts itself (os.execv) to recover. Mitigations: int4 weight compression, a single worker (both enforced on GPU by setup.sh), a smaller model, and/or reducing concurrent load; the self-restart explains the perceived restart.",
+      "expected_output": "Diagnosis: error code -5 is GPU OOM and os.execv recovery is intentional. Checks the effective VLM_DEVICE/compression/worker settings because setup.sh forces int4 and one worker only for exact VLM_DEVICE=GPU; then recommends smaller model or lower concurrency if already optimized.",
       "expectations": [
         "Identifies error code -5 as GPU out-of-memory",
         "Explains the self-restart is intentional recovery behavior of the service, not a crash loop to be 'fixed' by restart policies",
-        "Recommends at least two concrete mitigations among: int4 weights, single worker, smaller model, fewer concurrent requests",
+        "Checks effective device/compression/worker settings and notes the setup.sh enforcement applies to exact VLM_DEVICE=GPU",
+        "Recommends a smaller model or fewer concurrent requests if int4 and one worker are already effective",
         "Does not recommend rebuilding the image or editing service source code as the primary fix"
       ]
     },
     {
       "id": 4,
-      "name": "negative-embeddings-routing",
-      "prompt": "I need to generate text embeddings for a few thousand product descriptions so I can do similarity search. Can you set that up with an Intel microservice?",
-      "expected_output": "Recognizes that the VLM chat-completions service is the wrong tool: it does not expose an embeddings endpoint. Points to a dedicated embedding service (e.g. Intel's multimodal-embedding-serving) instead, and does not deploy the VLM stack.",
+      "name": "model-mismatch-404",
+      "prompt": "My VLM service is healthy on localhost:9764, but POST /v1/chat/completions returns 404 saying the requested model is not available. How do I diagnose and fix the request?",
+      "expected_output": "Queries GET /v1/models, copies the returned configured model id exactly into the chat request, and does not treat the healthy service as needing a rebuild/restart.",
       "expectations": [
-        "Does not deploy or configure vlm-openvino-serving for this request",
-        "States that the VLM service has no embeddings endpoint (it serves chat completions)",
-        "Suggests a dedicated embedding service such as multimodal-embedding-serving for similarity-search embeddings"
+        "Queries GET http://localhost:9764/v1/models to discover the configured model id",
+        "Uses the exact returned model id in POST /v1/chat/completions",
+        "Does not recommend rebuilding or restarting a healthy service as the primary fix"
       ]
     }
   ]

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/compliance-checker.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/compliance-checker.md
@@ -1,0 +1,14 @@
+Build a compliance checker that grades an image against a fixed checklist using the VLM service.
+
+- Bring the VLM service up if it isn't already (prebuilt image, CPU is fine); wait for /health.
+- Send the image with the checklist and demand strict JSON only: {"checks": [{"item": ..., "pass": true|false, "evidence": ...}], "overall_pass": ...} — one entry per checklist item, evidence describing what is visible.
+- Parse the response; on a JSON parse failure retry once with "Return only valid JSON.", then pretty-print the verdict.
+
+Validate the application using:
+- Model Qwen/Qwen2.5-VL-3B-Instruct on http://localhost:9764/v1.
+- A frame extracted from worker-zone-detection.mp4 in Intel's sample-videos repo (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4).
+- Checklist: "worker wears a hard hat", "worker wears a hi-vis vest", "no person lying on the ground".
+
+Expected results:
+- Valid JSON with exactly the three checklist entries; pass values consistent with what the frame actually shows, each with evidence describing the visible worker.
+- overall_pass is the logical AND of the per-item verdicts.

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/image-to-json-extractor.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/image-to-json-extractor.md
@@ -1,0 +1,13 @@
+Build an image-to-JSON extractor that converts a visual scene into structured data using the VLM service.
+
+- Bring the VLM service up if it isn't already (prebuilt image, CPU is fine); wait for /health.
+- Send each image with a prompt demanding strict JSON only: {"objects": [{"name": ..., "count": ...}], "visible_text": [...], "risks": [...]} — empty arrays when nothing applies.
+- Parse the response; on a JSON parse failure retry once with "Return only valid JSON."; append each record to scene.json.
+
+Validate the application using:
+- Model Qwen/Qwen2.5-VL-3B-Instruct on http://localhost:9764/v1.
+- Frames extracted with ffmpeg from person-bicycle-car-detection.mp4 in Intel's sample-videos repo (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4) — pick frames where the pedestrian, the cyclist, and the car each appear.
+
+Expected results:
+- Every frame yields parseable JSON; objects include person/bicycle/car with plausible counts in the frames where they appear.
+- Fields with nothing to report are empty arrays (e.g. visible_text), not invented values.

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/retail-shelf-assistant.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/retail-shelf-assistant.md
@@ -1,0 +1,14 @@
+Build a retail shelf assistant that reads shelf/aisle images and reports stock issues using the VLM service.
+
+- Bring the VLM service up if it isn't already (prebuilt image, CPU is fine); wait for /health.
+- Send each aisle image with the prompt: "You are a store-shelf auditor. Report: (1) visibly empty or sparsely stocked shelf sections, (2) misplaced or fallen items, (3) overall tidiness. Answer in three short sections; say 'none observed' where nothing applies."
+- Print the audit per image.
+
+Validate the application using:
+- Model Qwen/Qwen2.5-VL-3B-Instruct on http://localhost:9764/v1.
+- Frames extracted with ffmpeg from store-aisle-detection.mp4 (and optionally fruit-and-vegetable-detection.mp4) in Intel's sample-videos repo (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4).
+
+Expected results:
+- A three-section audit per frame that only describes shelves, products, and people actually visible in the overhead aisle view.
+- Sections with nothing to report say "none observed" instead of inventing issues.
+- Rerunning on the same frame gives substantively consistent findings.

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/safety-inspection-assistant.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/safety-inspection-assistant.md
@@ -1,0 +1,14 @@
+Build a safety inspection assistant that checks camera frames for PPE and unsafe scenes using the VLM service.
+
+- Bring the VLM service up if it isn't already (prebuilt image, CPU is fine); wait for /health before sending.
+- For each frame, send one chat completion with an image part plus a rules prompt, e.g.: "You are a safety inspector. Rules: (1) every person must wear a hard hat, (2) every person must wear a hi-vis vest, (3) walkways and exits must be clear. List visible violations as bullets citing the rule number. If there are none, reply exactly: No violations."
+- Print one report per frame.
+
+Validate the application using:
+- Model Qwen/Qwen2.5-VL-3B-Instruct on http://localhost:9764/v1.
+- Frames extracted with ffmpeg (e.g. one every 5 s) from worker-zone-detection.mp4 in Intel's sample-videos repo (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4).
+
+Expected results:
+- /health returns 200 and model matches GET /v1/models before the first request.
+- Each report cites only the numbered rules and correctly states whether the worker's hard hat and vest are actually visible in that frame; frames with no people yield exactly "No violations".
+- The assistant does not invent people, PPE, or hazards that are not in the frame.

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/screenshot-understanding.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/screenshot-understanding.md
@@ -1,0 +1,13 @@
+Build a document/screenshot understanding helper that answers questions about UI screenshots, forms, charts, or dashboards using the VLM service.
+
+- Bring the VLM service up if it isn't already (prebuilt image, CPU is fine); wait for /health.
+- Send the screenshot as an image part plus the user's question in one chat completion; support structured follow-ups like "list every button with its label" or "read the table values as JSON".
+- Print the answer.
+
+Validate the application using:
+- Model Qwen/Qwen2.5-VL-3B-Instruct on http://localhost:9764/v1.
+- A screenshot of the service's own Swagger UI — open http://localhost:9764/docs in a browser and capture it (the sample-videos repo has no document footage, so the service documents itself).
+
+Expected results:
+- Asked "which API endpoints are listed?", the answer names only endpoints actually visible in the screenshot (e.g. /v1/chat/completions, /health) and invents none.
+- "Return the visible endpoints as a JSON array" yields parseable JSON matching the screenshot.

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/smart-camera-operator-console.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/example-prompts/smart-camera-operator-console.md
@@ -1,0 +1,13 @@
+Build a smart camera operator console: an operator asks natural-language questions about the latest frame of a (simulated) live camera, answered by the VLM service.
+
+- Bring the VLM service up if it isn't already (prebuilt image, CPU is fine); wait for /health.
+- Simulate the camera by extracting one frame every N seconds from a looping video file; keep only the newest frame with its timestamp (the VLM has no memory — each answer comes from the frame you send).
+- On each operator question ("Is the loading bay clear?", "How many people are visible?"), send the newest frame plus the question as one chat completion and print the answer tagged with the frame timestamp.
+
+Validate the application using:
+- Model Qwen/Qwen2.5-VL-3B-Instruct on http://localhost:9764/v1.
+- one-by-one-person-detection.mp4 from Intel's sample-videos repo (download: https://github.com/intel-iot-devkit/sample-videos/raw/refs/heads/master/<name>.mp4) as the simulated feed — people enter the area one at a time.
+
+Expected results:
+- Repeatedly asking "Is the area clear of people?" flips between yes and no as the sampled frame changes with people entering and leaving.
+- Every answer is tagged with the timestamp of the frame it was computed from; stale frames are never sent.

--- a/microservices/vlm-openvino-serving/AGENTS.md
+++ b/microservices/vlm-openvino-serving/AGENTS.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# VLM OpenVINO Serving — AI agents
+
+**Do not add project policy here.**
+
+- **All tools:** [`.github/copilot-instructions.md`](.github/copilot-instructions.md)
+- **Claude:** [`CLAUDE.md`](CLAUDE.md)
+- **Cursor:** [`.cursor/rules/vlm-openvino-serving.mdc`](.cursor/rules/vlm-openvino-serving.mdc)

--- a/microservices/vlm-openvino-serving/CLAUDE.md
+++ b/microservices/vlm-openvino-serving/CLAUDE.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# VLM OpenVINO Serving — Claude
+
+**Do not add project policy here.**
+
+- **Canonical instructions:** [`.github/copilot-instructions.md`](.github/copilot-instructions.md)
+- **Skills:** [`.github/skills/`](.github/skills/)


### PR DESCRIPTION
### Description

Adds agent **skills** for the VSS microservices, each split into `-user` (deploy & consume) and `-dev` (modify the source) variants, with a harness-neutral `skill-catalog.json` for discovery.

## What's included

- **Evals** : `evals/evals.json` per skill, covering the core end-to-end scenarios (bring-up/health, request shapes, capability/routing checks, and negative cases).
- **Example prompts** : real problem-solving scenarios under `example-prompts/` (e.g. similarity search, safety inspection, retail shelf, screenshot understanding).

## Note for reviewers

These skills will likely need **further refinement based on real-world use and future changes** to the services, treat this as a first iteration rather than a final version.  Feedback on the skill structure, eval coverage, and prompt wording is welcome.

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?


Used claude and codex to test multiple skills.
Exercised the `-user` skills' bring-up paths **both ways**:

- **With a clone (REPO path)** : run from the microservice root.
- **Without a clone (STANDALONE path)** : fetched `setup.sh` + `docker/compose.yaml` from GitHub raw into a fresh directory and brought up the prebuilt `intel/…` image.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

