### PR TITLE
[ViPPET] Remove obsolete test and field

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/shared/models/supported_models.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/shared/models/supported_models.yaml
@@ -292,7 +292,6 @@
       model_proc: ""
   extra_model_procs: []
   unsupported_devices: "NPU"
-  default: false
   download_request:
     hub: openvino
     name: google/gemma-4-E4B-it
@@ -335,7 +334,6 @@
       model_proc: ""
   extra_model_procs: []
   unsupported_devices: "NPU"
-  default: false
   download_request:
     hub: openvino
     name: openbmb/MiniCPM-V-4_5
@@ -357,7 +355,6 @@
       model_proc: ""
   extra_model_procs: []
   unsupported_devices: "NPU"
-  default: false
   download_request:
     hub: openvino
     name: OpenGVLab/InternVL2-2B
@@ -490,7 +487,6 @@
       model_proc: ""
   extra_model_procs: []
   unsupported_devices: ""
-  default: false
   download_request:
     hub: ultralytics
     name: mars-small128

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_list.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_models_list.py
@@ -143,26 +143,6 @@ def test_models_endpoint_returns_models(http_client: requests.Session) -> None:
                 ), f"Variant has unsupported precision: {variant.get('precision')}"
 
 
-@pytest.mark.smoke
-def test_default_models_present_in_api(
-    http_client: requests.Session,
-    supported_models_config: list[ModelDict],
-) -> None:
-    """Every model marked as default=true in supported_models.yaml must be
-    returned by the API with the correct display_name, precision and category."""
-    api_models = fetch_models(http_client)
-
-    default_models = _expand_model_precisions(
-        [m for m in supported_models_config if m.get("default") is True]
-    )
-    assert default_models, "No default models found in supported_models.yaml"
-    logger.info(
-        "Verifying %d default model variant(s) from config", len(default_models)
-    )
-
-    _assert_models_present_in_api(api_models, default_models)
-
-
 @pytest.mark.full
 def test_all_models_present_in_api(
     http_client: requests.Session,


### PR DESCRIPTION
This pull request removes the obsolete `default` field from model entries in the `supported_models.yaml` file and the test that checked for its presence.

Fixes #2608, #2630 and #2633.