### PR TITLE
[ViPPET] Update metrics-manager and DLStreamer to version 2026.2.0-rc1

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose-experimental.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose-experimental.yml
@@ -180,7 +180,7 @@ services:
       ia-time-series-analytics-microservice:
         condition: service_started
   metrics-manager:
-    image: docker.io/intel/metrics-manager:2026.2.0-20260804-weekly
+    image: docker.io/intel/metrics-manager:2026.2.0-rc1
     container_name: metrics-manager
     ports:
       - "9090:9090"

--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -177,7 +177,7 @@ services:
     ports:
       - "7860:7860"
   metrics-manager:
-    image: docker.io/intel/metrics-manager:2026.2.0-20260804-weekly
+    image: docker.io/intel/metrics-manager:2026.2.0-rc1
     container_name: metrics-manager
     init: true
     ports:

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -17,7 +17,7 @@
 # syntax=docker/dockerfile:1.7
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.2.0-20260804-weekly-ubuntu24 AS prod
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1 AS prod
 
 # Switch to root user to install dependencies
 USER root


### PR DESCRIPTION
Update metrics-manager to version 2026.2.0-rc1