### PR TITLE
[ViPPET] Add links to benchmarking guides

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/user-guide/benchmarking.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/user-guide/benchmarking.md
@@ -14,6 +14,12 @@ ViPPET provides two benchmarking modes for evaluating AI inference pipeline perf
 
 Both modes share a common execution configuration and report results through the same job management system.
 
+For detailed instructions, see:
+
+- [Performance Testing](./benchmarking/performance-testing.md)
+- [Stream Density Testing](./benchmarking/density-testing.md)
+- [Managing Jobs](./benchmarking/managing-jobs.md)
+
 ## Key concepts
 
 | Concept             | Description                                                                                                 |


### PR DESCRIPTION
This pull request improves the documentation for the ViPPET benchmarking tool by adding links to detailed instructions for different benchmarking tasks. This makes it easier for users to find relevant guides.

Documentation improvements:

* Added links to separate guides for performance testing, stream density testing, and job management in the benchmarking user guide (`benchmarking.md`).