### PR TITLE
Update DLStreamer base image to 2026.2.0-ubuntu24-rc1

### DIFF
--- a/microservices/audio-analyzer/Dockerfile
+++ b/microservices/audio-analyzer/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-FROM intel/dlstreamer:2026.1.0-ubuntu24
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
 
 ARG APP_UID=1000
 ARG APP_GID=1000

--- a/microservices/audio-analyzer/docker/Dockerfile
+++ b/microservices/audio-analyzer/docker/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-FROM intel/dlstreamer:2026.1.0-ubuntu24
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
 
 ARG APP_UID=1000
 ARG APP_GID=1000

--- a/microservices/text-to-speech/Dockerfile
+++ b/microservices/text-to-speech/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-FROM intel/dlstreamer:2026.1.0-ubuntu24
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc1
 
 ARG APP_UID=1000
 ARG APP_GID=1000


### PR DESCRIPTION
## Summary
- Updated the DLStreamer base image from `2026.1.0-ubuntu24` to `2026.2.0-ubuntu24-rc1`
- Updated the following Dockerfiles:
  - `microservices/audio-analyzer/Dockerfile`
  - `microservices/audio-analyzer/docker/Dockerfile`
  - `microservices/text-to-speech/Dockerfile`

## Validation
- Successfully built the Audio Analyzer Docker image.
- Successfully built the Text-to-Speech Docker image.
- Verified Audio Analyzer:
  - `/health`
  - `/v1/audio/transcriptions`
- Verified Text-to-Speech:
  - `/health`
  - `/v1/audio/voices`
  - `/v1/audio/speech`