### PR TITLE
[ViPPET] Fix make stop failing on experimental-only services

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/Makefile
@@ -220,7 +220,7 @@ shell-videogenerator: ## Open shell in videogenerator container
 	$(MAKE) shell SERVICE=videogenerator
 
 stop: ## Stop the docker compose services
-	docker compose down model-download metrics-manager videogenerator mediamtx vippet-ui vippet onvif-discovery ia-timeseries-ingestion ia-time-series-analytics-microservice
+	docker compose down
 
 clean: clean-model-download clean-models clean-output-videos ## Clean all build artifacts
 	rm -rf shared/onvif/onvif_cameras.json shared/videos/input shared/videos/video-generator


### PR DESCRIPTION
## Summary

`make stop` hardcoded `ia-timeseries-ingestion` and
`ia-time-series-analytics-microservice` in its `docker compose down`
service list. Those two services only exist in `compose-experimental.yml`,
not in `compose.yml` (the file used by `make build`/`make run`), so `stop`
failed with `no such service: ia-timeseries-ingestion` for anyone running
the default (non-experimental) stack.

Fix: use a bare `docker compose down` with no service list. `down`
identifies containers via the Compose project label rather than
re-resolving service names against the currently loaded compose file, so
it correctly stops the core stack (and cleans up the network) without
needing this list kept in sync with `compose.yml`'s services.

`stop-experimental` is unaffected and already handles the experimental
compose file with a bare `down`.

## Checklist

- [x] Scope is limited to the intended change.
- [x] No unrelated refactors were introduced.
- [x] Documentation was updated when behavior or API changed. (N/A - no behavior/API change, internal tooling fix)
- [x] Relevant lint checks pass locally (`make lint`).
- [x] Relevant tests pass locally (`make test` or targeted tests). (N/A - Makefile-only change, not exercised by the test suite)
- [x] API changes include OpenAPI/client regeneration when required. (N/A)
- [x] No secrets, `.env` files, or model artifacts are included.

## Validation

- `make build run` then `make stop` — services stop cleanly, network removed, no error.

## Screenshots (if UI change)

N/A