### PR TITLE
[video-search-and-summarization] add vss-build skill and clean catalog

### DIFF
--- a/sample-applications/video-search-and-summarization/.github/skills/skill-catalog.json
+++ b/sample-applications/video-search-and-summarization/.github/skills/skill-catalog.json
@@ -110,24 +110,6 @@
       ]
     },
     {
-      "name": "vss-model-onboarding",
-      "path": ".github/skills/vss-model-onboarding/SKILL.md",
-      "description": "Bring a new VLM/embedding model into OVMS with OpenVINO IR conversion and model-dir layout.",
-      "triggers": [
-        "onboard new model",
-        "add vlm model",
-        "convert to ovms",
-        "openVINO IR conversion",
-        "model deployment"
-      ],
-      "requires": [
-        ".github/skills/vss-model-onboarding/scripts/vss-bootstrap.sh",
-        ".github/skills/vss-model-onboarding/scripts/prepare_ovms_model.py",
-        "OpenVINO",
-        "model assets"
-      ]
-    },
-    {
       "name": "vss-deploy-helm",
       "path": ".github/skills/vss-deploy-helm/SKILL.md",
       "description": "Deploy VSS to Kubernetes via Helm chart with mode mapping to values.yaml.",
@@ -193,24 +175,6 @@
         "docker compose",
         "DLStreamer",
         "video-ingestion/"
-      ]
-    },
-    {
-      "name": "vss-search-internals",
-      "path": ".github/skills/vss-search-internals/SKILL.md",
-      "description": "Work on embeddings and VDMS retrieval; understand frame vs summary-text embedding.",
-      "triggers": [
-        "search internals",
-        "embeddings",
-        "vdms retrieval",
-        "embedding model",
-        "vector search"
-      ],
-      "requires": [
-        ".github/skills/vss-search-internals/scripts/vss-bootstrap.sh",
-        "search-ms/",
-        "VDMS",
-        "embedding model"
       ]
     },
     {

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/BENCHMARK.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/BENCHMARK.md
@@ -1,0 +1,61 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Benchmark — vss-build
+
+_Generated: 2026-07-20T16:45:39+05:30_
+
+## Models
+
+| Role | Model |
+|---|---|
+| Eval execution (with & without skill) | `claude-sonnet-5` |
+| Orchestrator / grader | `claude-opus-4.8` |
+
+**Token source:** Real runtime usage from the local session store (assistant_usage_events), summed per serialized top-level background agent (model claude-sonnet-5) - authoritative token metadata, not an estimate.
+
+## Results summary
+
+| Mode | Evals passed | Expectations passed | Input tokens | Output tokens | Total tokens |
+|---|---|---|---|---|---|
+| **With skill** | 6/7 | 33/35 | 387808 | 10750 | 398558 |
+| **Without skill** | 0/7 | 19/35 | 249450 | 7369 | 256819 |
+
+**Skill impact:** +6 evals passed with the skill vs without.
+
+## Per-eval detail
+
+| Eval | Prompt file | With skill | Without skill |
+|---|---|---|---|
+| 1 | `example-prompts/01-local-app-rebuild.md` | PASS (5/5) | FAIL (4/5) |
+| 2 | `example-prompts/02-first-time-with-dependencies.md` | PASS (5/5) | FAIL (4/5) |
+| 3 | `example-prompts/03-registry-tag-push.md` | PASS (5/5) | FAIL (3/5) |
+| 4 | `example-prompts/04-corporate-proxy-build.md` | PASS (5/5) | FAIL (3/5) |
+| 5 | `example-prompts/05-fresh-checkout-bootstrap.md` | PASS (5/5) | FAIL (1/5) |
+| 6 | `example-prompts/06-copyleft-sources-build.md` | PASS (5/5) | FAIL (4/5) |
+| 90 | `example-prompts/07-bootstrap-fresh-machine.md` | FAIL (3/5) | FAIL (0/5) |
+
+## Token consumption
+
+- **With skill:** 398558 total tokens (387808 in / 10750 out)
+- **Without skill:** 256819 total tokens (249450 in / 7369 out)
+
+## Eval 90 re-run (implicit bootstrap detection)
+
+_Re-generated: 2026-07-21T03:00:47Z_
+
+Eval 90 was rewritten to test IMPLICIT bootstrap behavior (no explicit 'fresh machine'/clone wording in the prompt) and re-run in isolation. The mode_tokens block above still reflects the ORIGINAL full-suite run (unchanged, not corrupted by this partial re-run); these numbers are for the eval-90-only re-run.
+
+- Prompt file: `example-prompts/07-bootstrap-fresh-machine.md`
+- With skill: FAIL (3/5)
+- Without skill: FAIL (0/5)
+
+| Mode | Input tokens | Output tokens | Total tokens |
+|---|---|---|---|
+| With skill (eval 90 only) | 316265 | 4381 | 320646 |
+| Without skill (eval 90 only) | 274099 | 3262 | 277361 |
+
+**Token source:** top-level background agent usage window (partially shared-pool batched for 13/15 skills; see grader_note)
+

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/SKILL.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: vss-build
+description: Build (and optionally push) the VSS Docker images from source using build.sh - the application services, the pre-built dependency services, or both, with registry/tag and proxy controls. Use when the user says "build vss", "rebuild the images", "build from source", "build the dependencies", or "push the vss images". build.sh is the source of truth for builds, not the Makefile.
+license: Apache-2.0
+metadata:
+  version: "1.0.0"
+  tags: "vss build development"
+---
+
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# VSS Build
+
+Build VSS container images with **`build.sh`** - the true source for builds in
+this repo. Do **not** drive builds via the Makefile here. Run the commands
+yourself and relay output.
+
+## Environment setup (run first)
+
+This skill drives the Video Search & Summarization app through its real source
+files, so the VSS application must be present and you must run commands from its
+app root. **Do this before anything else**, and it works whether or not the VSS
+source is already in your workspace.
+
+Run the bundled bootstrap. It first tries to find an existing VSS checkout -
+walking up from the current directory and inspecting the enclosing git repo - and
+reuses it **without ever re-cloning**. Only when no checkout is found does it do a
+shallow, single-branch, sparse checkout of just
+`sample-applications/video-search-and-summarization` from `main`. It prints the
+resolved app root on stdout:
+
+```bash
+# SKILL_DIR is THIS skill's own directory (shown to you when the skill loads);
+# in-repo it is .github/skills/vss-build. Works the same if the skill is installed standalone.
+SKILL_DIR=".github/skills/vss-build"
+APP_ROOT="$(bash "$SKILL_DIR/scripts/vss-bootstrap.sh")"
+cd "$APP_ROOT"
+```
+
+Every command below assumes the working directory is this `APP_ROOT`. To pull
+from a fork/branch or reuse a specific checkout dir, override `VSS_REPO_URL`,
+`VSS_REPO_BRANCH`, or `VSS_CLONE_DIR` before running it.
+
+## What build.sh does
+
+| Command | Builds |
+|---|---|
+| `./build.sh` | Application services: `video-ingestion`, `pipeline-manager`, `search-ms`, UI |
+| `./build.sh --dependencies` | Dependency services: `vdms-dataprep`, `multimodal-embedding-serving` (needs **poetry** for the embedding wheel) |
+| `./build.sh --push` | Push all built images to the configured registry |
+| `./build.sh --help` | Usage |
+
+Run `--dependencies` before the plain build the first time, or when those
+upstream services changed; otherwise the plain `./build.sh` is enough for
+day-to-day app changes.
+
+## Controls (env vars)
+
+`build.sh` reads these from the shell (it does not read a `.env`):
+
+| Var | Effect | Default |
+|---|---|---|
+| `REGISTRY_URL` | registry host prefix (trailing `/` auto-added) | empty (local tags) |
+| `PROJECT_NAME` | project/namespace segment after the registry | empty |
+| `TAG` | image tag | `latest` |
+| `http_proxy` / `https_proxy` / `no_proxy` | passed through as Docker `--build-arg`s | inherited |
+| `COPYLEFT_SOURCES` | if set, builds with `--build-arg COPYLEFT_SOURCES=true` | unset |
+
+With no `REGISTRY_URL` you get local image names (fine for local deploy via
+`setup.sh`). Final image prefix is `${REGISTRY_URL}/${PROJECT_NAME}/`.
+
+Reuse the same values you deploy with - see
+[`vss-deploy/vss.config.env`](../vss-deploy/vss.config.env) (`REGISTRY_URL`, `TAG`).
+
+## Typical flows
+
+```bash
+# Local app rebuild (no registry), then deploy:
+./build.sh
+#   ! ./.github/skills/vss-deploy/scripts/gen-secrets.sh && source .github/skills/vss-deploy/vss.config.env && source .github/skills/vss-deploy/vss.secrets.env && source setup.sh --summary
+
+# First-time / dependency refresh:
+./build.sh --dependencies && ./build.sh
+
+# Build for a registry and push:
+export REGISTRY_URL=intel TAG=dev
+./build.sh && ./build.sh --push
+```
+
+## Prerequisites & gotchas
+
+- **Docker** required for any build; **poetry** also required for
+  `--dependencies` (builds the multimodal-embedding wheel) - build.sh aborts
+  early with an install hint if missing.
+- Behind a corporate proxy, export `http_proxy`/`https_proxy`/`no_proxy` before
+  building so they reach the image builds.
+- After building locally, deploy with [`vss-deploy`](../vss-deploy/SKILL.md); `setup.sh`
+  uses the images you just built (match `TAG`/`REGISTRY_URL`).
+
+## Verify
+
+```bash
+docker images | grep -E 'pipeline-manager|search|video-ingestion|vss|embedding|dataprep'
+```

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/evals/evals.json
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/evals/evals.json
@@ -1,0 +1,103 @@
+{
+  "skill_name": "vss-build",
+  "evals": [
+    {
+      "id": 1,
+      "prompt_file": "example-prompts/01-local-app-rebuild.md",
+      "prompt": "I just fixed a bug in pipeline-manager. Can you rebuild the VSS app images from source so I can redeploy and test the fix locally? I don't need a registry, just local tags.",
+      "expected_output": "Resolves the VSS app root with the bundled bootstrap helper, changes into it, runs the plain ./build.sh for application services only with local tags, verifies images with docker images grep, and notes redeploying is handled by vss-deploy/setup.sh using the just-built images.",
+      "files": [],
+      "expectations": [
+        "The answer runs scripts/vss-bootstrap.sh to resolve APP_ROOT and cd into the VSS app root before building.",
+        "The answer uses the plain ./build.sh command for application services and does not use --dependencies for a day-to-day app change.",
+        "The answer does not set REGISTRY_URL or PROJECT_NAME when local image tags are requested.",
+        "The answer verifies with docker images | grep -E 'pipeline-manager|search|video-ingestion|vss|embedding|dataprep'.",
+        "The answer points deploy follow-up to vss-deploy/setup.sh rather than driving deployment through build.sh."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt_file": "example-prompts/02-first-time-with-dependencies.md",
+      "prompt": "This is my first time building VSS from source on this machine. I want all the images built, including the dependency services like vdms-dataprep and the multimodal embedding service, not just the app ones. What do I need installed and what commands do I run?",
+      "expected_output": "Explains prerequisites, especially Docker for all builds and poetry for ./build.sh --dependencies, resolves and enters the app root, runs ./build.sh --dependencies before ./build.sh, and verifies both dependency and application images.",
+      "files": [],
+      "expectations": [
+        "The answer runs scripts/vss-bootstrap.sh and cd \"$APP_ROOT\" before invoking build.sh.",
+        "The answer states Docker is required for any build and poetry is required for --dependencies because it builds the multimodal-embedding wheel.",
+        "The answer runs ./build.sh --dependencies before the plain ./build.sh command.",
+        "The answer identifies --dependencies as building vdms-dataprep and multimodal-embedding-serving.",
+        "The answer verifies the result with docker images | grep -E 'pipeline-manager|search|video-ingestion|vss|embedding|dataprep'."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt_file": "example-prompts/03-registry-tag-push.md",
+      "prompt": "Build the VSS images and push them to our internal registry at `registry.internal.example.com` under the `vss-team` project, tagged `v0.9.2`. I need both the app images and the dependency images pushed so the k8s team can pull them.",
+      "expected_output": "Exports REGISTRY_URL=registry.internal.example.com, PROJECT_NAME=vss-team, and TAG=v0.9.2, builds dependencies then app images using build.sh, runs ./build.sh --push, verifies the local image list, and reminds the user to reuse matching registry/tag values for deployment.",
+      "files": [],
+      "expectations": [
+        "The answer resolves and enters the app root through scripts/vss-bootstrap.sh before building.",
+        "The answer exports REGISTRY_URL, PROJECT_NAME, and TAG with the values requested by the prompt.",
+        "The answer builds dependency images with ./build.sh --dependencies before building application images with ./build.sh.",
+        "The answer uses ./build.sh --push to push built images rather than inventing another push command.",
+        "The answer mentions matching REGISTRY_URL/TAG values when deploying with vss-deploy."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt_file": "example-prompts/04-corporate-proxy-build.md",
+      "prompt": "My builds keep failing to reach the internet because we're behind a corporate proxy. Our proxy is `http://proxy.corp.example.com:8080` for both http and https, and I need to bypass it for `localhost` and `.corp.example.com`. Can you build the VSS images with that proxy config applied?",
+      "expected_output": "Sets http_proxy, https_proxy, and no_proxy in the shell before invoking build.sh, because build.sh passes inherited proxy variables through as Docker build args, then runs the appropriate build and verifies images.",
+      "files": [],
+      "expectations": [
+        "The answer resolves APP_ROOT with scripts/vss-bootstrap.sh and changes into that directory first.",
+        "The answer exports http_proxy and https_proxy to http://proxy.corp.example.com:8080 before running build.sh.",
+        "The answer exports no_proxy including localhost, 127.0.0.1, and .corp.example.com before running build.sh.",
+        "The answer explains that build.sh reads inherited proxy env vars and passes them as Docker --build-arg values, not via custom proxy flags.",
+        "The answer runs ./build.sh for app images and only adds ./build.sh --dependencies first if dependency images are needed."
+      ]
+    },
+    {
+      "id": 5,
+      "prompt_file": "example-prompts/05-fresh-checkout-bootstrap.md",
+      "prompt": "I only have this skills folder here, there's no video-search-and-summarization source checked out anywhere on this machine. Please get the source and build the VSS images from scratch for me.",
+      "expected_output": "Runs the bundled vss-bootstrap.sh from the skill directory to make the source available, explains that absent source triggers a shallow single-branch sparse checkout of only sample-applications/video-search-and-summarization from main, cd\u2019s into the resolved app root, runs ./build.sh, and verifies images.",
+      "files": [],
+      "expectations": [
+        "The answer runs the bundled scripts/vss-bootstrap.sh helper before any build command.",
+        "The answer states that when no checkout is found, the helper performs a shallow, single-branch sparse checkout from main.",
+        "The answer states the checkout is limited to sample-applications/video-search-and-summarization rather than the full repository.",
+        "The answer changes directory into the resolved APP_ROOT before running ./build.sh.",
+        "The answer mentions VSS_REPO_URL, VSS_REPO_BRANCH, or VSS_CLONE_DIR only as optional bootstrap overrides, not as required flags."
+      ]
+    },
+    {
+      "id": 6,
+      "prompt_file": "example-prompts/06-copyleft-sources-build.md",
+      "prompt": "For our compliance-tagged release, I need the VSS images built with COPYLEFT_SOURCES enabled so the copyleft build-arg is set on every image. Build both the dependency and app images this way, tag them `compliance-2026-07`, and don't push anywhere yet - just confirm locally that they built.",
+      "expected_output": "Exports COPYLEFT_SOURCES=true and TAG=compliance-2026-07, builds dependency images first and then app images with build.sh so the copyleft build arg is applied, skips --push because the prompt asks for local confirmation only, and verifies local images show the requested tag.",
+      "files": [],
+      "expectations": [
+        "The answer resolves and cd\u2019s into the VSS app root using scripts/vss-bootstrap.sh before building.",
+        "The answer exports COPYLEFT_SOURCES=true so build.sh uses --build-arg COPYLEFT_SOURCES=true.",
+        "The answer exports TAG=compliance-2026-07 and does not require REGISTRY_URL or PROJECT_NAME for local confirmation.",
+        "The answer runs ./build.sh --dependencies before ./build.sh to build both dependency and application images.",
+        "The answer does not run ./build.sh --push because the prompt explicitly says not to push."
+      ]
+    },
+    {
+      "id": 90,
+      "prompt_file": "example-prompts/07-bootstrap-fresh-machine.md",
+      "prompt": "I need to cut a new build of the VSS app images tagged `nightly-2026-07-21`. Just build the app services from source with the default settings, no need to push anywhere - I'll test locally first.",
+      "expected_output": "Before doing anything else, runs the bundled scripts/vss-bootstrap.sh to resolve the VSS app root, even though the prompt never mentioned setup or cloning. The check inspects the enclosing git repo's remote (origin/upstream) to see if it already points at the official VSS repo or a fork of it, reusing that checkout with no re-clone if so, or otherwise performing a shallow, single-branch, sparse checkout of sample-applications/video-search-and-summarization from main, then cd's into the resolved app root before building the requested images.",
+      "files": [],
+      "expectations": [
+        "The answer runs the bundled bootstrap helper (scripts/vss-bootstrap.sh) as an unconditional first step, before building the requested images, even though the prompt never asked about setup, location, or cloning.",
+        "The bootstrap check determines whether the current location is already a valid VSS checkout by inspecting the enclosing git repository's remote configuration (e.g. `git remote -v`, origin/upstream URL) to see if it points at the official open-edge-platform/edge-ai-libraries repo or a fork of it, not merely by checking for local marker files.",
+        "If that remote check finds a valid existing checkout (the user's own clone or a fork whose remote traces back to the official repo), the answer reuses it and performs NO re-clone.",
+        "If no valid checkout/remote is found, the answer performs a shallow, single-branch, sparse checkout of only sample-applications/video-search-and-summarization from the main branch (not a full-history, all-branches, or full-tree clone).",
+        "The answer changes directory into the resolved app root (cd \"$APP_ROOT\") before running any of the skill's build.sh commands for the requested build."
+      ]
+    }
+  ]
+}

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/01-local-app-rebuild.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/01-local-app-rebuild.md
@@ -1,0 +1,6 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+I just fixed a bug in pipeline-manager. Can you rebuild the VSS app images from source so I can redeploy and test the fix locally? I don't need a registry, just local tags.

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/02-first-time-with-dependencies.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/02-first-time-with-dependencies.md
@@ -1,0 +1,6 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+This is my first time building VSS from source on this machine. I want all the images built, including the dependency services like vdms-dataprep and the multimodal embedding service, not just the app ones. What do I need installed and what commands do I run?

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/03-registry-tag-push.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/03-registry-tag-push.md
@@ -1,0 +1,6 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+Build the VSS images and push them to our internal registry at `registry.internal.example.com` under the `vss-team` project, tagged `v0.9.2`. I need both the app images and the dependency images pushed so the k8s team can pull them.

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/04-corporate-proxy-build.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/04-corporate-proxy-build.md
@@ -1,0 +1,6 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+My builds keep failing to reach the internet because we're behind a corporate proxy. Our proxy is `http://proxy.corp.example.com:8080` for both http and https, and I need to bypass it for `localhost` and `.corp.example.com`. Can you build the VSS images with that proxy config applied?

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/05-fresh-checkout-bootstrap.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/05-fresh-checkout-bootstrap.md
@@ -1,0 +1,6 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+I only have this skills folder here, there's no video-search-and-summarization source checked out anywhere on this machine. Please get the source and build the VSS images from scratch for me.

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/06-copyleft-sources-build.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/06-copyleft-sources-build.md
@@ -1,0 +1,6 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+For our compliance-tagged release, I need the VSS images built with COPYLEFT_SOURCES enabled so the copyleft build-arg is set on every image. Build both the dependency and app images this way, tag them `compliance-2026-07`, and don't push anywhere yet - just confirm locally that they built.

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/07-bootstrap-fresh-machine.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/07-bootstrap-fresh-machine.md
@@ -1,0 +1,6 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+I need to cut a new build of the VSS app images tagged `nightly-2026-07-21`. Just build the app services from source with the default settings, no need to push anywhere - I'll test locally first.

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/README.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/example-prompts/README.md
@@ -1,0 +1,16 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+Each file below is a ready-to-use prompt for `vss-build` and can be used directly via `@file`.
+
+| File | Title |
+|---|---|
+| [01-local-app-rebuild.md](01-local-app-rebuild.md) | Local App Rebuild |
+| [02-first-time-with-dependencies.md](02-first-time-with-dependencies.md) | First Time With Dependencies |
+| [03-registry-tag-push.md](03-registry-tag-push.md) | Registry Tag Push |
+| [04-corporate-proxy-build.md](04-corporate-proxy-build.md) | Corporate Proxy Build |
+| [05-fresh-checkout-bootstrap.md](05-fresh-checkout-bootstrap.md) | Fresh Checkout Bootstrap |
+| [06-copyleft-sources-build.md](06-copyleft-sources-build.md) | Copyleft Sources Build |
+| [07-bootstrap-fresh-machine.md](07-bootstrap-fresh-machine.md) | Bootstrap Fresh Machine |

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-build/scripts/vss-bootstrap.sh
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-build/scripts/vss-bootstrap.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# vss-bootstrap.sh - Make the Video Search and Summarization (VSS) application
+# source available and resolve its app root, regardless of where a VSS skill is
+# invoked from.
+#
+# Behaviour
+#   * If the current working directory is already somewhere inside a VSS checkout
+#     (or the enclosing git repo contains one), that checkout is reused and NO
+#     clone is performed.
+#   * Otherwise the VSS application is fetched with a shallow, single-branch,
+#     sparse checkout of only
+#     `sample-applications/video-search-and-summarization` from `main`.
+#
+# Output
+#   The resolved absolute VSS app root is printed on stdout as the ONLY stdout
+#   line. All diagnostics go to stderr. Callers should do:
+#       APP_ROOT="$(bash vss-bootstrap.sh)" && cd "$APP_ROOT"
+#
+# Environment overrides
+#   VSS_REPO_URL     Git URL to clone (default: upstream open-edge-platform).
+#   VSS_REPO_BRANCH  Branch to fetch (default: main).
+#   VSS_CLONE_DIR    Where to place the checkout when cloning is required
+#                    (default: ${XDG_CACHE_HOME:-$HOME/.cache}/vss-src/edge-ai-libraries).
+#   VSS_FORCE_CLONE  If set to 1, skip local detection and always clone.
+#
+# Exit status
+#   0 on success (app root printed), non-zero on failure.
+
+set -euo pipefail
+
+REPO_URL="${VSS_REPO_URL:-https://github.com/open-edge-platform/edge-ai-libraries.git}"
+REPO_BRANCH="${VSS_REPO_BRANCH:-main}"
+CACHE_BASE="${XDG_CACHE_HOME:-$HOME/.cache}"
+CLONE_DIR="${VSS_CLONE_DIR:-$CACHE_BASE/vss-src/edge-ai-libraries}"
+VSS_SUBPATH="sample-applications/video-search-and-summarization"
+
+log() { printf '[vss-bootstrap] %s\n' "$*" >&2; }
+
+# A directory is a VSS app root when it carries the app's unmistakable markers.
+is_vss_root() {
+  local d="$1"
+  [ -n "$d" ] && [ -f "$d/setup.sh" ] \
+    && [ -d "$d/docker" ] && [ -d "$d/pipeline-manager" ]
+}
+
+# Walk up from a starting directory looking for a VSS app root.
+find_vss_root_upward() {
+  local dir="$1"
+  while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+    if is_vss_root "$dir"; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  is_vss_root "/" && { printf '/\n'; return 0; }
+  return 1
+}
+
+# Try to locate an existing VSS checkout without cloning.
+detect_local_vss_root() {
+  local found
+  # 1) Anywhere in the current directory's ancestry.
+  if found="$(find_vss_root_upward "$PWD")"; then
+    printf '%s\n' "$found"; return 0
+  fi
+  # 2) The enclosing git repository, if any, may hold VSS under its subpath.
+  local git_root
+  if git_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    if is_vss_root "$git_root/$VSS_SUBPATH"; then
+      printf '%s\n' "$git_root/$VSS_SUBPATH"; return 0
+    fi
+    if is_vss_root "$git_root"; then
+      printf '%s\n' "$git_root"; return 0
+    fi
+  fi
+  # 3) A previous bootstrap clone that is already on disk.
+  if is_vss_root "$CLONE_DIR/$VSS_SUBPATH"; then
+    printf '%s\n' "$CLONE_DIR/$VSS_SUBPATH"; return 0
+  fi
+  return 1
+}
+
+# Sparse, shallow, single-branch clone of just the VSS subtree.
+clone_vss() {
+  if is_vss_root "$CLONE_DIR/$VSS_SUBPATH"; then
+    log "Reusing existing bootstrap checkout at $CLONE_DIR"
+    printf '%s\n' "$CLONE_DIR/$VSS_SUBPATH"; return 0
+  fi
+
+  command -v git >/dev/null 2>&1 || { log "ERROR: git is required but not found."; return 1; }
+
+  log "VSS source not found locally; sparse-cloning $VSS_SUBPATH"
+  log "  repo=$REPO_URL branch=$REPO_BRANCH dest=$CLONE_DIR"
+  mkdir -p "$(dirname "$CLONE_DIR")"
+  rm -rf "$CLONE_DIR"
+
+  git clone --filter=blob:none --no-checkout --depth 1 \
+    --single-branch --branch "$REPO_BRANCH" "$REPO_URL" "$CLONE_DIR" >&2
+
+  git -C "$CLONE_DIR" sparse-checkout init --cone >&2
+  git -C "$CLONE_DIR" sparse-checkout set "$VSS_SUBPATH" >&2
+  git -C "$CLONE_DIR" checkout "$REPO_BRANCH" >&2
+
+  if ! is_vss_root "$CLONE_DIR/$VSS_SUBPATH"; then
+    log "ERROR: clone completed but $VSS_SUBPATH does not look like a VSS app root."
+    return 1
+  fi
+  log "Clone complete."
+  printf '%s\n' "$CLONE_DIR/$VSS_SUBPATH"
+}
+
+main() {
+  local root
+  if [ "${VSS_FORCE_CLONE:-0}" != "1" ] && root="$(detect_local_vss_root)"; then
+    log "Found existing VSS source at: $root (no clone needed)"
+    printf '%s\n' "$root"
+    return 0
+  fi
+  root="$(clone_vss)"
+  printf '%s\n' "$root"
+}
+
+main "$@"


### PR DESCRIPTION
### Description

Add the `vss-build` skill to the Video Search & Summarization component. This introduces a skill definition, example prompts, evals, a benchmark note, and a bootstrap script that locates or sparse-clones the VSS app for builds. Also cleans up deprecated catalog entries as part of the VSS skills consolidation.

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

Reviewed diffs and validated new shell scripts with `bash -n`. Confirmed commits are present on the feature branch and ran basic smoke checks.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0.
- [x] I have not included any company confidential information, trade secret, password or security token.
- [x] I have performed a self-review of my code.
