### PR TITLE
[DOCS] Alert Agent Service - prepare docs for publishing - 2026.2

### DIFF
--- a/microservices/alert-agent-service/README
+++ b/microservices/alert-agent-service/README
@@ -1,0 +1,35 @@
+# Alert Agent Microservice
+
+**Alert Agent Microservice** is a FastAPI-based microservice for alert action dispatching.
+It receives alert events from upstream detection pipelines, reasons over the alert context
+using an LLM-powered agentic backend, and dispatches one or more configurable action tools —
+such as logging, webhook notifications, MQTT publishing, and snapshot saving.
+
+Below, you will find links to detailed documentation to help you get started,
+configure, and deploy the microservice.
+
+## Documentation
+
+- Overview
+
+  - [Overview](./docs/user-guide/index.md): A high-level introduction to the
+    microservice and its capabilities.
+  - [How It Works](./docs/user-guide/how-it-works.md): An explanation of the internal architecture,
+    components, and processing flow.
+
+- Getting Started
+
+  - [Get Started](./docs/user-guide/get-started.md): Step-by-step entry point that walks
+    you through your first run.
+  - [System Requirements](./docs/user-guide/get-started/system-requirements.md): Hardware, OS, and
+    runtime prerequisites.
+
+- API Reference
+
+  - [API Reference](./docs/user-guide/api-reference.md): Comprehensive reference for the
+    available REST API endpoints.
+
+- Release Notes
+
+  - [Release Notes](./docs/user-guide/release-notes.md): Notable updates, improvements,
+    and known limitations.

--- a/microservices/alert-agent-service/docs/user-guide/api-reference.md
+++ b/microservices/alert-agent-service/docs/user-guide/api-reference.md
@@ -11,46 +11,46 @@ Interactive API documentation (Swagger UI) is available at `http://<host>:9001/d
 
 ### Actions
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/api/v1/alerts` | Flexible JSON alert ingestion (alert-service compatible) |
-| `POST` | `/api/v1/actions/execute` | Dispatch alert actions (main entry point) |
+| Method | Path                      | Description                                              |
+| ------ | ------------------------- | -------------------------------------------------------- |
+| `POST` | `/api/v1/alerts`          | Flexible JSON alert ingestion (alert-service compatible) |
+| `POST` | `/api/v1/actions/execute` | Dispatch alert actions (main entry point)                |
 
 ### Streaming
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/events` | Server-Sent Events stream for real-time alert fanout |
-| `GET` | `/api/v1/ws` | WebSocket stream (mirrors SSE events) |
+| Method | Path             | Description                                          |
+| ------ | ---------------- | ---------------------------------------------------- |
+| `GET`  | `/api/v1/events` | Server-Sent Events stream for real-time alert fanout |
+| `GET`  | `/api/v1/ws`     | WebSocket stream (mirrors SSE events)                |
 
 ### Tools
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/tools` | List all registered action tools (built-in + MCP) |
+| Method | Path                          | Description                                         |
+| ------ | ----------------------------- | --------------------------------------------------- |
+| `GET`  | `/api/v1/tools`               | List all registered action tools (built-in + MCP)   |
 | `POST` | `/api/v1/tools/{name}/invoke` | Manually invoke a built-in tool (testing/debugging) |
