### PR TITLE
Added configurable gvawatermark support for RTSP and WebRTC frame destinations

### DIFF
--- a/microservices/dlstreamer-pipeline-server/README.md
+++ b/microservices/dlstreamer-pipeline-server/README.md
@@ -98,7 +98,7 @@ Open another terminal and send the following curl request
 >
 > - If `"overlay": true`, frames are streamed with `gvawatermark` applied.
 > - If `"overlay": false`, frames are streamed without `gvawatermark`, and `frame.overlay-properties` is ignored.
-> - If your pipeline already includes custom `gvawatermark` settings (for example, `displ-cfg=show-roi=...` or `displ-cfg=hide-roi=...`), set `"overlay": false` to avoid applying a second default watermark.
+> - If your pipeline in [config.json](configs/default/config.json) already includes custom `gvawatermark` settings (for example, `displ-cfg=show-roi=...` or `displ-cfg=hide-roi=...`), set `"overlay": false` to avoid applying a second default watermark.
 > - `frame.overlay-properties` accepts any `gvawatermark` options supported by DL Streamer.
 >
 > Example with overlay disabled:

--- a/microservices/dlstreamer-pipeline-server/README.md
+++ b/microservices/dlstreamer-pipeline-server/README.md
@@ -94,7 +94,14 @@ Open another terminal and send the following curl request
 }'
 ```
 
-> **Note:** When using a custom `gvawatermark` configuration (e.g., `displ-cfg=show-roi=...` or `displ-cfg=hide-roi=...`) in your pipeline, set `"overlay": false` in the frame destination to prevent the RTSP stream from adding a second `gvawatermark` with default settings that overrides your filtering configuration:
+> **Note:** Frame destinations support `overlay` and optional `gvawatermark` configuration for both RTSP and WebRTC outputs.
+>
+> - If `"overlay": true`, frames are streamed with `gvawatermark` applied.
+> - If `"overlay": false`, frames are streamed without `gvawatermark`, and any `frame.gvawatermark` values are ignored.
+> - If your main pipeline already contains `gvawatermark`, set `"overlay": false` to avoid applying it twice.
+> - `frame.gvawatermark` can include any `gvawatermark` option supported by DL Streamer. The examples below show only a few common properties.
+>
+> When using a custom `gvawatermark` configuration (e.g., `displ-cfg=show-roi=...` or `displ-cfg=hide-roi=...`) in your pipeline, set `"overlay": false` in the frame destination to prevent the RTSP stream from adding a second `gvawatermark` with default settings that overrides your filtering configuration:
 > ```json
 > "frame": {
 >     "type": "rtsp",
@@ -102,6 +109,21 @@ Open another terminal and send the following curl request
 >     "overlay": false
 > }
 > ```
+>
+> Example RTSP frame destination with `gvawatermark`:
+> ```json
+> "frame": {
+>     "type": "rtsp",
+>     "path": "pallet-defect-detection",
+>     "overlay": true,
+>     "gvawatermark": {
+>         "font-scale": 1.5,
+>         "draw-txt-bg": false,
+>         "thickness": 3
+>     }
+> }
+> ```
+
 
 The REST request will return a pipeline instance ID, which can be used as an identifier to query later the pipeline status or stop the pipeline instance. For example, a6d67224eacc11ec9f360242c0a86003.
 

--- a/microservices/dlstreamer-pipeline-server/README.md
+++ b/microservices/dlstreamer-pipeline-server/README.md
@@ -94,14 +94,14 @@ Open another terminal and send the following curl request
 }'
 ```
 
-> **Note:** Frame destinations support `overlay` and optional `gvawatermark` configuration for both RTSP and WebRTC outputs.
+> **Note:** Frame destinations support `overlay` and optional `overlay-properties`.
 >
 > - If `"overlay": true`, frames are streamed with `gvawatermark` applied.
-> - If `"overlay": false`, frames are streamed without `gvawatermark`, and any `frame.gvawatermark` values are ignored.
-> - If your main pipeline already contains `gvawatermark`, set `"overlay": false` to avoid applying it twice.
-> - `frame.gvawatermark` can include any `gvawatermark` option supported by DL Streamer. The examples below show only a few common properties.
+> - If `"overlay": false`, frames are streamed without `gvawatermark`, and `frame.overlay-properties` is ignored.
+> - If your pipeline already includes custom `gvawatermark` settings (for example, `displ-cfg=show-roi=...` or `displ-cfg=hide-roi=...`), set `"overlay": false` to avoid applying a second default watermark.
+> - `frame.overlay-properties` accepts any `gvawatermark` options supported by DL Streamer.
 >
-> When using a custom `gvawatermark` configuration (e.g., `displ-cfg=show-roi=...` or `displ-cfg=hide-roi=...`) in your pipeline, set `"overlay": false` in the frame destination to prevent the RTSP stream from adding a second `gvawatermark` with default settings that overrides your filtering configuration:
+> Example with overlay disabled:
 > ```json
 > "frame": {
 >     "type": "rtsp",
@@ -110,13 +110,13 @@ Open another terminal and send the following curl request
 > }
 > ```
 >
