### PR TITLE
[ViPPET] Add stop section to installation guides

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/build-from-source.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/build-from-source.md
@@ -73,7 +73,7 @@ Stop and remove all running containers:
 make stop
 ```
 
-Downloaded models, videos, and benchmark output under `shared/` are preserved. To also remove
+Downloaded models and videos under `shared/` are preserved. To also remove
 those artifacts, run:
 
 ```bash

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/build-from-source.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/build-from-source.md
@@ -64,3 +64,18 @@ Hugging Face Hub.
 
    Open a browser and navigate to `http://localhost/api/v1/docs` (or `http://<HOST-IP>/api/v1/docs`)
    to access the Swagger UI.
+
+## Stop the application
+
+Stop and remove all running containers:
+
+```bash
+make stop
+```
+
+Downloaded models, videos, and benchmark output under `shared/` are preserved. To also remove
+those artifacts, run:
+
+```bash
+make clean
+```

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/docker-compose.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/docker-compose.md
@@ -111,7 +111,7 @@ Stop and remove all running containers:
 make stop
 ```
 
-Downloaded models, videos, and benchmark output under `shared/` are preserved. To also remove
+Downloaded models and videos under `shared/` are preserved. To also remove
 those artifacts, run:
 
 ```bash

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/docker-compose.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/docker-compose.md
@@ -102,3 +102,18 @@ For alternative ways to set up the sample application, refer to
 > **Note:** On the first start the `model-download` service may take several minutes to become
 > healthy because it provisions its plugin virtual environments. The other services wait for it
 > automatically.
+
+## Stop the application
+
+Stop and remove all running containers:
+
+```bash
+make stop
+```
+
+Downloaded models, videos, and benchmark output under `shared/` are preserved. To also remove
+those artifacts, run:
+
+```bash
+make clean
+```


### PR DESCRIPTION
This pull request updates the installation documentation to add instructions for stopping and cleaning up the application. The new sections explain how to stop and remove running containers and how to remove downloaded artifacts.

**Documentation improvements:**

* Added a "Stop the application" section to both `build-from-source.md` and `docker-compose.md`, describing how to stop and remove running containers using `make stop`, and how to clean up downloaded models and artifacts using `make clean`.