### PR TITLE
[ViPPET] Cherry-pick demo fixes to release-2026.2.0

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/package-lock.json
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/package-lock.json
@@ -4333,9 +4333,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/demo/DemoMode.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/demo/DemoMode.tsx
@@ -225,6 +225,9 @@ const DemoMode = () => {
   const [densityJobId, setDensityJobId] = useState<string | null>(null);
   const handleStreamRateChange = useStreamRateChange(setPipelineSelections);
   const [performanceJobId, setPerformanceJobId] = useState<string | null>(null);
+  const [activeTest, setActiveTest] = useState<
+    "performance-test" | "density-test"
+  >("performance-test");
 
   useActiveJobSync(
     activeTest === "performance-test" ? performanceJobId : densityJobId,
@@ -272,9 +275,6 @@ const DemoMode = () => {
   );
   const [openConfigSection, setOpenConfigSection] =
     useState<string>("pipeline-config");
-  const [activeTest, setActiveTest] = useState<
-    "performance-test" | "density-test"
-  >("performance-test");
   const [lastRunTest, setLastRunTest] = useState<
     "performance-test" | "density-test"
   >("performance-test");
@@ -2232,7 +2232,7 @@ const DemoMode = () => {
                                   <div className="space-y-3">
                                     {/* Participation rate per pipeline */}
                                     <div className="space-y-2">
-                                      {pipelineSelections.map((selection) => {
+                                      {pipelineSelections.map((selection, index) => {
                                         const pipeline = pipelines.find(
                                           (p) => p.id === selection.pipelineId,
                                         );
@@ -2258,7 +2258,7 @@ const DemoMode = () => {
                                               value={selection.stream_rate}
                                               onChange={(val) =>
                                                 handleStreamRateChange(
-                                                  selection.pipelineId,
+                                                  index,
                                                   val,
                                                 )
                                               }


### PR DESCRIPTION
## Summary
This PR cherry-picks the demo-fix changes from `demo_fix` into `release-2026.2.0`.

### Included commits
- `bf2b012d` - Provide update to unlock demo mode
- `6881740b` - Update package version

## Scope
- UI demo mode update in ViPPET
- UI package lock version alignment