-> Example RTSP frame destination with `gvawatermark`:
+> Example RTSP frame destination with `overlay-properties`:
 > ```json
 > "frame": {
 >     "type": "rtsp",
 >     "path": "pallet-defect-detection",
 >     "overlay": true,
->     "gvawatermark": {
+>     "overlay-properties": {
 >         "font-scale": 1.5,
 >         "draw-txt-bg": false,
 >         "thickness": 3

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/how-to-guides/perform-webrtc-frame-streaming.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/how-to-guides/perform-webrtc-frame-streaming.md
@@ -56,6 +56,26 @@ After setting all the above information, we can start the WebRTC streaming:
 - Open `http://<HOST_IP>:8889/<peer-id>` in your browser to view the WebRTC stream:
     ![Stream output on browser using WebRTC](../_assets/sample_webrtc_mediamtx.png)
 
+> **Note:** You can control WebRTC frame overlays using `overlay` and `overlay-properties` in `destination.frame`.
+>
+> - If `"overlay": true`, `gvawatermark` is applied.
+> - If `"overlay": false`, `gvawatermark` is not applied and `overlay-properties` is ignored.
+> - If your pipeline in config.json already contains custom `gvawatermark` settings, use `"overlay": false` to avoid applying watermark twice.
+>
+> Example Webrtc frame destination with `overlay-properties`:
+> ```json
+> "frame": {
+>     "type": "webrtc",
+>     "peer-id": "pallet-defect-detection",
+>     "overlay": true,
+>     "overlay-properties": {
+>         "font-scale": 1.5,
+>         "draw-txt-bg": false,
+>         "thickness": 3
+>     }
+> }
+> ```
+
 > **Note:** If you are using 4K or high resolution video make sure to increase the bitrate to
 > avoid choppy video streaming. You can set the bitrate by adding `"bitrate" : 5000` with the
 > WebRTC configurations in your Curl command.

--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_destination.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_destination.py
@@ -44,14 +44,14 @@ class GStreamerRtspDestination(AppDestination):
         self._sync_with_destination = request.get("sync-with-destination", True)
         self._encode_quality = request.get("encode-quality", 85)
         self.overlay = request.get("overlay", True)
-        self._watermark_cfg = request.get("gvawatermark", {})
+        self.gvawatermark = request.get("gvawatermark", {})
 
     def _init_stream(self, sample):
         self._frame_size = sample.get_buffer().get_size()
         caps = sample.get_caps()
         self._pipeline.appsink_element.props.caps = caps
         self._need_data = False
-        self._rtsp_server.add_stream(self._identifier, self._rtsp_path, caps, self, self.overlay, self._watermark_cfg)
+        self._rtsp_server.add_stream(self._identifier, self._rtsp_path, caps, self, self.overlay, self.gvawatermark)
         self._last_timestamp = self._clock.get_time()
         if self._sync_with_source is not None:
             self._pipeline.appsink_element.set_property("sync", self._sync_with_source)

--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_destination.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_destination.py
@@ -44,13 +44,14 @@ class GStreamerRtspDestination(AppDestination):
         self._sync_with_destination = request.get("sync-with-destination", True)
         self._encode_quality = request.get("encode-quality", 85)
         self.overlay = request.get("overlay", True)
+        self._watermark_cfg = request.get("gvawatermark", {})
 
     def _init_stream(self, sample):
         self._frame_size = sample.get_buffer().get_size()
         caps = sample.get_caps()
         self._pipeline.appsink_element.props.caps = caps
         self._need_data = False
-        self._rtsp_server.add_stream(self._identifier, self._rtsp_path, caps, self,self.overlay)
+        self._rtsp_server.add_stream(self._identifier, self._rtsp_path, caps, self, self.overlay, self._watermark_cfg)
         self._last_timestamp = self._clock.get_time()
         if self._sync_with_source is not None:
             self._pipeline.appsink_element.set_property("sync", self._sync_with_source)

--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_destination.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_destination.py
@@ -44,14 +44,14 @@ class GStreamerRtspDestination(AppDestination):
         self._sync_with_destination = request.get("sync-with-destination", True)
         self._encode_quality = request.get("encode-quality", 85)
         self.overlay = request.get("overlay", True)
-        self.gvawatermark = request.get("gvawatermark", {})
+        self.overlay_properties = request.get("overlay-properties", request.get("gvawatermark", {}))
 
     def _init_stream(self, sample):
         self._frame_size = sample.get_buffer().get_size()
         caps = sample.get_caps()
         self._pipeline.appsink_element.props.caps = caps
         self._need_data = False
-        self._rtsp_server.add_stream(self._identifier, self._rtsp_path, caps, self, self.overlay, self.gvawatermark)
+        self._rtsp_server.add_stream(self._identifier, self._rtsp_path, caps, self, self.overlay, self.overlay_properties)
         self._last_timestamp = self._clock.get_time()
         if self._sync_with_source is not None:
             self._pipeline.appsink_element.set_property("sync", self._sync_with_source)

--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_factory.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_factory.py
@@ -8,7 +8,6 @@ import gi
 gi.require_version('GstRtspServer', '1.0')
 gi.require_version('Gst', '1.0')
 # pylint: disable=wrong-import-position
-import json
 from gi.repository import Gst, GstRtspServer
 from src.server.common.utils import logging
 # pylint: enable=wrong-import-position
