### PR TITLE
[ViPPET] Fix SIGINT handling during GPU/NPU pipeline initialization

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/gst_runner.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/gst_runner.py
@@ -50,7 +50,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 import gi  # pyright: ignore[reportMissingImports]
 
@@ -397,7 +397,12 @@ def parse_pipeline(pipeline_description: str) -> Tuple[Optional[Gst.Pipeline], b
 
 @dataclass
 class _RunState:
-    """Internal state tracked during a single pipeline run."""
+    """Internal state tracked during a single pipeline run.
+
+    Thread-safety note: field reads/writes rely on the GIL for atomicity.
+    If migrating to free-threaded Python (PEP 703 / --disable-gil),
+    protect these fields with a lock or use threading.Event.
+    """
 
     error_seen: bool = False
     eos_seen: bool = False
@@ -464,9 +469,9 @@ class _PipelineRunner:
             err, debug = message.parse_error()
             debug = debug.replace("\r", " ").replace("\n", " ")
 
-            # Ignore errors that occur during graceful shutdown after max-runtime.
-            # Elements like rtspclientsink may report errors when the pipeline
-            # is being stopped, which is expected behavior.
+            # Ignore errors that occur during graceful shutdown (max-runtime,
+            # SIGINT, etc.).  Elements like rtspclientsink may report errors
+            # when the pipeline is being stopped, which is expected behavior.
             if self._state.shutdown_in_progress:
                 self._logger.debug(
                     "Ignoring error during shutdown: %s (debug: %s)",
@@ -497,8 +502,9 @@ class _PipelineRunner:
 
         This method is safe to call from any context (thread, signal handler,
         GLib callback). It sets the shutdown flags and quits the main loop.
-        The actual pipeline teardown (set_state(NULL)) is handled by the
-        ``run()`` method's ``finally`` block.
+        The actual pipeline teardown (set_state(NULL)) is handled by
+        ``_cleanup()``, called from ``run()``'s ``finally`` block or from
+        the early-exit path.
 
         If shutdown has already been initiated (by max-runtime, SIGINT, or
         a previous call), this method is a no-op.
@@ -528,7 +534,7 @@ class _PipelineRunner:
         After `max_run_time_sec` seconds, this thread initiates a graceful
         shutdown by calling _initiate_shutdown(), which quits the GLib main
         loop. The actual pipeline teardown (set_state(NULL)) is handled by
-        the ``run()`` method's ``finally`` block.
+        ``_cleanup()``, called from ``run()``'s ``finally`` block.
 
         The shutdown approach mimics what gst-launch-1.0 does when it
         receives SIGINT (Ctrl+C): transition directly to NULL without
@@ -559,6 +565,55 @@ class _PipelineRunner:
         self._initiate_shutdown("sigint", loop)
         return GLib.SOURCE_REMOVE
 
+    def _cleanup(
+        self,
+        bus: Gst.Bus,
+        handler_id: int,
+        original_sigint_handler: Any,
+    ) -> None:
+        """Restore the SIGINT handler, disconnect the bus, and set pipeline to NULL.
+
+        This is shared between the early-exit path (SIGINT during state
+        transition) and the normal finally block after the main loop.
+
+        Args:
+            bus: The pipeline's bus, previously obtained via get_bus().
+            handler_id: The connection id returned by bus.connect("message", ...).
+            original_sigint_handler: The SIGINT handler in effect before
+                run() installed its own, as returned by signal.getsignal().
+                Restored here so callers of run() get their handler back.
+        """
+        signal.signal(signal.SIGINT, original_sigint_handler)
+        try:
+            bus.disconnect(handler_id)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.debug("Error disconnecting bus signal handler: %r", exc)
+        bus.remove_signal_watch()
+        try:
+            self._pipeline.set_state(Gst.State.NULL)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.warning("Error while stopping pipeline: %r", exc)
+
+    def _finalize(self, bus: Gst.Bus) -> Tuple[bool, Optional[str]]:
+        """Drain any remaining bus messages and derive the final (ok, reason).
+
+        Must be called after ``_cleanup()`` so that any ERROR message
+        posted while transitioning the pipeline to NULL (e.g. during the
+        early-exit SIGINT path) is still observed instead of being left
+        undrained on the bus.
+        """
+        if drain_bus_messages(bus, self._logger):
+            if not self._state.error_seen:
+                self._state.error_seen = True
+                self._state.reason = self._state.reason or "error"
+
+        if self._state.error_seen:
+            return False, "error"
+        if self._state.max_runtime_triggered and not self._state.error_seen:
+            return True, "max_runtime"
+        # EOS, SIGINT, or normal stop without errors.
+        return True, None
+
     def run(self) -> Tuple[bool, Optional[str]]:
         """Run the pipeline and return (ok, reason).
 
@@ -566,26 +621,37 @@ class _PipelineRunner:
 
         1. Obtain the pipeline's bus and create a GLib.MainLoop.
         2. Attach a bus watch and connect _on_bus_message for ERROR/EOS.
-        3. Request PLAYING state on the pipeline.
-        4. Call get_state() with a configured wait time (for diagnostics only)
-           to log the initial state-change outcome.
-        5. If max-runtime > 0, start a background thread that will trigger when
+        3. Install a Python-level SIGINT handler that schedules a graceful
+           shutdown via GLib.idle_add().  Installed early so that SIGINT
+           during hardware initialization does not raise KeyboardInterrupt.
+        4. Request PLAYING state on the pipeline.
+        5. Call get_state() with a configured wait time (for diagnostics only)
+           to log the initial state-change outcome.  A KeyboardInterrupt
+           safety net catches platforms where the custom handler is bypassed.
+        6. If shutdown was requested during the state transition (e.g. SIGINT),
+           clean up immediately via _cleanup() and return via _finalize()
+           (steps 10-11 below), skipping the main loop entirely.
+        7. If max-runtime > 0, start a background thread that will trigger when
            max_run_time_sec elapses.
-        6. Install a Python-level SIGINT handler that schedules a graceful
-           shutdown via GLib.idle_add().
-        7. Run the GLib.MainLoop until:
+        8. Run the GLib.MainLoop until:
              - ERROR on the bus, OR
              - EOS on the bus, OR
              - the max-runtime enforcement thread calls loop.quit(), OR
              - SIGINT (Ctrl+C) triggers a graceful shutdown.
-        8. After the loop exits:
-             a. Restore the original SIGINT handler.
-             b. Disconnect the bus signal handler and remove the signal
+        9. After the loop exits, call _cleanup() which:
+             a. Restores the original SIGINT handler.
+             b. Disconnects the bus signal handler and removes the signal
                 watch to break reference cycles (needed for GObject
                 element finalization by Python's GC).
-             c. Transition the pipeline to NULL.
-             d. Drain any remaining bus messages for logging.
-        9. Derive the final result from _RunState.
+             c. Transitions the pipeline to NULL.
+        10. Call _finalize() to drain any remaining bus messages, so that
+            an ERROR posted while transitioning to NULL (step 9c) is still
+            observed rather than left undrained on the bus.
+        11. Derive the final result from _RunState.
+
+        Steps 10-11 are shared (via _finalize()) between the early-exit
+        path (step 6) and the normal post-main-loop path, so both report
+        errors consistently.
 
         Returns:
             (True, None)
@@ -604,31 +670,6 @@ class _PipelineRunner:
         bus.add_signal_watch()
         handler_id = bus.connect("message", self._on_bus_message, loop)
 
-        # Request PLAYING state.
-        ret = self._pipeline.set_state(Gst.State.PLAYING)
-        self._logger.debug("Requested pipeline state PLAYING, result: %s", ret)
-
-        # Wait for initial state change (for logging only).
-        state_change_ret, current_state, pending = self._pipeline.get_state(
-            5 * Gst.SECOND,
-        )
-
-        self._logger.debug(
-            "Initial state change result: %s, current: %s, pending: %s",
-            state_change_ret,
-            current_state,
-            pending,
-        )
-
-        # Start max-runtime enforcement thread only if max-runtime > 0.
-        if self._max_run_time_sec > 0:
-            max_runtime_thread = threading.Thread(
-                target=self._max_runtime_enforcement_thread,
-                args=(loop,),
-                daemon=True,
-            )
-            max_runtime_thread.start()
-
         # Install a Python-level SIGINT handler that schedules a graceful
         # shutdown on the GLib main loop via GLib.idle_add().
         #
@@ -640,12 +681,64 @@ class _PipelineRunner:
         # GLib.idle_add() is thread-safe and main-loop-safe, so calling it
         # from a Python signal handler (which runs in the main thread
         # between bytecode instructions) is correct.
+        #
+        # The handler is installed BEFORE set_state(PLAYING) and get_state()
+        # so that SIGINT arriving during hardware initialization
+        # (GPU/NPU model loading) does not raise KeyboardInterrupt.
         original_sigint_handler = signal.getsignal(signal.SIGINT)
 
-        def _sigint_handler(signum, frame):
+        def _sigint_handler(_signum, _frame):
             GLib.idle_add(self._on_sigint, loop)
 
         signal.signal(signal.SIGINT, _sigint_handler)
+
+        # Request PLAYING state.
+        ret = self._pipeline.set_state(Gst.State.PLAYING)
+        self._logger.debug("Requested pipeline state PLAYING, result: %s", ret)
+
+        # Wait for initial state change (for logging only).
+        # Wrapped in try/except as a safety net: on some platforms or GI
+        # binding versions, SIGINT can still raise KeyboardInterrupt from
+        # within blocking C calls even with a custom signal handler.
+        try:
+            state_change_ret, current_state, pending = self._pipeline.get_state(
+                5 * Gst.SECOND,
+            )
+        except KeyboardInterrupt:
+            # _sigint_handler may also have fired; _initiate_shutdown is
+            # idempotent so the pending idle_add callback is harmless.
+            self._logger.info("SIGINT received during pipeline state transition.")
+            self._state.shutdown_in_progress = True
+            self._state.reason = "sigint"
+            state_change_ret = Gst.StateChangeReturn.FAILURE
+            current_state = Gst.State.VOID_PENDING  # actual state is indeterminate
+            pending = Gst.State.VOID_PENDING
+
+        self._logger.debug(
+            "Initial state change result: %s, current: %s, pending: %s",
+            state_change_ret,
+            current_state,
+            pending,
+        )
+
+        # If shutdown was requested during state transition (via SIGINT),
+        # skip entering the main loop and proceed to cleanup.
+        if self._state.shutdown_in_progress:
+            self._logger.info(
+                "Shutdown requested before main loop (reason: %s), skipping run.",
+                self._state.reason,
+            )
+            self._cleanup(bus, handler_id, original_sigint_handler)
+            return self._finalize(bus)
+
+        # Start max-runtime enforcement thread only if max-runtime > 0.
+        if self._max_run_time_sec > 0:
+            max_runtime_thread = threading.Thread(
+                target=self._max_runtime_enforcement_thread,
+                args=(loop,),
+                daemon=True,
+            )
+            max_runtime_thread.start()
 
         # Run main loop until:
         #   - ERROR (bus handler quits loop),
@@ -655,39 +748,15 @@ class _PipelineRunner:
         try:
             loop.run()
         finally:
-            # Restore the original SIGINT handler.
-            signal.signal(signal.SIGINT, original_sigint_handler)
-
-            # Disconnect the bus signal handler and remove the signal watch
-            # BEFORE setting state to NULL. This breaks the reference cycle
+            # Restore SIGINT handler, disconnect bus, and transition to NULL.
+            # Bus disconnect BEFORE set_state(NULL) breaks the reference cycle
             # between the bus, the signal handler closure, and the pipeline,
             # which is essential for Python's GC to later destroy the
             # pipeline object and trigger C-level element finalizers.
-            try:
-                bus.disconnect(handler_id)
-            except Exception:  # noqa: BLE001
-                pass
-            bus.remove_signal_watch()
+            self._cleanup(bus, handler_id, original_sigint_handler)
 
-            # Transition to NULL. This stops all elements.
-            try:
-                self._pipeline.set_state(Gst.State.NULL)
-            except Exception as exc:  # noqa: BLE001
-                self._logger.warning("Error while stopping pipeline after run: %r", exc)
-
-        # Drain any remaining messages for logging purposes.
-        if drain_bus_messages(bus, self._logger):
-            if not self._state.error_seen:
-                self._state.error_seen = True
-                self._state.reason = self._state.reason or "error"
-
-        # Determine final outcome.
-        if self._state.error_seen:
-            return False, "error"
-        if self._state.max_runtime_triggered and not self._state.error_seen:
-            return True, "max_runtime"
-        # EOS, SIGINT, or normal stop without errors.
-        return True, None
+        # Drain any remaining messages and derive the final outcome.
+        return self._finalize(bus)
 
 
 def run_pipeline_for_duration(

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/gst_runner_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/gst_runner_test.py
@@ -420,6 +420,93 @@ class TestPipelineRunner(unittest.TestCase):
             self.assertTrue(runner._state.max_runtime_triggered)
             self.assertEqual(runner._state.reason, "max_runtime")
 
+    def test_pipeline_runner_sigint_during_get_state_returns_early(self) -> None:
+        """SIGINT (KeyboardInterrupt) during the initial get_state() call should
+        skip the main loop entirely, clean up immediately, and report success.
+        """
+        fake_pipeline = mock.create_autospec(gst_runner.Gst.Pipeline)
+        fake_bus = mock.Mock()
+        fake_pipeline.get_bus.return_value = fake_bus
+        fake_bus.pop.return_value = None
+
+        # Simulate SIGINT interrupting the blocking get_state() call.
+        fake_pipeline.get_state.side_effect = KeyboardInterrupt
+
+        with mock.patch.object(gst_runner, "GLib") as mock_glib:
+            mock_loop = mock.Mock()
+            mock_glib.MainLoop.return_value = mock_loop
+
+            runner = gst_runner._PipelineRunner(
+                fake_pipeline, max_run_time_sec=0.1, mode="normal"
+            )
+            ok, reason = runner.run()
+
+        self.assertTrue(ok)
+        self.assertIsNone(reason)
+        # The main loop must never be entered.
+        mock_loop.run.assert_not_called()
+        # _cleanup() must still transition the pipeline to NULL.
+        fake_pipeline.set_state.assert_any_call(gst_runner.Gst.State.NULL)
+        self.assertTrue(runner._state.shutdown_in_progress)
+        self.assertEqual(runner._state.reason, "sigint")
+
+    def test_pipeline_runner_sigint_early_exit_still_detects_bus_error(self) -> None:
+        """The early-exit path (SIGINT during get_state()) must still observe
+        an ERROR posted on the bus while _cleanup() transitions the pipeline
+        to NULL, instead of unconditionally reporting success.
+        """
+        fake_pipeline = mock.create_autospec(gst_runner.Gst.Pipeline)
+        fake_bus = mock.Mock()
+        fake_pipeline.get_bus.return_value = fake_bus
+
+        fake_error_message = mock.Mock()
+        fake_error_message.type = gst_runner.Gst.MessageType.ERROR
+        fake_error = mock.Mock()
+        fake_error.message = "simulated-teardown-error"
+        fake_error_message.parse_error.return_value = (fake_error, "debug-info")
+
+        # One ERROR message is sitting on the bus when _finalize() drains it,
+        # simulating an error posted while set_state(NULL) ran in _cleanup().
+        fake_bus.pop.side_effect = [fake_error_message, None]
+
+        fake_pipeline.get_state.side_effect = KeyboardInterrupt
+
+        with mock.patch.object(gst_runner, "GLib") as mock_glib:
+            mock_loop = mock.Mock()
+            mock_glib.MainLoop.return_value = mock_loop
+
+            runner = gst_runner._PipelineRunner(
+                fake_pipeline, max_run_time_sec=0.1, mode="normal"
+            )
+            ok, reason = runner.run()
+
+        self.assertFalse(ok)
+        self.assertEqual(reason, "error")
+        mock_loop.run.assert_not_called()
+
+    def test_finalize_reports_error_drained_from_bus(self) -> None:
+        """_finalize should surface an ERROR message drained from the bus even
+        if no error had previously been recorded on _RunState.
+        """
+        fake_pipeline = mock.create_autospec(gst_runner.Gst.Pipeline)
+        fake_bus = mock.Mock()
+
+        fake_error_message = mock.Mock()
+        fake_error_message.type = gst_runner.Gst.MessageType.ERROR
+        fake_error = mock.Mock()
+        fake_error.message = "late-error"
+        fake_error_message.parse_error.return_value = (fake_error, "debug-info")
+        fake_bus.pop.side_effect = [fake_error_message, None]
+
+        runner = gst_runner._PipelineRunner(
+            fake_pipeline, max_run_time_sec=0.0, mode="normal"
+        )
+
+        ok, reason = runner._finalize(fake_bus)
+
+        self.assertFalse(ok)
+        self.assertEqual(reason, "error")
+
 
 class TestMain(unittest.TestCase):
     """Tests for the main CLI entry point using dependency injection.


### PR DESCRIPTION
### Description

When a performance test pipeline running on GPU/NPU is cancelled immediately after start, SIGINT arrives during the blocking get_state() call. Previously, the custom SIGINT handler was installed after set_state(PLAYING) and get_state(), so Python's default handler raised KeyboardInterrupt, causing exit code -2 and marking the pipeline as FAILED instead of CANCELLED.

Changes:
- Move SIGINT handler installation before set_state(PLAYING) so it covers the entire initialization window including get_state()
- Add KeyboardInterrupt catch around get_state() as safety net
- Add early-exit path when shutdown_in_progress is detected after get_state() returns, skipping the main loop and proceeding directly to cleanup
- Extract _cleanup() method: restores default SIGINT handler, disconnects bus signal, sets pipeline to NULL
- Extract _finalize() method: drains remaining bus messages after cleanup to detect late-arriving errors, derives final (ok, reason) tuple
- Add 3 new unit tests covering SIGINT during get_state, early exit with bus error detection, and finalize error reporting

Fixes # (issue with error handling when user quickly start and stop pipeline)

### Any Newly Introduced Dependencies

No new dependencies were introduced.

### How Has This Been Tested?

Deploy vippet in state ready to run pipelines (incl. download models).
Select pipeline variant with GPU and/or NPU target devices.
Start pipeline and quickly (within ~1s) stop it (via UI buttons).
Graceful blue "cancelled by user" notification shall appear, instead of red error (-2).

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