-| `POST` | `/api/v1/tools/reload` | Hot-reload `resources/tools.json` without restart |
+| `POST` | `/api/v1/tools/reload`        | Hot-reload `resources/tools.json` without restart   |
 
 ### MCP
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/mcp/status` | Get connection status of all configured MCP servers |
-| `GET` | `/api/v1/mcp/tools` | List all tools discovered from MCP servers |
-| `POST` | `/api/v1/mcp/reload` | Reconnect to MCP servers and refresh the tool registry |
-| `POST` | `/api/v1/mcp/tools/{name}/invoke` | Manually invoke an MCP tool (testing/debugging) |
+| Method | Path                              | Description                                            |
+| ------ | --------------------------------- | ------------------------------------------------------ |
+| `GET`  | `/api/v1/mcp/status`              | Get connection status of all configured MCP servers    |
+| `GET`  | `/api/v1/mcp/tools`               | List all tools discovered from MCP servers             |
+| `POST` | `/api/v1/mcp/reload`              | Reconnect to MCP servers and refresh the tool registry |
+| `POST` | `/api/v1/mcp/tools/{name}/invoke` | Manually invoke an MCP tool (testing/debugging)        |
 
 ### Subscriptions
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/subscriptions` | List all loaded subscription entries from config |
+| Method | Path                    | Description                                      |
+| ------ | ----------------------- | ------------------------------------------------ |
+| `GET`  | `/api/v1/subscriptions` | List all loaded subscription entries from config |
 
 ### Observability
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/health` | Liveness probe |
+| Method | Path             | Description    |
+| ------ | ---------------- | -------------- |
+| `GET`  | `/api/v1/health` | Liveness probe |
 
 ---
 
@@ -62,17 +62,17 @@ Accept a flexible JSON alert payload, matching the alert-service API contract. T
 
 Any JSON object. The following fields are recognised and mapped:
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `alert_type` | string | `"UNKNOWN"` | Alert type identifier |
-| `source_id` | string | `"unknown"` | Originating source identifier |
-| `alert_name` | string | value of `alert_type` | Name of the triggered alert |
-| `answer` | string | `"YES"` | Detection result (`YES` / `NO`) |
-| `reason` | string | `""` | Human-readable explanation |
-| `metadata` | object | `{}` | Arbitrary metadata |
-| `timestamp` | string | auto-generated | ISO-8601 timestamp |
-| `tools` | array | `["log_alert"]` | Tool names to invoke |
-| `payloads` | array | `[]` | Multimodal payload list |
+| Field        | Type   | Default               | Description                     |
+| ------------ | ------ | --------------------- | ------------------------------- |
+| `alert_type` | string | `"UNKNOWN"`           | Alert type identifier           |
+| `source_id`  | string | `"unknown"`           | Originating source identifier   |
+| `alert_name` | string | value of `alert_type` | Name of the triggered alert     |
+| `answer`     | string | `"YES"`               | Detection result (`YES` / `NO`) |
+| `reason`     | string | `""`                  | Human-readable explanation      |
+| `metadata`   | object | `{}`                  | Arbitrary metadata              |
+| `timestamp`  | string | auto-generated        | ISO-8601 timestamp              |
+| `tools`      | array  | `["log_alert"]`       | Tool names to invoke            |
+| `payloads`   | array  | `[]`                  | Multimodal payload list         |
 
 ### Example Request
 
@@ -105,7 +105,7 @@ Submit an alert with optional multimodal payloads. The service dispatches config
 
 ### Request Body
 
-```json
+```
 {
   "event_id": "string (auto-generated UUID if omitted)",
   "source_id": "string (required) — camera ID, sensor ID, device ID",
@@ -173,12 +173,12 @@ Connects to the Server-Sent Events stream and receives real-time alert dispatch 
 
 ### Event Types
 
-| Event | Description |
-|-------|-------------|
-| `init` | Emitted on connect — confirms service info |
-| `alert_action` | Emitted after each successful dispatch |
-| `keepalive` | Emitted every 15 seconds to prevent proxy timeouts |
-| `error` | Emitted on unexpected SSE-level errors |
+| Event          | Description                                        |
+| -------------- | -------------------------------------------------- |
+| `init`         | Emitted on connect — confirms service info         |
+| `alert_action` | Emitted after each successful dispatch             |
+| `keepalive`    | Emitted every 15 seconds to prevent proxy timeouts |
+| `error`        | Emitted on unexpected SSE-level errors             |
 
 ### Example `alert_action` Event Data
 
@@ -294,19 +294,19 @@ Lists all subscription entries loaded from the subscription config file.
     {
       "alert_name": "CONCEALMENT",
       "tools": ["log_alert", "trigger_webhook", "capture_snapshot"],
-      "tool_arguments": {"trigger_webhook": {"url": "https://..."}},
-      "dedup": {"enabled": true, "strategy": "field_hash", "fields": ["source_id"], "window_seconds": 30},
-      "escalation": {"threshold_consecutive": 3, "additional_tools": ["publish_mqtt"]}
+      "tool_arguments": { "trigger_webhook": { "url": "https://..." } },
+      "dedup": {
+        "enabled": true,
+        "strategy": "field_hash",
+        "fields": ["source_id"],
+        "window_seconds": 30
+      },
+      "escalation": {
+        "threshold_consecutive": 3,
+        "additional_tools": ["publish_mqtt"]
+      }
     }
   ],
   "count": 1
 }
 ```
-
----
-
-<!--hide_directive
-```{eval-rst}
-.. swagger-plugin:: ./_assets/openapi.yaml
-```
-hide_directive-->

--- a/microservices/alert-agent-service/docs/user-guide/get-started.md
+++ b/microservices/alert-agent-service/docs/user-guide/get-started.md
@@ -26,7 +26,8 @@ See [System Requirements](./get-started/system-requirements.md) for full details
 ## Deploy with Docker Compose
 
 ### 1. Clone the Microservice