@@ -19,11 +18,11 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
     _RtspVideoPipeline_withjpeginput = " ! rtpjpegpay name=pay0"  # removed gvawatermark to avoid duplicate overlay assuming DLStreamer pipeline server pipeline already has gvawatermark
         # ! gvawatermark ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0"
 
-    _RtspVideoPipeline_withjpeginput_overlay = " ! jpegdec ! videoconvert  \
-        ! gvawatermark ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0" 
+    _RtspVideoPipeline_withjpeginput_overlay = " ! jpegdec ! videoconvert {gvawatermark} \
+        ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0"
 
-    _RtspVideoPipeline = " ! videoconvert  \
-        ! gvawatermark ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0"
+    _RtspVideoPipeline = " ! videoconvert {gvawatermark} \
+        ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0"
     
     # GPU pipeline variants for hardware-accelerated buffers
     # _RtspVideoPipeline_GPU_VASurface = " ! vaapipostproc ! vaapijpegenc ! rtpjpegpay name=pay0"
@@ -45,22 +44,6 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
         if "jpegdec" in pipeline:
             pipeline = pipeline.replace("jpegdec", "vajpegdec")
         return pipeline        
-
-    def _build_watermark_element(self, watermark_cfg):
-        if not watermark_cfg:
-            return "gvawatermark"
-
-        watermark_properties = ",".join(
-            "{}={}".format(
-                key,
-                str(value).lower() if isinstance(value, bool) else str(value),
-            )
-            for key, value in watermark_cfg.items()
-            if value is not None
-        )
-        if not watermark_properties:
-            return "gvawatermark"
-        return 'gvawatermark displ-cfg="{}"'.format(watermark_properties)
 
     def __init__(self, rtsp_server):
         GstRtspServer.RTSPMediaFactory.__init__(self)
@@ -106,6 +89,18 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
             # System memory (CPU)
             return False, "System"
 
+    def _build_gvawatermark_stage(self, overlay, gvawatermark):
+        if overlay is False:
+            return ""
+        if not isinstance(gvawatermark, dict) or not gvawatermark:
+            return " ! gvawatermark"
+        properties = [
+            "{}={}".format(key, str(value).lower() if isinstance(value, bool) else value)
+            for key, value in gvawatermark.items()
+            if value is not None
+        ]
+        return " ! gvawatermark" if not properties else " ! gvawatermark displ-cfg={}".format(",".join(properties))
+
     def do_create_element(self, url):
         # pylint: disable=arguments-differ
         # pylint disable added as pylint comparing do_create_element with some other method with same name.
@@ -119,38 +114,22 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
         source = stream.source
         caps = stream.caps
         overlay = stream.overlay
-        watermark_cfg = getattr(stream, "watermark_cfg", {})
-        if not isinstance(watermark_cfg, dict):
-            watermark_cfg = {}
+        gvawatermark = stream.gvawatermark
+        watermark_stage = self._build_gvawatermark_stage(overlay, gvawatermark)
         new_caps = self._select_caps(caps.to_string())
         s_src = "{} caps=\"{}\"".format(GStreamerRtspFactory._source, ','.join(new_caps))
         
         # Determine if we're dealing with GPU or CPU buffers
         is_gpu, buffer_type = self._is_gpu_buffer(caps)
-        watermark_element = self._build_watermark_element(watermark_cfg)
         
         if "image/jpeg" in new_caps:
             if overlay:
                 media_pipeline = GStreamerRtspFactory._RtspVideoPipeline_withjpeginput_overlay
-                if watermark_cfg:
-                    media_pipeline = media_pipeline.replace("! gvawatermark !",
-                                                            "! gvawatermark ! {} !".format(watermark_element))
-            elif watermark_cfg:
-                media_pipeline = GStreamerRtspFactory._RtspVideoPipeline_withjpeginput_overlay
-                media_pipeline = media_pipeline.replace("! gvawatermark !",
-                                                        "! {} !".format(watermark_element))
             else:
                 media_pipeline = GStreamerRtspFactory._RtspVideoPipeline_withjpeginput
         else:
             media_pipeline = GStreamerRtspFactory._RtspVideoPipeline
-            if overlay is False and not watermark_cfg:
-                media_pipeline = media_pipeline.replace("gvawatermark ! ", "")
-            if overlay and watermark_cfg:
-                media_pipeline = media_pipeline.replace("! gvawatermark !",
-                                                        "! gvawatermark ! {} !".format(watermark_element))
-            elif watermark_cfg:
-                media_pipeline = media_pipeline.replace("! gvawatermark !",
-                                                        "! {} !".format(watermark_element))
+        media_pipeline = media_pipeline.format(gvawatermark=watermark_stage)
 
         if is_gpu and buffer_type == "VAMemory":
             self._logger.debug("Using GPU pipeline for caps: {} (type: {})".format(caps.to_string(), buffer_type))

--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_factory.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_factory.py
@@ -8,6 +8,7 @@ import gi
 gi.require_version('GstRtspServer', '1.0')
 gi.require_version('Gst', '1.0')
 # pylint: disable=wrong-import-position
+import json
 from gi.repository import Gst, GstRtspServer
 from src.server.common.utils import logging
 # pylint: enable=wrong-import-position
