### PR TITLE
[ViPPET] Add GenAI VLM models: Gemma 4, MiniCPM-V 4.5, InternVL2 2B

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/shared/models/supported_models.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/shared/models/supported_models.yaml
@@ -297,6 +297,28 @@
       device: CPU
       cache_size: 10
 
+- name: gemma4
+  display_name: Gemma 4 E4B
+  source: huggingface
+  hub: huggingface
+  type: genai
+  precisions:
+    - precision: INT4
+      model_path: openvino_models/cpu/int4/google/gemma-4-E4B-it/
+      model_proc: ""
+  extra_model_procs: []
+  unsupported_devices: "NPU"
+  default: false
+  download_request:
+    hub: openvino
+    name: google/gemma-4-E4B-it
+    type: vlm
+    is_ovms: true
+    config:
+      precision: int4
+      device: CPU
+      cache_size: 10
+
 - name: minicpm-v-2_6
   display_name: MiniCPM-V 2.6
   source: huggingface
@@ -312,6 +334,50 @@
   download_request:
     hub: openvino
     name: openbmb/MiniCPM-V-2_6
+    type: vlm
+    is_ovms: true
+    config:
+      precision: int4
+      device: CPU
+      cache_size: 10
+
+- name: minicpm-v4_5
+  display_name: MiniCPM-V 4.5 8B
+  source: huggingface
+  hub: huggingface
+  type: genai
+  precisions:
+    - precision: INT4
+      model_path: openvino_models/cpu/int4/openbmb/MiniCPM-V-4_5/
+      model_proc: ""
+  extra_model_procs: []
+  unsupported_devices: "NPU"
+  default: false
+  download_request:
+    hub: openvino
+    name: openbmb/MiniCPM-V-4_5
+    type: vlm
+    is_ovms: true
+    config:
+      precision: int4
+      device: CPU
+      cache_size: 10
+
+- name: internvl2-2b
+  display_name: InternVL2 2B
+  source: huggingface
+  hub: huggingface
+  type: genai
+  precisions:
+    - precision: INT4
+      model_path: openvino_models/cpu/int4/OpenGVLab/InternVL2-2B/
+      model_proc: ""
+  extra_model_procs: []
+  unsupported_devices: "NPU"
+  default: false
+  download_request:
+    hub: openvino
+    name: OpenGVLab/InternVL2-2B
     type: vlm
     is_ovms: true
     config:


### PR DESCRIPTION
### Description

Add GenAI VLM models: Gemma 4, MiniCPM-V 4.5, InternVL2 2B for future usage.

Note that they may not be functional in VLM pipelines yet, i.e.:

> Gemma 4 implementation supports text and image inputs only. Video input is not supported at the moment.  ([src](https://openvinotoolkit.github.io/openvino.genai/docs/supported-models/#gemma4-notes))

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

It was verified that models are being downloaded via UI and available for selection in relevant pipelines.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