-Go to the target directory of your choice and clone the microservice. If you want to clone a specific release branch, replace main with the desired tag. To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/dev/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
+
+Go to the target directory of your choice and clone the microservice. If you want to clone a specific release branch, replace main with the desired tag. To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/2026.2/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
 
 ```bash
 git clone --filter=blob:none --sparse --branch main https://github.com/open-edge-platform/edge-ai-libraries.git
@@ -87,11 +88,11 @@ docker compose -f docker/docker-compose.yml --profile agent up -d
 
 This starts up to three containers:
 
-| Container | Description |
-|-----------|-------------|
-| `alert-agent-service` | The alert action dispatcher |
-| `mqtt` | Local MQTT broker used by the MQTT action tool |
-| `ovms-llm` | OpenVINO Model Server serving the Phi-4-mini-instruct LLM (agent mode only) |
+| Container             | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `alert-agent-service` | The alert action dispatcher                                                 |
+| `mqtt`                | Local MQTT broker used by the MQTT action tool                              |
+| `ovms-llm`            | OpenVINO Model Server serving the Phi-4-mini-instruct LLM (agent mode only) |
 
 In agent mode, the `ovms-llm` container is started only when you include `--profile agent`. Initial startup may take 2–5 minutes while the LLM model is downloaded and loaded. During that time, `alert-agent-service` may be up before the LLM is ready.
 
@@ -128,11 +129,7 @@ Expected response:
 
 ### 5. Access the API Documentation
 
-Open the Swagger UI at:
-
-```json
-  http://localhost:8000/docs
-```
+Open the Swagger UI at `http://localhost:8000/docs`.
 
 ### 6. Stop the Services
 
@@ -234,29 +231,29 @@ curl http://localhost:8000/api/v1/tools
 
 ### Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PORT` | `8000` | Port the service listens on |
-| `LOG_LEVEL` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `AGENT_MODE` | `true` | Enable ADK (LLM-reasoned) dispatch; set `false` for rule-based mode |
-| `TARGET_DEVICE` | `GPU` | OVMS inference device — set to `CPU` for Intel devices without a discrete GPU |
-| `LLM_URL` | `http://ovms-llm:9000/v3` | OpenAI-compatible LLM endpoint |
-| `LLM_MODEL` | `OpenVINO/Phi-4-mini-instruct-int4-ov` | Model repository path / name |
-| `LLM_TIMEOUT` | `10.0` | LLM request timeout in seconds |
-| `ACTION_WORKERS` | `2` | Concurrent worker pool size for tool execution |
-| `WEBHOOK_URL` | _(empty)_ | Default webhook endpoint for `trigger_webhook` |
-| `WEBHOOK_SECRET` | _(empty)_ | HMAC-SHA256 secret for webhook request signing |
-| `MQTT_BROKER` | _(empty)_ | MQTT broker hostname or IP |
-| `MQTT_PORT` | `1883` | MQTT broker port |
-| `MQTT_USERNAME` | _(empty)_ | MQTT broker username |
-| `MQTT_PASSWORD` | _(empty)_ | MQTT broker password |
-| `MQTT_BASE_TOPIC` | `alerts` | Base MQTT topic prefix |
-| `SNAPSHOT_DIR` | `snapshots` | Directory for saving image snapshots |
-| `RETRY_ATTEMPTS` | `3` | Number of retry attempts for failed tool invocations |
-| `RETRY_INTERVAL_SECONDS` | `2.0` | Delay in seconds between retry attempts |
-| `SUBSCRIPTION_CONFIG_PATH` | `resources/config.yaml` | Path to the subscription YAML configuration file |
-| `MCP_ENABLED` | `true` | Enable MCP server integration |
-| `MCP_CONFIG_FILE` | `resources/mcp_servers.json` | Path to the MCP servers configuration file |
+| Variable                   | Default                                | Description                                                                   |
+| -------------------------- | -------------------------------------- | ----------------------------------------------------------------------------- |
+| `PORT`                     | `8000`                                 | Port the service listens on                                                   |
+| `LOG_LEVEL`                | `INFO`                                 | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`)                           |
+| `AGENT_MODE`               | `true`                                 | Enable ADK (LLM-reasoned) dispatch; set `false` for rule-based mode           |
+| `TARGET_DEVICE`            | `GPU`                                  | OVMS inference device — set to `CPU` for Intel devices without a discrete GPU |
+| `LLM_URL`                  | `http://ovms-llm:9000/v3`              | OpenAI-compatible LLM endpoint                                                |
+| `LLM_MODEL`                | `OpenVINO/Phi-4-mini-instruct-int4-ov` | Model repository path / name                                                  |
+| `LLM_TIMEOUT`              | `10.0`                                 | LLM request timeout in seconds                                                |
+| `ACTION_WORKERS`           | `2`                                    | Concurrent worker pool size for tool execution                                |
+| `WEBHOOK_URL`              | _(empty)_                              | Default webhook endpoint for `trigger_webhook`                                |
+| `WEBHOOK_SECRET`           | _(empty)_                              | HMAC-SHA256 secret for webhook request signing                                |
+| `MQTT_BROKER`              | _(empty)_                              | MQTT broker hostname or IP                                                    |
+| `MQTT_PORT`                | `1883`                                 | MQTT broker port                                                              |
+| `MQTT_USERNAME`            | _(empty)_                              | MQTT broker username                                                          |
+| `MQTT_PASSWORD`            | _(empty)_                              | MQTT broker password                                                          |
+| `MQTT_BASE_TOPIC`          | `alerts`                               | Base MQTT topic prefix                                                        |
+| `SNAPSHOT_DIR`             | `snapshots`                            | Directory for saving image snapshots                                          |
+| `RETRY_ATTEMPTS`           | `3`                                    | Number of retry attempts for failed tool invocations                          |
+| `RETRY_INTERVAL_SECONDS`   | `2.0`                                  | Delay in seconds between retry attempts                                       |
+| `SUBSCRIPTION_CONFIG_PATH` | `resources/config.yaml`                | Path to the subscription YAML configuration file                              |
+| `MCP_ENABLED`              | `true`                                 | Enable MCP server integration                                                 |
+| `MCP_CONFIG_FILE`          | `resources/mcp_servers.json`           | Path to the MCP servers configuration file                                    |
 
 ### Subscription Configuration (`resources/config.yaml`)
 
