### PR TITLE
Link hugginface access acteptance instruction

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/pre-installation-steps.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/pre-installation-steps.md
@@ -32,7 +32,7 @@ supported hubs. Only the Hugging Face download functionality is disabled.
 1. Sign in (or create an account) at [https://huggingface.co](https://huggingface.co).
 2. Open **Settings -> Access Tokens** and create a new token. A token with the **read** role
    is sufficient to download public and gated models.
-3. For any gated model, additionally accept its license on the model's Hugging Face page
+3. For any gated model, additionally [accept](../../user-guide/model-management/huggingface.md) its license on the model's Hugging Face page
    while signed in with the same account.
 
 #### Configure the token


### PR DESCRIPTION
Linking hugginface access accteptance instruction:

<img width="387" height="170" alt="image" src="https://github.com/user-attachments/assets/4c044776-8eb5-4244-be8d-0476c39bfca1" />
