### PR TITLE
[ViPPET] Add Mars Small128 re-identification model to supported models

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/shared/models/supported_models.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/shared/models/supported_models.yaml
@@ -432,3 +432,22 @@
   download_request:
     hub: ultralytics
     name: yolo26n-seg
+
+- name: mars-small128
+  display_name: Mars Small128 Re-ID
+  source: public
+  hub: ultralytics
+  type: classification
+  precisions:
+    - precision: FP32
+      model_path: ultralytics/public/mars-small128/mars_small128_fp32.xml
+      model_proc: ""
+    - precision: INT8
+      model_path: ultralytics/public/mars-small128/mars_small128_int8.xml
+      model_proc: ""
+  extra_model_procs: []
+  unsupported_devices: ""
+  default: false
+  download_request:
+    hub: ultralytics
+    name: mars-small128


### PR DESCRIPTION
## Summary

Add the mars-small128 re-identification model to ViPPET's supported models registry, enabling DeepSORT-based object tracking pipelines.

## Changes

- Add `mars-small128` entry to `supported_models.yaml` with FP32 and INT8 precisions
- Model is sourced from the `ultralytics` hub and categorized as `classification` (re-ID embedding network)

## Use Case

Mars Small128 generates appearance feature embeddings used by the `gvatrack tracking-type=deep-sort` element in DLStreamer pipelines. This enables robust multi-object tracking with re-identification across frames, improving tracking accuracy over short-term (zero-term) or IOU-based approaches.