@@ -331,25 +328,28 @@ Set `"enabled": false` to disable a server without removing its configuration.
 
 ### Docker Volumes
 
-| Volume | Container Path | Description |
-|--------|---------------|-------------|
+| Volume        | Container Path   | Description                                                                      |
+| ------------- | ---------------- | -------------------------------------------------------------------------------- |
 | `./resources` | `/app/resources` | Subscription config, tools.json, and mcp_servers.json (mounted for live updates) |
-| `snapshots` | `/app/snapshots` | Persistent storage for captured image snapshots |
+| `snapshots`   | `/app/snapshots` | Persistent storage for captured image snapshots                                  |
 
 ---
 
 ## Troubleshooting
 
 **The alert-agent-service fails to start, showing `Agent not initialised`:**
+
 - Check that `ovms-llm` has passed its health check: `docker compose -f docker/docker-compose.yml --profile agent logs ovms-llm`
 - The LLM model may still be loading. Wait up to 5 minutes and re-check.
 - If running on a CPU-only device, ensure `TARGET_DEVICE=CPU` is set in your environment before running `docker compose -f docker/docker-compose.yml up` (add `--profile agent` when using agent mode).
 
 **Webhook notifications are skipped:**
+
 - Verify `WEBHOOK_URL` is set and reachable from within the container.
 - Check logs: `docker compose -f docker/docker-compose.yml logs alert-agent-service | grep webhook`
 
 **MQTT publishing is skipped:**
+
 - Verify `MQTT_BROKER` is set and the broker is reachable.
 - Ensure `MQTT_PORT`, `MQTT_USERNAME`, and `MQTT_PASSWORD` are correct.
 
