### PR TITLE
fix(vss): stop reporting an object detection model for simple ingestion

### DIFF
--- a/sample-applications/video-search-and-summarization/pipeline-manager/src/state-manager/services/pipeline.service.ts
+++ b/sample-applications/video-search-and-summarization/pipeline-manager/src/state-manager/services/pipeline.service.ts
@@ -13,6 +13,7 @@ import {
   SummaryStreamChunk,
 } from 'src/events/Pipeline.events';
 import { ChunkQueue } from 'src/evam/models/message-broker.model';
+import { EVAMPipelines } from 'src/evam/models/evam.model';
 import { EvamService } from 'src/evam/services/evam.service';
 import { lastValueFrom } from 'rxjs';
 import { ChunkingService } from 'src/state-manager/queues/chunking.service';
@@ -133,10 +134,17 @@ export class PipelineService {
           ),
         );
 
-        this.$state.addEVAMInferenceConfig(
-          stateId,
-          this.$evam.getInferenceConfig(),
-        );
+        // Only the object detection pipeline runs a detection model. Simple
+        // ingestion does not, so leaving objectDetection unset keeps the UI
+        // from advertising a model that was never used.
+        if (
+          state.systemConfig.evamPipeline === EVAMPipelines.OBJECT_DETECTION
+        ) {
+          this.$state.addEVAMInferenceConfig(
+            stateId,
+            this.$evam.getInferenceConfig(),
+          );
+        }
 
         // Pre-populate VLM and LLM inference configs so UI shows model info upfront
         if (this.$vlm.serviceReady) {

--- a/sample-applications/video-search-and-summarization/setup.sh
+++ b/sample-applications/video-search-and-summarization/setup.sh
@@ -288,7 +288,6 @@ export POSTGRES_USER=${POSTGRES_USER}  # Set this in your shell before running t
 export POSTGRES_PASSWORD=${POSTGRES_PASSWORD}  # Set this in your shell before running the script
 
 # env for minio-service
-export MINIO_HOST=${MINIO_HOST:-minio-service}
 export MINIO_ROOT_USER=${MINIO_ROOT_USER} # Set this in your shell before running the script
 export MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD} # Set this in your shell before running the script
 

--- a/sample-applications/video-search-and-summarization/setup.sh
+++ b/sample-applications/video-search-and-summarization/setup.sh
@@ -288,9 +288,9 @@ export POSTGRES_USER=${POSTGRES_USER}  # Set this in your shell before running t
 export POSTGRES_PASSWORD=${POSTGRES_PASSWORD}  # Set this in your shell before running the script
 
 # env for minio-service
+export MINIO_HOST=${MINIO_HOST:-minio-service}
 export MINIO_ROOT_USER=${MINIO_ROOT_USER} # Set this in your shell before running the script
 export MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD} # Set this in your shell before running the script
-export OVMS_ALLOWED_MEDIA_DOMAINS=${OVMS_ALLOWED_MEDIA_DOMAINS:-${MINIO_HOST},localhost}
 
 # env for vdms-vector-db
 export VDMS_VDB_HOST_PORT=55555

--- a/sample-applications/video-search-and-summarization/ui/react/src/components/Summaries/Summary.tsx
+++ b/sample-applications/video-search-and-summarization/ui/react/src/components/Summaries/Summary.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch, useAppSelector } from '../../redux/store';
 import { SummaryActions, SummarySelector } from '../../redux/summary/summarySlice';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
-import { StateActionStatus, SystemConfigWithMeta, UIState } from '../../redux/summary/summary';
+import { EVAMPipelines, StateActionStatus, SystemConfigWithMeta, UIState } from '../../redux/summary/summary';
 import { AILabel, AILabelContent, IconButton, Modal, ModalBody, Tag } from '@carbon/react';
 
 import { Renew, Download, Headphones } from '@carbon/icons-react';
@@ -357,6 +357,8 @@ export const Summary: FC = () => {
       content += `|------------|-------|--------|\n`;
       if (selectedSummary.inferenceConfig?.objectDetection) {
         content += `| Object Detection | ${selectedSummary.inferenceConfig.objectDetection.model} | ${selectedSummary.inferenceConfig.objectDetection.device} |\n`;
+      } else {
+        content += `| Object Detection | Disabled | - |\n`;
       }
       if (selectedSummary.inferenceConfig?.imageInference) {
         content += `| VLM | ${selectedSummary.inferenceConfig.imageInference.model} | ${selectedSummary.inferenceConfig.imageInference.device} |\n`;
@@ -400,6 +402,13 @@ export const Summary: FC = () => {
 
   const SummaryHero = () => {
     const summaryData = selectedSummary!;
+    // Simple ingestion runs no detection model, so the configured object
+    // detection model must not be advertised for those pipelines. Fall back to
+    // the reported inference config so summaries persisted before this
+    // distinction existed still render their recorded model.
+    const objectDetectionEnabled =
+      summaryData.systemConfig.evamPipeline === EVAMPipelines.OBJECT_DETECTION ||
+      !!summaryData.inferenceConfig?.objectDetection;
     return (
       <SummaryTitle>
         <div className='video-container'>
@@ -433,16 +442,22 @@ export const Summary: FC = () => {
                       })}
                     </li>
                   )}
-                  <li>
-                    {t('aiModel', {
-                      model: summaryData.inferenceConfig?.objectDetection?.model ?? 'N/A',
-                    })}
-                  </li>
-                  <li>
-                    {t('runningOn', {
-                      device: summaryData.inferenceConfig?.objectDetection?.device ?? 'N/A',
-                    })}
-                  </li>
+                  {objectDetectionEnabled ? (
+                    <>
+                      <li>
+                        {t('aiModel', {
+                          model: summaryData.inferenceConfig?.objectDetection?.model ?? 'N/A',
+                        })}
+                      </li>
+                      <li>
+                        {t('runningOn', {
+                          device: summaryData.inferenceConfig?.objectDetection?.device ?? 'N/A',
+                        })}
+                      </li>
+                    </>
+                  ) : (
+                    <li>{t('objectDetectionDisabled')}</li>
+                  )}
                 </ul>
                 <hr />
                 <h5 className='secondary bold'>Frame Captioning</h5>

--- a/sample-applications/video-search-and-summarization/ui/react/src/utils/i18n/translations/en.ts
+++ b/sample-applications/video-search-and-summarization/ui/react/src/utils/i18n/translations/en.ts
@@ -108,6 +108,7 @@ export const enTranslations = {
   sampleRate: 'Sample Rate: {{frames}} frames every {{interval}} seconds',
   aiModel: 'Model: {{model}}',
   runningOn: 'Running on: {{device}}',
+  objectDetectionDisabled: 'Object Detection: Disabled',
   frameOverlap: 'Frame Overlap: {{overlap}}',
   multiFrame: 'Multi Frames: {{multiFrame}}',
   noticeMessage: 'Development in progress',


### PR DESCRIPTION

### Description

- Starting a summary pipeline always recorded the configured object detection model against the state, regardless of which ingestion pipeline was selected. Render "Object Detection: Disabled" when no detection model ran.
- Fix setup.sh regression that brought back `OVMS_ALLOWED_MEDIA_DOMAINS` param - caused OVMS to lose minio-service connectivity.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