@@ -44,6 +45,22 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
         if "jpegdec" in pipeline:
             pipeline = pipeline.replace("jpegdec", "vajpegdec")
         return pipeline        
+
+    def _build_watermark_element(self, watermark_cfg):
+        if not watermark_cfg:
+            return "gvawatermark"
+
+        watermark_properties = ",".join(
+            "{}={}".format(
+                key,
+                str(value).lower() if isinstance(value, bool) else str(value),
+            )
+            for key, value in watermark_cfg.items()
+            if value is not None
+        )
+        if not watermark_properties:
+            return "gvawatermark"
+        return 'gvawatermark displ-cfg="{}"'.format(watermark_properties)
 
     def __init__(self, rtsp_server):
         GstRtspServer.RTSPMediaFactory.__init__(self)
@@ -102,21 +119,38 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
         source = stream.source
         caps = stream.caps
         overlay = stream.overlay
+        watermark_cfg = getattr(stream, "watermark_cfg", {})
+        if not isinstance(watermark_cfg, dict):
+            watermark_cfg = {}
         new_caps = self._select_caps(caps.to_string())
         s_src = "{} caps=\"{}\"".format(GStreamerRtspFactory._source, ','.join(new_caps))
         
         # Determine if we're dealing with GPU or CPU buffers
         is_gpu, buffer_type = self._is_gpu_buffer(caps)
+        watermark_element = self._build_watermark_element(watermark_cfg)
         
         if "image/jpeg" in new_caps:
             if overlay:
                 media_pipeline = GStreamerRtspFactory._RtspVideoPipeline_withjpeginput_overlay
+                if watermark_cfg:
+                    media_pipeline = media_pipeline.replace("! gvawatermark !",
+                                                            "! gvawatermark ! {} !".format(watermark_element))
+            elif watermark_cfg:
+                media_pipeline = GStreamerRtspFactory._RtspVideoPipeline_withjpeginput_overlay
+                media_pipeline = media_pipeline.replace("! gvawatermark !",
+                                                        "! {} !".format(watermark_element))
             else:
                 media_pipeline = GStreamerRtspFactory._RtspVideoPipeline_withjpeginput
         else:
             media_pipeline = GStreamerRtspFactory._RtspVideoPipeline
-            if overlay is False:
+            if overlay is False and not watermark_cfg:
                 media_pipeline = media_pipeline.replace("gvawatermark ! ", "")
+            if overlay and watermark_cfg:
+                media_pipeline = media_pipeline.replace("! gvawatermark !",
+                                                        "! gvawatermark ! {} !".format(watermark_element))
+            elif watermark_cfg:
+                media_pipeline = media_pipeline.replace("! gvawatermark !",
+                                                        "! {} !".format(watermark_element))
 
         if is_gpu and buffer_type == "VAMemory":
             self._logger.debug("Using GPU pipeline for caps: {} (type: {})".format(caps.to_string(), buffer_type))

--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_factory.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_factory.py
@@ -89,14 +89,14 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
             # System memory (CPU)
             return False, "System"
 
-    def _build_gvawatermark_stage(self, overlay, gvawatermark):
+    def _build_gvawatermark_stage(self, overlay, overlay_properties):
         if overlay is False:
             return ""
-        if not isinstance(gvawatermark, dict) or not gvawatermark:
+        if not isinstance(overlay_properties, dict) or not overlay_properties:
             return " ! gvawatermark"
         properties = [
             "{}={}".format(key, str(value).lower() if isinstance(value, bool) else value)
-            for key, value in gvawatermark.items()
+            for key, value in overlay_properties.items()
             if value is not None
         ]
         return " ! gvawatermark" if not properties else " ! gvawatermark displ-cfg={}".format(",".join(properties))
@@ -114,8 +114,8 @@ class GStreamerRtspFactory(GstRtspServer.RTSPMediaFactory):
         source = stream.source
         caps = stream.caps
         overlay = stream.overlay
-        gvawatermark = stream.gvawatermark
-        watermark_stage = self._build_gvawatermark_stage(overlay, gvawatermark)
+        overlay_properties = stream.overlay_properties
+        watermark_stage = self._build_gvawatermark_stage(overlay, overlay_properties)
         new_caps = self._select_caps(caps.to_string())
         s_src = "{} caps=\"{}\"".format(GStreamerRtspFactory._source, ','.join(new_caps))
         

--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_server.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_server.py
@@ -16,7 +16,7 @@ from src.server.common.utils import logging
 from src.server.rtsp.gstreamer_rtsp_factory import GStreamerRtspFactory
 # pylint: enable=wrong-import-position
 
-Stream = namedtuple('stream', ['source', 'caps', 'overlay', 'gvawatermark'])
+Stream = namedtuple('stream', ['source', 'caps', 'overlay', 'overlay_properties'])
 Stream.__new__.__defaults__ = (None, None, True, None)
 
 class GStreamerRtspServer():
@@ -40,8 +40,8 @@ class GStreamerRtspServer():
             self._logger.error("RTSP Stream at {} already exists, use different path".format(rtsp_path))
             raise Exception("RTSP Stream at {} already exists, use different path".format(rtsp_path))
 
