### PR TITLE
[ViPPET] Fix optimization job status crash when DLStreamer returns metrics dict

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/optimization_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/optimization_manager.py
@@ -140,9 +140,12 @@ class OptimizationRunner:
             f"allowed_devices={allowed_devices}"
         )
 
-        optimized_pipeline, total_fps = opt.optimize_for_fps(
+        optimized_pipeline, metrics = opt.optimize_for_fps(
             pipeline_description, search_duration=search_duration
         )
+
+        # DLStreamer optimizer may return a metrics dict or a bare float.
+        total_fps = metrics["fps"] if isinstance(metrics, dict) else metrics
 
         return PipelineOptimizationResult(
             optimized_pipeline_description=optimized_pipeline, total_fps=total_fps


### PR DESCRIPTION
### Description

DLStreamer's optimize_for_fps() returns (str, dict) where the dict has keys {fps, detections, power}. ViPPET was passing the raw dict to the total_fps field (float | None), causing a Pydantic validation error when polling the optimization job status.

Extract metrics["fps"] from the dict, with a fallback for the bare float case.

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

- Deploy ViPPET
- duplicate any pre-defined pipeline
- (optionally if not done earlier) download required models
- enable advanced mode and run pipeline optimization

Expected that optimization job completes successfully, instead of silently breaking (from UI perspective, in vippet container logs there is traceback).

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

