### PR TITLE
[ViPPET] Bump all Intel container images to latest 2026.2.0 weekly releases and CVE resolution

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -119,7 +119,7 @@ services:
       - ./shared/videos/:/videos
       - ./vippet/api/static:/usr/share/nginx/html/static
   model-download:
-    image: docker.io/intel/model-download:2026.1.0
+    image: docker.io/intel/model-download:2026.2.0-20260728-weekly
     container_name: model-download
     ports:
       - "8000:8000"
@@ -170,7 +170,7 @@ services:
     ports:
       - "7860:7860"
   metrics-manager:
-    image: docker.io/intel/metrics-manager:2026.1.0
+    image: docker.io/intel/metrics-manager:2026.2.0-20260715-weekly
     container_name: metrics-manager
     init: true
     ports:

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.1.0-ubuntu24
+FROM intel/dlstreamer:2026.2.0-20260728-weekly-ubuntu24
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -23,6 +23,10 @@ USER root
 # Set environment variable to non-interactive mode (avoids some prompts)
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Remove kernel headers inherited from base image (not needed at runtime,
+# source of CVE-2026-* critical vulnerabilities reported by Trivy).
+RUN dpkg --purge --force-depends linux-libc-dev
+
 # Set GStreamer plugin path
 ENV GST_PLUGIN_PATH=$GST_PLUGIN_PATH/usr/lib/x86_64-linux-gnu/gstreamer-1.0/
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -34,6 +34,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     apt-get install --yes --no-install-recommends yq v4l-utils
 
+# Remove kernel headers inherited from base image (not needed at runtime,
+# source of CVE-2026-* critical vulnerabilities reported by Trivy).
+RUN dpkg --purge --force-depends linux-libc-dev
+
 # Switch to dlstreamer user
 USER dlstreamer
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -17,7 +17,7 @@
 # syntax=docker/dockerfile:1.7
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.1.0-ubuntu24 AS prod
+FROM intel/dlstreamer:2026.2.0-20260728-weekly-ubuntu24 AS prod
 
 # Switch to root user to install dependencies
 USER root


### PR DESCRIPTION

## Summary

Bump all Intel container images to latest 2026.2.0 weekly releases for upcoming release alignment and CVE resolution.

## Changes

- Bump DLStreamer base image from `intel/dlstreamer:2026.1.0-ubuntu24` to `intel/dlstreamer:2026.2.0-20260728-weekly-ubuntu24`
- Remove `linux-libc-dev` from runtime images with `dpkg --purge --force-depends`
- Bump `intel/model-download:2026.1.0` to `intel/model-download:2026.2.0-20260728-weekly`
- Bump `intel/metrics-manager:2026.1.0` to `intel/metrics-manager:2026.2.0-20260715-weekly`