-    def add_stream(self, identifier, rtsp_path, caps, source, overlay, gvawatermark=None):
-        self._streams[rtsp_path] = Stream(source, caps, overlay, gvawatermark)
+    def add_stream(self, identifier, rtsp_path, caps, source, overlay, overlay_properties=None):
+        self._streams[rtsp_path] = Stream(source, caps, overlay, overlay_properties)
         self._mount_points.add_factory(rtsp_path, self._factory)
         url = "rtsp:://<host ip>:{}{}".format(self._port, rtsp_path)
         self._logger.info("Created RTSP Stream for instance {} at {}".format(identifier, url))

--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_server.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_server.py
@@ -16,8 +16,8 @@ from src.server.common.utils import logging
 from src.server.rtsp.gstreamer_rtsp_factory import GStreamerRtspFactory
 # pylint: enable=wrong-import-position
 
-Stream = namedtuple('stream', ['source', 'caps', 'overlay', 'watermark_cfg'])
-Stream.__new__.__defaults__ = (None, None, True)
+Stream = namedtuple('stream', ['source', 'caps', 'overlay', 'gvawatermark'])
+Stream.__new__.__defaults__ = (None, None, True, None)
 
 class GStreamerRtspServer():
     def __init__(self, port):
@@ -40,8 +40,8 @@ class GStreamerRtspServer():
             self._logger.error("RTSP Stream at {} already exists, use different path".format(rtsp_path))
             raise Exception("RTSP Stream at {} already exists, use different path".format(rtsp_path))
 
-    def add_stream(self, identifier, rtsp_path, caps, source, overlay, watermark_cfg=None):
-        self._streams[rtsp_path] = Stream(source, caps, overlay, watermark_cfg or {})
+    def add_stream(self, identifier, rtsp_path, caps, source, overlay, gvawatermark=None):
+        self._streams[rtsp_path] = Stream(source, caps, overlay, gvawatermark)
         self._mount_points.add_factory(rtsp_path, self._factory)
         url = "rtsp:://<host ip>:{}{}".format(self._port, rtsp_path)
         self._logger.info("Created RTSP Stream for instance {} at {}".format(identifier, url))

--- a/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_server.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/rtsp/gstreamer_rtsp_server.py
@@ -16,7 +16,7 @@ from src.server.common.utils import logging
 from src.server.rtsp.gstreamer_rtsp_factory import GStreamerRtspFactory
 # pylint: enable=wrong-import-position
 
-Stream = namedtuple('stream', ['source', 'caps','overlay'])
+Stream = namedtuple('stream', ['source', 'caps', 'overlay', 'watermark_cfg'])
 Stream.__new__.__defaults__ = (None, None, True)
 
 class GStreamerRtspServer():
@@ -40,8 +40,8 @@ class GStreamerRtspServer():
             self._logger.error("RTSP Stream at {} already exists, use different path".format(rtsp_path))
             raise Exception("RTSP Stream at {} already exists, use different path".format(rtsp_path))
 
-    def add_stream(self, identifier, rtsp_path, caps, source, overlay):
-        self._streams[rtsp_path] = Stream(source, caps, overlay)
+    def add_stream(self, identifier, rtsp_path, caps, source, overlay, watermark_cfg=None):
+        self._streams[rtsp_path] = Stream(source, caps, overlay, watermark_cfg or {})
         self._mount_points.add_factory(rtsp_path, self._factory)
         url = "rtsp:://<host ip>:{}{}".format(self._port, rtsp_path)
         self._logger.info("Created RTSP Stream for instance {} at {}".format(identifier, url))

--- a/microservices/dlstreamer-pipeline-server/src/server/schema.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/schema.py
@@ -301,7 +301,7 @@ destination = {
                 "type": "boolean",
                 "default": True
               },