@@ -389,16 +389,10 @@ docker compose -f docker/docker-compose.yml --profile agent logs -f ovms-llm
    uv run pytest tests/ -v
    ```
 
----
-
-## Run in a Kubernetes Cluster
-
-See [Deploy with Helm Chart](./get-started/deploy-with-helm-chart.md) for details.
-
 ## Learn More
 
 - [**System Requirements**](./get-started/system-requirements.md)
-- [**Deploy with Helm Chart**](./get-started/deploy-with-helm-chart.md)
+- [**How It Works**](./how-it-works.md)
 - [**API Reference**](./api-reference.md)
 
 <!--hide_directive
@@ -406,7 +400,6 @@ See [Deploy with Helm Chart](./get-started/deploy-with-helm-chart.md) for detail
 :hidden:
 
 ./get-started/system-requirements
-./get-started/deploy-with-helm-chart
 
 :::
 hide_directive-->

--- a/microservices/alert-agent-service/docs/user-guide/get-started/system-requirements.md
+++ b/microservices/alert-agent-service/docs/user-guide/get-started/system-requirements.md
@@ -2,41 +2,35 @@
 
 ## Hardware Requirements
 
-| Component | Minimum | Recommended |
-|-----------|---------|-------------|
-| CPU | 4 cores | 8+ cores |
-| RAM | 8 GB | 16 GB |
-| Disk | 10 GB free | 20 GB free |
-| GPU | _(optional)_ Intel® Arc™ / Flex / Data Center GPU | Intel® Arc™ A770 or equivalent |
+| Component | Minimum                                           | Recommended                    |
+| --------- | ------------------------------------------------- | ------------------------------ |
+| CPU       | 4 cores                                           | 8+ cores                       |
+| RAM       | 8 GB                                              | 16 GB                          |
+| Disk      | 10 GB free                                        | 20 GB free                     |
+| GPU       | _(optional)_ Intel® Arc™ / Flex / Data Center GPU | Intel® Arc™ A770 or equivalent |
 
-> **Note:** The default LLM (`Phi-4-mini-instruct-int4-ov`) can run on either GPU or CPU. Set `TARGET_DEVICE=CPU` in your environment to use CPU-only inference. GPU provides significantly lower latency and is recommended for production workloads with high alert frequency.
+> **Note:** The default LLM (`Phi-4-mini-instruct-int4-ov`) can run on either GPU or CPU. Set
+> `TARGET_DEVICE=CPU` in your environment to use CPU-only inference. GPU provides significantly
+> lower latency and is recommended for production workloads with high alert frequency.
 
 ## Software Requirements
 
-| Software | Version | Notes |
-|----------|---------|-------|
-| Docker Engine | 24.0 or later | [Install Docker](https://docs.docker.com/engine/install/) |
-| Docker Compose | v2 plugin | Bundled with Docker Desktop; install separately on Linux |
-| Python | 3.12 or later | Required only for running tests locally |
-| `uv` | Latest | Required only for local development; `pip install uv` |
-
-## Kubernetes Requirements (Helm Deployment)
-
-| Tool | Version | Notes |
-|------|---------|-------|
-| Kubernetes | 1.27 or later | Cluster must support dynamic Persistent Volume provisioning |
-| kubectl | Latest | [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) |
-| Helm | 3.x | [Install Helm](https://helm.sh/docs/intro/install/) |
+| Software       | Version       | Notes                                                     |
+| -------------- | ------------- | --------------------------------------------------------- |
+| Docker Engine  | 24.0 or later | [Install Docker](https://docs.docker.com/engine/install/) |
+| Docker Compose | v2 plugin     | Bundled with Docker Desktop; install separately on Linux  |
+| Python         | 3.12 or later | Required only for running tests locally                   |
+| `uv`           | Latest        | Required only for local development; `pip install uv`     |
 
 ## Network Requirements
 
 The following network ports are used by default:
 
-| Port | Service | Configurable via |
-|------|---------|-----------------|
-| `9001` | Alert Agent Service REST API | `PORT` environment variable |
-| `8001` | OVMS LLM server (host-mapped) | `LLM_PORT` environment variable |
-| `1883` | MQTT broker (if used) | `MQTT_PORT` environment variable |
+| Port   | Service                       | Configurable via                 |
+| ------ | ----------------------------- | -------------------------------- |
+| `9001` | Alert Agent Service REST API  | `PORT` environment variable      |
+| `8001` | OVMS LLM server (host-mapped) | `LLM_PORT` environment variable  |
+| `1883` | MQTT broker (if used)         | `MQTT_PORT` environment variable |
 
 ## Proxy Settings
 

--- a/microservices/alert-agent-service/docs/user-guide/how-it-works.md
+++ b/microservices/alert-agent-service/docs/user-guide/how-it-works.md
@@ -1,0 +1,112 @@
+# How It Works
+
+This article provides a detailed overview of the internal architecture, components, and data
+flow of the Alert Agent Service. It is intended for developers and system integrators who want
+to understand how the service processes alert events, reasons over them, and dispatches actions.
+
+## Architecture
+
+The service exposes a FastAPI-based REST API and supports two dispatch modes:
+
+- **ADK mode (default)**: Uses Google Agent Development Kit (ADK) backed by an OpenVINO Model Server (OVMS) LLM to reason over the alert and invoke tools autonomously.
+- **Rule-based mode**: Directly invokes the ordered list of tools specified in the request or subscription configuration without LLM reasoning.
+
+The following diagram illustrates the high-level architecture and data flow:
+
+```mermaid
+---
+config: {"theme": "dark"}
+---
+flowchart TD
+    A[Detection Pipeline] -->|POST /api/v1/actions/execute| B
+
+    subgraph B[Alert Agent Service]
+        C[Subscription Config — YAML]
+        D[Dedup Engine]
+        E["Alert Action Agent<br/>(ADK / rule-based)"]
+        F["Tool Registry<br/>(built-in + MCP tools)"]
+        C --> D --> E --> F
+    end
+
+    F --> G[log_alert]
+    F --> H[trigger_webhook]
+    F --> I[publish_mqtt]
+    H --> J[capture_snapshot]
+    J --> K["SSE / WebSocket fanout<br/>to connected subscribers"]
+```
+
+## Components
+
+### Core Components
+
+1. **FastAPI Service Layer**
+   - **Description**: Primary entry point for client interactions. Exposes a RESTful API for dispatching alert actions, streaming events, and managing tools.
+   - **Functions**:
+     - Accepts multimodal alert payloads (text, image, audio, video, binary).
+     - Routes requests through the dedup engine, subscription config, and agent dispatcher.
+     - Fans out processed events to SSE and WebSocket subscribers.
+     - Provides OpenAPI (Swagger) documentation at `/docs`.
+
+2. **Alert Action Agent**
+   - **Description**: The central dispatch component that orchestrates tool invocation in either ADK (LLM-reasoned) or rule-based mode.
+   - **Functions**:
+     - In ADK mode: uses an LLM (served by OVMS) to decide which tools to invoke and in what order.
+     - In rule-based mode: directly invokes the ordered tool list from the request or subscription config.
+     - Handles escalation logic — invokes additional tools when a consecutive-detection threshold is reached.
+
+3. **Subscription Configuration**
+   - **Description**: YAML-based default routing rules that map alert names to tool lists, dedup settings, and escalation policies.
+   - **Functions**:
+     - Provides per-alert-name defaults for tools, tool arguments, dedup, and escalation.
+     - Per-request fields override these defaults, allowing fine-grained control.
+
+4. **Deduplication Engine**
+   - **Description**: Prevents duplicate alert actions within a configurable time window.
+   - **Functions**:
+     - Supports `field_hash` strategy — hashes specified alert context fields and suppresses repeat events within the window.
+     - Configurable per-alert in subscription config or per-request.
+
+5. **Tool Registry**
+   - **Description**: Dynamic registry of all available action tools (built-in and MCP-discovered).
+   - **Functions**:
+     - Loads built-in tools from `resources/tools.json` at startup.
+     - Discovers additional tools from configured MCP servers.
+     - Supports hot-reload without service restart (`POST /api/v1/tools/reload`).
+
+6. **MCP Client**
+   - **Description**: Model Context Protocol (MCP) client that connects to external MCP servers and exposes their tools as first-class actions.
+   - **Functions**:
+     - Connects to HTTP-based MCP servers defined in `resources/mcp_servers.json`.
+     - Registers discovered tools into the Tool Registry.
+     - Supports runtime reconnection and tool refresh (`POST /api/v1/mcp/reload`).
+
+7. **Event Manager (SSE + WebSocket)**
+   - **Description**: Real-time event broadcasting to connected clients after each dispatch.
+   - **Functions**:
+     - SSE stream at `GET /api/v1/events` — emits `alert_action`, `init`, `keepalive`, and `error` events.
+     - WebSocket stream at `GET /api/v1/ws` — mirrors the same events.
+
+### Built-in Action Tools
+
+| Tool | Description | Required Configuration |
+|------|-------------|----------------------|
+| `log_alert` | Logs the alert event to application logs | None |
+| `trigger_webhook` | HTTP POST to a configurable external endpoint, with optional HMAC-SHA256 signing | `WEBHOOK_URL` |
+| `capture_snapshot` | Saves the image payload from the request to disk | `SNAPSHOT_DIR` |
+| `publish_mqtt` | Publishes the alert to an MQTT broker topic | `MQTT_BROKER` |
+
+## Integration
+
+The service can be integrated into applications through:
+
+- REST API calls
+- Docker container deployment
+- Docker Compose orchestration
+
+## Limitations
+
+- OVMS LLM startup can take several minutes; the agent service waits for OVMS to become healthy before starting.
+- ADK mode requires a compatible chat-completion endpoint (OpenAI-compatible, served by OVMS).
+- For CPU-only Intel devices, set `TARGET_DEVICE=CPU` — inference latency will be higher than GPU but the full ADK pipeline remains functional.
+- MCP server connections are HTTP-based; stdio/process-based MCP transports are not currently supported.
+- The `capture_snapshot` tool only saves disk snapshots when the image payload is provided with `encoding=base64`; URI-based payloads are logged but not downloaded.

--- a/microservices/alert-agent-service/docs/user-guide/index.md
+++ b/microservices/alert-agent-service/docs/user-guide/index.md
@@ -2,120 +2,16 @@
 
 <!--hide_directive
 <div class="component_card_widget">
-  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-libraries/tree/main/microservices/alert-services/alert-agent-service">
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-libraries/tree/release-2026.2.0/microservices/alert-agent-service">
      GitHub
+  </a>
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/alert-agent-service/README.md">
+     Readme
   </a>
 </div>
 hide_directive-->
 
 The Alert Agent Service is a generic, multimodal alert action dispatcher microservice. It receives alert events from upstream detection pipelines (such as video analytics, audio sensors, or IoT devices), reasons over the alert context using an LLM-powered agentic backend, and dispatches one or more configurable action tools — such as logging, webhook notifications, MQTT publishing, and snapshot saving.
-
-## Architecture
-
-The service exposes a FastAPI-based REST API and supports two dispatch modes:
-
-- **ADK mode (default)**: Uses Google Agent Development Kit (ADK) backed by an OpenVINO Model Server (OVMS) LLM to reason over the alert and invoke tools autonomously.
-- **Rule-based mode**: Directly invokes the ordered list of tools specified in the request or subscription configuration without LLM reasoning.
-
-The following diagram illustrates the high-level architecture and data flow:
-
-```
-Detection Pipeline ──► POST /api/v1/actions/execute
-                              │
-                    ┌─────────▼──────────┐
-                    │  Alert Agent Service │
-                    │                      │
-                    │  ┌────────────────┐  │
-                    │  │  Subscription  │  │
-                    │  │  Config (YAML) │  │
-                    │  └───────┬────────┘  │
-                    │          │           │
-                    │  ┌───────▼────────┐  │
-                    │  │  Dedup Engine  │  │
-                    │  └───────┬────────┘  │
-                    │          │           │
-                    │  ┌───────▼────────┐  │
-                    │  │ Alert Action   │  │
-                    │  │ Agent (ADK/    │  │
-                    │  │ rule-based)    │  │
-                    │  └───────┬────────┘  │
-                    │          │           │
-                    │  ┌───────▼────────┐  │
-                    │  │  Tool Registry │  │
-                    │  │ (built-in +    │  │
-                    │  │  MCP tools)    │  │
-                    │  └───────┬────────┘  │
-                    └──────────┼───────────┘
-                               │
-                 ┌─────────────┼──────────────┐
-                 ▼             ▼              ▼
-           log_alert    trigger_webhook  publish_mqtt
-                             │
-                       capture_snapshot
-                             │
-                    SSE / WebSocket fanout
-                    to connected subscribers
-```
-
-## Components
-
-### Core Components
-
-1. **FastAPI Service Layer**
-   - **Description**: Primary entry point for client interactions. Exposes a RESTful API for dispatching alert actions, streaming events, and managing tools.
-   - **Functions**:
-     - Accepts multimodal alert payloads (text, image, audio, video, binary).
-     - Routes requests through the dedup engine, subscription config, and agent dispatcher.
-     - Fans out processed events to SSE and WebSocket subscribers.
-     - Provides OpenAPI (Swagger) documentation at `/docs`.
-
-2. **Alert Action Agent**
-   - **Description**: The central dispatch component that orchestrates tool invocation in either ADK (LLM-reasoned) or rule-based mode.
-   - **Functions**:
-     - In ADK mode: uses an LLM (served by OVMS) to decide which tools to invoke and in what order.
-     - In rule-based mode: directly invokes the ordered tool list from the request or subscription config.
-     - Handles escalation logic — invokes additional tools when a consecutive-detection threshold is reached.
-
-3. **Subscription Configuration**
-   - **Description**: YAML-based default routing rules that map alert names to tool lists, dedup settings, and escalation policies.
-   - **Functions**:
-     - Provides per-alert-name defaults for tools, tool arguments, dedup, and escalation.
-     - Per-request fields override these defaults, allowing fine-grained control.
-
-4. **Deduplication Engine**
-   - **Description**: Prevents duplicate alert actions within a configurable time window.
-   - **Functions**:
-     - Supports `field_hash` strategy — hashes specified alert context fields and suppresses repeat events within the window.
-     - Configurable per-alert in subscription config or per-request.
-
-5. **Tool Registry**
-   - **Description**: Dynamic registry of all available action tools (built-in and MCP-discovered).
-   - **Functions**:
-     - Loads built-in tools from `resources/tools.json` at startup.
-     - Discovers additional tools from configured MCP servers.
-     - Supports hot-reload without service restart (`POST /api/v1/tools/reload`).
-
-6. **MCP Client**
-   - **Description**: Model Context Protocol (MCP) client that connects to external MCP servers and exposes their tools as first-class actions.
-   - **Functions**:
-     - Connects to HTTP-based MCP servers defined in `resources/mcp_servers.json`.
-     - Registers discovered tools into the Tool Registry.
-     - Supports runtime reconnection and tool refresh (`POST /api/v1/mcp/reload`).
-
-7. **Event Manager (SSE + WebSocket)**
-   - **Description**: Real-time event broadcasting to connected clients after each dispatch.
-   - **Functions**:
-     - SSE stream at `GET /api/v1/events` — emits `alert_action`, `init`, `keepalive`, and `error` events.
-     - WebSocket stream at `GET /api/v1/ws` — mirrors the same events.
-
-### Built-in Action Tools
-
-| Tool | Description | Required Configuration |
-|------|-------------|----------------------|
-| `log_alert` | Logs the alert event to application logs | None |
-| `trigger_webhook` | HTTP POST to a configurable external endpoint, with optional HMAC-SHA256 signing | `WEBHOOK_URL` |
-| `capture_snapshot` | Saves the image payload from the request to disk | `SNAPSHOT_DIR` |
-| `publish_mqtt` | Publishes the alert to an MQTT broker topic | `MQTT_BROKER` |
 
 ## Key Features
 
@@ -129,15 +25,6 @@ Detection Pipeline ──► POST /api/v1/actions/execute
 - **SSE / WebSocket Streaming**: Real-time event fanout to monitoring dashboards and downstream consumers.
 - **Hot-Reload**: Refresh tool and MCP configurations at runtime without restarting the service.
 
-## Integration
-
-The service can be integrated into applications through:
-
-- REST API calls
-- Docker container deployment
-- Docker Compose orchestration
-- Helm chart deployment on Kubernetes
-
 ## Use Cases
 
 This microservice is ideal for:
@@ -147,19 +34,10 @@ This microservice is ideal for:
 - Multi-sensor environments (cameras, microphones, IoT) with unified alert handling
 - Monitoring dashboards consuming real-time alert event streams
 
-## Limitations
-
-- OVMS LLM startup can take several minutes; the agent service waits for OVMS to become healthy before starting.
-- ADK mode requires a compatible chat-completion endpoint (OpenAI-compatible, served by OVMS).
-- For CPU-only Intel devices, set `TARGET_DEVICE=CPU` — inference latency will be higher than GPU but the full ADK pipeline remains functional.
-- MCP server connections are HTTP-based; stdio/process-based MCP transports are not currently supported.
-- The `capture_snapshot` tool only saves disk snapshots when the image payload is provided with `encoding=base64`; URI-based payloads are logged but not downloaded.
-
 ## Learn More
 
 - [**Get Started Guide**](./get-started.md)
 - [**API Reference**](./api-reference.md)
-- [**Deploy with Helm Chart**](./get-started/deploy-with-helm-chart.md)
 - [**Release Notes**](./release-notes.md)
 
 <!--hide_directive
@@ -167,6 +45,7 @@ This microservice is ideal for:
 :hidden:
 
 ./get-started.md
+./how-it-works.md
 ./api-reference.md
 Release Notes <./release-notes.md>
 

--- a/microservices/alert-agent-service/docs/user-guide/release-notes.md
+++ b/microservices/alert-agent-service/docs/user-guide/release-notes.md
@@ -2,9 +2,9 @@
 
 ## Version 2026.2.0
 
-**TBD**
+**Release date:** TBD
 
-**New**
+**New:**
 
 - Initial release of the Alert Agent Service.
 - Generic multimodal alert action dispatcher supporting text, image, video, and binary payloads.
@@ -21,7 +21,7 @@
 - Liveness probe (`GET /api/v1/health`).
 - Docker Compose deployment with OVMS LLM sidecar container.
 
-**Known Issues**
+**Known Issues:**
 
 - OVMS LLM container startup may take up to 5 minutes while the model is downloaded and loaded for the first time.
 - MCP integration supports HTTP transport only; stdio/process-based MCP transports are not currently supported.


### PR DESCRIPTION
### Description

Prepare the Alert Agent Service docs for publication on the OEP docs site.

- rearrange info in `index.md` (Features and Use Cases)
- separate `how-it-works.md` from `index.md`
- replace the ASCII architecture diagram with Mermaid (dark mode)
- formatting
- clean up Helm references
- remove swagger plugin until `openapi.yaml` is added
- add README

Port from #2709 

### How Has This Been Tested?

Docs built locally.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.