### PR TITLE
Improve WebRTC video quality: switch CPU encoding to VP9

### DIFF
--- a/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_manager.py
+++ b/microservices/dlstreamer-pipeline-server/src/server/webrtc/gstreamer_webrtc_manager.py
@@ -28,6 +28,21 @@ class GStreamerWebRTCManager:
         " ! whipclientsink signaller::whip-endpoint="
     )
 
+    # VP9 software encoder variants. Preferred on CPU when vp9enc is available,
+    # otherwise the openh264enc variants above are used as fallback.
+    _WebRTCVideoPipeline_vp9 = (
+        " ! videoconvert ! video/x-raw,format=I420 {gvawatermark} "
+        " ! vp9enc name=vp9enc cpu-used=4 lag-in-frames=0 "
+        " ! video/x-vp9 "
+        " ! whipclientsink signaller::whip-endpoint="
+    )
+    _WebRTCVideoPipeline_jpeg_vp9 = (
+        " ! jpegdec ! videoconvert ! video/x-raw,format=I420 {gvawatermark} "
+        " ! vp9enc name=vp9enc cpu-used=4 lag-in-frames=0 "
+        " ! video/x-vp9 "
+        " ! whipclientsink signaller::whip-endpoint="
+    )
+
     # GPU pipeline variants for hardware-accelerated buffers
     _WebRTCVideoPipeline_VAMemory = (
         " ! videoconvert {gvawatermark} "
@@ -113,6 +128,15 @@ class GStreamerWebRTCManager:
         ]
         return "! gvawatermark" if not properties else "! gvawatermark displ-cfg={}".format(",".join(properties))
 
+    def _select_webrtcvideo_pipeline_cpu(self, vp9enc_present, jpeg=False):
+        # Prefer vp9enc on CPU, fall back to openh264enc when it is not present.
+        if vp9enc_present:
+            return self._WebRTCVideoPipeline_jpeg_vp9 if jpeg else self._WebRTCVideoPipeline_vp9
+        self._logger.warning(
+            "vp9enc not found, falling back to openh264enc for encoding."
+        )
+        return self._WebRTCVideoPipeline_jpeg if jpeg else self._WebRTCVideoPipeline
+
     def _get_launch_string(self, stream_caps, peer_id, overlay, overlay_properties=None):
         # pylint: disable=consider-using-f-string, too-many-branches
         s_src = '{} caps="{}"'.format(self._source_mediamtx, ",".join(stream_caps))
@@ -127,6 +151,10 @@ class GStreamerWebRTCManager:
         # encoder to ensure that the pipeline can still function without it.
         vah264enc_present = Gst.ElementFactory.find("vah264enc")
         vah264lpenc_present = Gst.ElementFactory.find("vah264lpenc")
+
+        # On CPU we prefer the vp9enc software encoder when available and fall
+        # back to openh264enc when it is not present.
+        vp9enc_present = Gst.ElementFactory.find("vp9enc")
 
         if "image/jpeg" in stream_caps:
             # GPU buffers with jpeg input
@@ -146,10 +174,10 @@ class GStreamerWebRTCManager:
                         "vah264enc and vah264lpenc not found, "
                         + "using software encoding"
                     )
-                    video_pipeline = self._WebRTCVideoPipeline_jpeg
+                    video_pipeline = self._select_webrtcvideo_pipeline_cpu(vp9enc_present, jpeg=True)
             # CPU buffers with jpeg input
             else:
-                video_pipeline = self._WebRTCVideoPipeline_jpeg
+                video_pipeline = self._select_webrtcvideo_pipeline_cpu(vp9enc_present, jpeg=True)
         else:
             # GPU buffers with raw video input
             if is_gpu and buffer_type == "VAMemory":
@@ -168,10 +196,10 @@ class GStreamerWebRTCManager:
                         "vah264enc and vah264lpenc not found, "
                         + "using software encoding"
                     )
-                    video_pipeline = self._WebRTCVideoPipeline
+                    video_pipeline = self._select_webrtcvideo_pipeline_cpu(vp9enc_present)
             # CPU buffers with raw video input
             else:
-                video_pipeline = self._WebRTCVideoPipeline
+                video_pipeline = self._select_webrtcvideo_pipeline_cpu(vp9enc_present)
         video_pipeline = video_pipeline.format(gvawatermark=watermark_stage)
         pipeline_launch = " {} {} ".format(s_src, video_pipeline)
         pipeline_launch = (


### PR DESCRIPTION
### Description

Switches the WebRTC (WHIP) software encoding path from openh264enc to the VP9 encoder (vp9enc) to improve streamed video quality on CPU-only / software-encode paths. Adds a safe fallback to openh264enc when vp9enc is not available

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