-              "gvawatermark": {
+              "overlay-properties": {
                 "type": "object",
                 "default": {}
               }
@@ -339,7 +339,7 @@ destination = {
                 "type": "boolean",
                 "default": True
               },
-              "gvawatermark": {
+              "overlay-properties": {
                 "type": "object",
                 "default": {}
               }
@@ -390,7 +390,7 @@ destination = {
                   "type": "boolean",
                   "default": True
                 },
-                "gvawatermark": {
+                "overlay-properties": {
                   "type": "object",
                   "default": {}
                 }
@@ -427,7 +427,7 @@ destination = {
                 "overlay": {
                   "type": "boolean"
                 },
-                "gvawatermark": {
+                "overlay-properties": {
                   "type": "object",
                   "default": {}
                 }

--- a/microservices/dlstreamer-pipeline-server/src/server/schema.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/schema.py
@@ -300,6 +300,10 @@ destination = {
               "overlay": {
                 "type": "boolean",
                 "default": True
+              },
+              "gvawatermark": {
+                "type": "object",
+                "default": {}
               }
             },
             "required": [
@@ -334,6 +338,10 @@ destination = {
               "overlay": {
                 "type": "boolean",
                 "default": True
+              },
+              "gvawatermark": {
+                "type": "object",
+                "default": {}
               }
             },
             "required": [
@@ -381,6 +389,10 @@ destination = {
                 "overlay": {
                   "type": "boolean",
                   "default": True
+                },
+                "gvawatermark": {
+                  "type": "object",
+                  "default": {}
                 }
               },
               "required": [
@@ -414,6 +426,10 @@ destination = {
                 },
                 "overlay": {
                   "type": "boolean"
+                },
+                "gvawatermark": {
+                  "type": "object",
+                  "default": {}
                 }
               },
               "required": [

--- a/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_destination.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_destination.py
@@ -41,6 +41,7 @@ class GStreamerWebRTCDestination(AppDestination):
         self._sync_with_destination = request.get("sync-with-destination", True)
         self.overlay = request.get("overlay",True)
         self.bitrate = request.get("bitrate", 2048)
+        self._watermark_cfg = request.get("gvawatermark", {})
 
     def _init_stream(self, sample):
         self._frame_size = sample.get_buffer().get_size()
@@ -53,7 +54,7 @@ class GStreamerWebRTCDestination(AppDestination):
             self._logger.info("Setting the appsink sync property to {}".format(self._sync_with_source))
         self._logger.info("Adding WebRTC frame destination stream for peer_id {}.".format(self._webrtc_peerid))
         self._logger.debug("WebRTC Stream frame caps == {}".format(caps))
-        self._webrtc_manager.add_stream(self._webrtc_peerid, caps, self,self.overlay)
+        self._webrtc_manager.add_stream(self._webrtc_peerid, caps, self, self.overlay, self._watermark_cfg)
 
     def _on_need_data(self, _unused_src, _):
         self._need_data = True

--- a/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_destination.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_destination.py
@@ -40,8 +40,8 @@ class GStreamerWebRTCDestination(AppDestination):
         self._sync_with_source = request.get("sync-with-source")
         self._sync_with_destination = request.get("sync-with-destination", True)
         self.overlay = request.get("overlay",True)
+        self.gvawatermark = request.get("gvawatermark", {})
         self.bitrate = request.get("bitrate", 2048)
-        self._watermark_cfg = request.get("gvawatermark", {})
 
     def _init_stream(self, sample):
         self._frame_size = sample.get_buffer().get_size()
@@ -54,7 +54,7 @@ class GStreamerWebRTCDestination(AppDestination):
             self._logger.info("Setting the appsink sync property to {}".format(self._sync_with_source))
         self._logger.info("Adding WebRTC frame destination stream for peer_id {}.".format(self._webrtc_peerid))
         self._logger.debug("WebRTC Stream frame caps == {}".format(caps))
-        self._webrtc_manager.add_stream(self._webrtc_peerid, caps, self, self.overlay, self._watermark_cfg)
+        self._webrtc_manager.add_stream(self._webrtc_peerid, caps, self, self.overlay, self.gvawatermark)
 
     def _on_need_data(self, _unused_src, _):
         self._need_data = True

--- a/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_destination.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_destination.py
@@ -40,7 +40,7 @@ class GStreamerWebRTCDestination(AppDestination):
         self._sync_with_source = request.get("sync-with-source")
         self._sync_with_destination = request.get("sync-with-destination", True)
         self.overlay = request.get("overlay",True)
-        self.gvawatermark = request.get("gvawatermark", {})
+        self.overlay_properties = request.get("overlay-properties", request.get("gvawatermark", {}))
         self.bitrate = request.get("bitrate", 2048)
 
     def _init_stream(self, sample):
@@ -54,7 +54,7 @@ class GStreamerWebRTCDestination(AppDestination):
             self._logger.info("Setting the appsink sync property to {}".format(self._sync_with_source))
         self._logger.info("Adding WebRTC frame destination stream for peer_id {}.".format(self._webrtc_peerid))
         self._logger.debug("WebRTC Stream frame caps == {}".format(caps))
-        self._webrtc_manager.add_stream(self._webrtc_peerid, caps, self, self.overlay, self.gvawatermark)
+        self._webrtc_manager.add_stream(self._webrtc_peerid, caps, self, self.overlay, self.overlay_properties)
 
     def _on_need_data(self, _unused_src, _):
         self._need_data = True

--- a/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_manager.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_manager.py
@@ -6,6 +6,7 @@
 import gi
 
 gi.require_version("Gst", "1.0")
+import json
 from gi.repository import Gst
 
 from src.server.webrtc.gstreamer_webrtc_stream import GStreamerWebRTCStream
@@ -55,10 +56,11 @@ class GStreamerWebRTCManager:
             return True
         return False
 
-    def add_stream(self, peer_id, frame_caps, destination_instance, overlay):
+    def add_stream(self, peer_id, frame_caps, destination_instance, overlay, watermark_cfg=None):
         stream_caps = self._select_caps(frame_caps.to_string())
         if not self._peerid_in_use(peer_id):
-            launch_string = self._get_launch_string(stream_caps, peer_id, overlay)
+            watermark_cfg = watermark_cfg or {}
+            launch_string = self._get_launch_string(stream_caps, peer_id, overlay, watermark_cfg)
             self._streams[peer_id] = GStreamerWebRTCStream(
                 peer_id,
                 stream_caps,
@@ -101,11 +103,29 @@ class GStreamerWebRTCManager:
             return True, "VAMemory"
         return False, None
 
-    def _get_launch_string(self, stream_caps, peer_id, overlay):
+    def _build_watermark_element(self, watermark_cfg):
+        if not watermark_cfg:
+            return "gvawatermark"
+
+        watermark_properties = ",".join(
+            "{}={}".format(
+                key,
+                str(value).lower() if isinstance(value, bool) else str(value),
+            )
+            for key, value in watermark_cfg.items()
+            if value is not None
+        )
+        if not watermark_properties:
+            return "gvawatermark"
+        return 'gvawatermark displ-cfg="{}"'.format(watermark_properties)
+
+    def _get_launch_string(self, stream_caps, peer_id, overlay, watermark_cfg=None):
         # pylint: disable=consider-using-f-string, too-many-branches
         s_src = '{} caps="{}"'.format(self._source_mediamtx, ",".join(stream_caps))
 
         is_gpu, buffer_type = self._is_gpu_buffer(stream_caps)
+        watermark_cfg = watermark_cfg or {}
+        watermark_element = self._build_watermark_element(watermark_cfg)
 
         # Look for vah264enc element. Reported in some Xeon platforms as missing.
         # When incoming buffers are from GPU and vah264enc is not present, we look for
@@ -159,10 +179,14 @@ class GStreamerWebRTCManager:
             # CPU buffers with raw video input
             else:
                 video_pipeline = self._WebRTCVideoPipeline
-        if overlay is False:
+        if overlay is False and not watermark_cfg:
             video_pipeline = video_pipeline.replace("! gvawatermark ", "")
-        elif overlay is True:
-            video_pipeline = video_pipeline
+        if watermark_cfg:
+            video_pipeline = video_pipeline.replace(
+                "! gvawatermark ",
+                "! gvawatermark ! {} ".format(watermark_element),
+                1,
+            )
         pipeline_launch = " {} {} ".format(s_src, video_pipeline)
         pipeline_launch = (
             pipeline_launch + self._whip_endpoint + "/" + peer_id + "/whip"

--- a/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_manager.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_manager.py
@@ -55,10 +55,10 @@ class GStreamerWebRTCManager:
             return True
         return False
 
-    def add_stream(self, peer_id, frame_caps, destination_instance, overlay, gvawatermark=None):
+    def add_stream(self, peer_id, frame_caps, destination_instance, overlay, overlay_properties=None):
         stream_caps = self._select_caps(frame_caps.to_string())
         if not self._peerid_in_use(peer_id):
-            launch_string = self._get_launch_string(stream_caps, peer_id, overlay, gvawatermark)
+            launch_string = self._get_launch_string(stream_caps, peer_id, overlay, overlay_properties)
             self._streams[peer_id] = GStreamerWebRTCStream(
                 peer_id,
                 stream_caps,
@@ -101,22 +101,22 @@ class GStreamerWebRTCManager:
             return True, "VAMemory"
         return False, None
 
-    def _build_gvawatermark_stage(self, overlay, gvawatermark):
+    def _build_gvawatermark_stage(self, overlay, overlay_properties):
         if overlay is False:
             return ""
-        if not isinstance(gvawatermark, dict) or not gvawatermark:
+        if not isinstance(overlay_properties, dict) or not overlay_properties:
             return "! gvawatermark"
         properties = [
             "{}={}".format(key, str(value).lower() if isinstance(value, bool) else value)
-            for key, value in gvawatermark.items()
+            for key, value in overlay_properties.items()
             if value is not None
         ]
         return "! gvawatermark" if not properties else "! gvawatermark displ-cfg={}".format(",".join(properties))
 
-    def _get_launch_string(self, stream_caps, peer_id, overlay, gvawatermark=None):
+    def _get_launch_string(self, stream_caps, peer_id, overlay, overlay_properties=None):
         # pylint: disable=consider-using-f-string, too-many-branches
         s_src = '{} caps="{}"'.format(self._source_mediamtx, ",".join(stream_caps))
-        watermark_stage = self._build_gvawatermark_stage(overlay, gvawatermark)
+        watermark_stage = self._build_gvawatermark_stage(overlay, overlay_properties)
 
         is_gpu, buffer_type = self._is_gpu_buffer(stream_caps)
 

--- a/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_manager.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_manager.py
@@ -6,7 +6,6 @@
 import gi
 
 gi.require_version("Gst", "1.0")
-import json
 from gi.repository import Gst
 
 from src.server.webrtc.gstreamer_webrtc_stream import GStreamerWebRTCStream
@@ -17,13 +16,13 @@ class GStreamerWebRTCManager:
 
     _source_mediamtx = "appsrc name=webrtc_source format=GST_FORMAT_TIME "
     _WebRTCVideoPipeline = (
-        " ! videoconvert ! gvawatermark "
+        " ! videoconvert {gvawatermark} "
         " ! openh264enc complexity=low name=h264enc"
         " ! video/x-h264,profile=baseline "
         " ! whipclientsink signaller::whip-endpoint="
     )
     _WebRTCVideoPipeline_jpeg = (
-        " ! jpegdec ! videoconvert ! gvawatermark "
+        " ! jpegdec ! videoconvert {gvawatermark} "
         " ! openh264enc complexity=low name=h264enc "
         " ! video/x-h264,profile=baseline "
         " ! whipclientsink signaller::whip-endpoint="
@@ -31,14 +30,14 @@ class GStreamerWebRTCManager:
 
     # GPU pipeline variants for hardware-accelerated buffers
     _WebRTCVideoPipeline_VAMemory = (
-        " ! videoconvert ! gvawatermark "
+        " ! videoconvert {gvawatermark} "
         " ! vah264enc name=h264enc "
         " ! h264parse  "
         " ! whipclientsink signaller::whip-endpoint="
     )
 
     _WebRTCVideoPipeline_jpeg_VAMemory = (
-        " ! vajpegdec ! videoconvert ! gvawatermark "
+        " ! vajpegdec ! videoconvert {gvawatermark} "
         " ! vah264enc name=h264enc "
         " ! h264parse  "
         " ! whipclientsink signaller::whip-endpoint="
@@ -56,11 +55,10 @@ class GStreamerWebRTCManager:
             return True
         return False
 
-    def add_stream(self, peer_id, frame_caps, destination_instance, overlay, watermark_cfg=None):
+    def add_stream(self, peer_id, frame_caps, destination_instance, overlay, gvawatermark=None):
         stream_caps = self._select_caps(frame_caps.to_string())
         if not self._peerid_in_use(peer_id):
-            watermark_cfg = watermark_cfg or {}
-            launch_string = self._get_launch_string(stream_caps, peer_id, overlay, watermark_cfg)
+            launch_string = self._get_launch_string(stream_caps, peer_id, overlay, gvawatermark)
             self._streams[peer_id] = GStreamerWebRTCStream(
                 peer_id,
                 stream_caps,
@@ -103,29 +101,24 @@ class GStreamerWebRTCManager:
             return True, "VAMemory"
         return False, None
 
-    def _build_watermark_element(self, watermark_cfg):
-        if not watermark_cfg:
-            return "gvawatermark"
-
-        watermark_properties = ",".join(
-            "{}={}".format(
-                key,
-                str(value).lower() if isinstance(value, bool) else str(value),
-            )
-            for key, value in watermark_cfg.items()
+    def _build_gvawatermark_stage(self, overlay, gvawatermark):
+        if overlay is False:
+            return ""
+        if not isinstance(gvawatermark, dict) or not gvawatermark:
+            return "! gvawatermark"
+        properties = [
+            "{}={}".format(key, str(value).lower() if isinstance(value, bool) else value)
+            for key, value in gvawatermark.items()
             if value is not None
-        )
-        if not watermark_properties:
-            return "gvawatermark"
-        return 'gvawatermark displ-cfg="{}"'.format(watermark_properties)
+        ]
+        return "! gvawatermark" if not properties else "! gvawatermark displ-cfg={}".format(",".join(properties))
 
-    def _get_launch_string(self, stream_caps, peer_id, overlay, watermark_cfg=None):
+    def _get_launch_string(self, stream_caps, peer_id, overlay, gvawatermark=None):
         # pylint: disable=consider-using-f-string, too-many-branches
         s_src = '{} caps="{}"'.format(self._source_mediamtx, ",".join(stream_caps))
+        watermark_stage = self._build_gvawatermark_stage(overlay, gvawatermark)
 
         is_gpu, buffer_type = self._is_gpu_buffer(stream_caps)
-        watermark_cfg = watermark_cfg or {}
-        watermark_element = self._build_watermark_element(watermark_cfg)
 
         # Look for vah264enc element. Reported in some Xeon platforms as missing.
         # When incoming buffers are from GPU and vah264enc is not present, we look for
@@ -179,14 +172,7 @@ class GStreamerWebRTCManager:
             # CPU buffers with raw video input
             else:
                 video_pipeline = self._WebRTCVideoPipeline
-        if overlay is False and not watermark_cfg:
-            video_pipeline = video_pipeline.replace("! gvawatermark ", "")
-        if watermark_cfg:
-            video_pipeline = video_pipeline.replace(
-                "! gvawatermark ",
-                "! gvawatermark ! {} ".format(watermark_element),
-                1,
-            )
+        video_pipeline = video_pipeline.format(gvawatermark=watermark_stage)
         pipeline_launch = " {} {} ".format(s_src, video_pipeline)
         pipeline_launch = (
             pipeline_launch + self._whip_endpoint + "/" + peer_id + "/whip"


### PR DESCRIPTION
### Description

Added support for passing gvawatermark configuration through RTSP and WebRTC frame destinations in DL Streamer Pipeline Server.
Tested the following destinations:
1.         "frame": {
                "type": "webrtc",
                "peer-id": "pallet-defect-detection",
		 "overlay": false
            }-no detections 
2. 	   "frame": {
                "type": "webrtc",
                "peer-id": "pallet-defect-detection",
		 "overlay": true
            }-detections 
3.         "frame": {
                "type": "webrtc",
                "peer-id": "pallet-defect-detection3",
		"overlay": true,
		"overlay-properties": {}
            } -detections 
4.         "frame": {
                "type": "webrtc",
                "peer-id": "pallet-defect-detection",
		"overlay": true,
		"overlay-properties": {
			"font-scale": 1,
                	"draw-txt-bg": false,
                	"thickness": 3,
                	"font-type": "plain"
	    	}
            } -detections with overlay properties
5.         "frame": {
                "type": "webrtc",
                "peer-id": "pallet-defect-detection2",
		"overlay": false,
		"overlay-properties": {
			"font-scale": 1.5,
                	"draw-txt-bg": true,
                	"thickness": 3,
                	"font-type": "plain"
	    	}
            } - no detections

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

