### PR TITLE
[VSS-UI] Fix search tag dropdown flicker

### DIFF
--- a/sample-applications/video-search-and-summarization/ui/react/src/components/PopupModal/SearchModal.tsx
+++ b/sample-applications/video-search-and-summarization/ui/react/src/components/PopupModal/SearchModal.tsx
@@ -58,6 +58,7 @@ export const SearchModal: FC<SearchModalProps> = ({ showModal, closeModal }) => 
       onRequestSubmit={() => {
         submitSearch();
       }}
+      hasScrollingContent
     >
       <ModalBody>
         <TextArea
@@ -72,6 +73,8 @@ export const SearchModal: FC<SearchModalProps> = ({ showModal, closeModal }) => 
 
         {suggestedTags && suggestedTags.length > 0 && (
           <MultiSelect
+            // Let the dropdown menu reposition itself according to the length
+            autoAlign
             helperText={t('tagsHelperText')}
             items={suggestedTags}
             itemToString={(item) => (item ? item : '')}

--- a/sample-applications/video-search-and-summarization/ui/react/vitest.setup.ts
+++ b/sample-applications/video-search-and-summarization/ui/react/vitest.setup.ts
@@ -9,6 +9,15 @@ afterEach(() => {
   cleanup();
 });
 
+// Provide a no-op stub for carbon React components as jsdom does not provide ResizeObserver.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
 // Global axios mock to prevent network calls in all tests
 vi.mock('axios', () => ({
   default: {


### PR DESCRIPTION
### Description

This fixes a Search UI flickering issue in the tag select dropdown. The flicker was visible when opening the tag menu, and it was noticeable when the number of tags was exactly four.

The modal now lets the Carbon dropdown auto-align inside a scrolling modal, which keeps the menu positioning stable and avoids the redraw jitter. The tag dropdown, now, scrolls cleanly when its content grows and keeps Carbon's multiselect aligned correctly.

The PR also adds a jsdom ResizeObserver stub so the UI test environment can render Carbon components reliably.

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

Ran `npm test -- --run src/tests/SearchModal.test.tsx` in the React UI package.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0.
- [x] I have not included any company confidential information, trade secret, password or security token.
- [x] I have performed a self-review of my code.