### PR TITLE
[ViPPET] Multi-GPU render node selection handling and validation

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
@@ -200,6 +200,32 @@ _IMAGE_SET_VA_DECODERS: dict[str, list[str]] = {
     "tiff": [],
 }
 
+# Pre-process backends that make an inference element attach to a VA display.
+VA_PREPROC_BACKENDS = {
+    "va",
+    "va-surface-sharing",
+    "vaapi",
+    "vaapi-surface-sharing",
+}
+
+
+def _required_va_render_node(device: str) -> Optional[int]:
+    """Render node an inference element pins its VA display to.
+
+    Returns the index relative to ``/dev/dri/renderD128``, or None when the element
+    adopts the display created upstream (bare ``GPU``) and so fits any pipeline.
+    """
+    normalized = (device or "").upper()
+    if normalized == "GPU":
+        return None
+
+    family, index = split_device_target(normalized)
+    if family == "GPU":
+        return index
+
+    # CPU and NPU never inspect the upstream context; they open the first render node.
+    return 0
+
 
 def _image_set_caps_for_extension(extension: str) -> str:
     """
@@ -3403,6 +3429,59 @@ class Graph:
                     f"Camera source '{node.type}' requires a decodebin3 element to follow it, "
                     f"but found '{next_type}' instead"
                 )
+
+    def validate_inference_devices_share_va_display(self) -> None:
+        """Validate that every VA-accelerated inference element can reach the frames.
+
+        Decoded frames live in the memory of one GPU render node, and DL Streamer
+        cannot hand a VA surface from one physical device to another. Each inference
+        element pins its VA display as follows (see ``createVaDisplay`` in DL Streamer's
+        ``inference_impl.cpp``):
+
+        * ``device=GPU.N`` opens ``/dev/dri/renderD(128+N)``
+        * ``device=GPU`` adopts whichever display the upstream decoder created
+        * ``device=NPU`` / ``device=CPU`` always open ``/dev/dri/renderD128``
+
+        So an NPU element only composes with ``GPU``/``GPU.0``, and two different
+        indexed GPUs never compose. Both cases otherwise fail mid-run with an opaque
+        ``vaCreateSurfaces2 ... resource allocation failed``, so reject them up front.
+
+        Raises:
+            ValueError: If a VA-accelerated inference element requires a different
+                render node than the one the pipeline decodes into.
+        """
+        chain_device = self.get_target_device()
+        chain_family, chain_index = split_device_target(chain_device)
+
+        # A CPU-decoded pipeline carries system memory, so there is no VA display to share.
+        if chain_family not in {"GPU", "NPU"}:
+            return
+
+        chain_render_node = chain_index or 0
+
+        for node in self.nodes:
+            if not node.type.startswith("gva"):
+                continue
+            if node.data.get("pre-process-backend") not in VA_PREPROC_BACKENDS:
+                continue
+
+            device = str(node.data.get("device", "")).upper()
+            required_render_node = _required_va_render_node(device)
+            if (
+                required_render_node is None
+                or required_render_node == chain_render_node
+            ):
+                continue
+
+            raise ValueError(
+                f"Cannot run '{node.type}' (node '{node.id}') on {device}: this pipeline "
+                f"decodes into {chain_device.upper()} memory (/dev/dri/renderD{128 + chain_render_node}), "
+                f"while {device} inference needs /dev/dri/renderD{128 + required_render_node}. "
+                "Decoded video frames stay on the accelerator that produced them and cannot be "
+                "moved to another one. Please set every inference element to the same GPU. "
+                "NPU and CPU inference always use the first GPU, so they can only be paired "
+                "with GPU or GPU.0."
+            )
 
     @staticmethod
     def _build_v4l2_caps_node(

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/graph.py
@@ -16,7 +16,7 @@ from resources import (
     get_scripts_manager,
 )
 from utils import slugify_text
-from video_decoder import VideoDecoder
+from video_decoder import VideoDecoder, split_device_target
 from videos import VideosManager
 from images import ImagesManager
 
@@ -1726,8 +1726,8 @@ class Graph:
         in order.
 
         Returns:
-            Device name ("CPU", "GPU", "NPU"), or "CPU" as default
-            if no gva* node with device attribute is found.
+            Device name as written on the element ("CPU", "GPU", "GPU.1", "NPU"),
+            or "CPU" as default if no gva* node with device attribute is found.
         """
         # Build adjacency map for forward traversal
         edges_from: dict[str, list[str]] = {}
@@ -1918,7 +1918,10 @@ class Graph:
         Args:
             codec: Input stream codec (e.g., "h264", "h265", "MJPG", "YUYV"),
                 or None if codec cannot be determined (keeps decodebin3 as fallback).
-            target_device: Target device from gvadetect ("CPU", "GPU", "NPU").
+            target_device: Target device from gvadetect ("CPU", "GPU", "GPU.1", "NPU").
+                For an indexed GPU the VA elements bound to the matching render
+                node are used (e.g. varenderD129h264dec for GPU.1), so decoding
+                and inference share the same GPU.
 
         Returns:
             Modified Graph with decodebin3 replaced.
@@ -1985,10 +1988,10 @@ class Graph:
         if replacement_kind == "keep":
             return modified_graph
 
-        # Determine output caps type based on target device.
+        # Determine output caps type based on target device family.
         # VA-API decoders (GPU/NPU) output to VAMemory, CPU decoders output raw.
-        device_upper = target_device.upper()
-        if device_upper in {"GPU", "NPU"}:
+        device_family, _ = split_device_target(target_device)
+        if device_family in {"GPU", "NPU"}:
             output_caps_type = "video/x-raw(memory:VAMemory)"
         else:
             output_caps_type = "video/x-raw"
@@ -2003,7 +2006,7 @@ class Graph:
             n.type == "gvamotiondetect" for n in modified_graph.nodes
         )
         needs_post_decoder_converter = v4l2_caps_node_info is not None or (
-            has_gvamotiondetect and device_upper == "CPU"
+            has_gvamotiondetect and device_family == "CPU"
         )
 
         # Find max existing ID across all nodes and edges for generating new IDs
@@ -2041,8 +2044,8 @@ class Graph:
 
         for db_node_id in decodebin3_node_ids:
             if replacement_kind == "videoconvert":
-                if device_upper in {"GPU", "NPU"}:
-                    element_type = "vapostproc"
+                if device_family in {"GPU", "NPU"}:
+                    element_type = video_decoder.select_postproc(target_device)
                 else:
                     element_type = "videoconvert"
                 replacements.append((db_node_id, element_type, [], []))
@@ -2066,8 +2069,8 @@ class Graph:
                 if needs_post_decoder_converter:
                     converter_node_id = str(next_id)
                     next_id += 1
-                    if device_upper in {"GPU", "NPU"}:
-                        converter_element = "vapostproc"
+                    if device_family in {"GPU", "NPU"}:
+                        converter_element = video_decoder.select_postproc(target_device)
                     else:
                         converter_element = "videoconvert"
                     converter_node = Node(
@@ -2190,14 +2193,16 @@ class Graph:
             if db_node is None:
                 continue
 
-            if kind in {"videoconvert", "vapostproc"}:
+            if kind != "parsebin_decoder":
+                # ``kind`` is the replacement element itself: videoconvert,
+                # vapostproc or its render-node variant (varenderD129postproc).
                 db_node.type = kind
                 logger.debug(
                     f"Replaced decodebin3 (node {db_node_id}) with {kind} "
                     f"for raw format '{codec}'"
                 )
 
-            elif kind == "parsebin_decoder":
+            else:
                 # Rename decodebin3 → parsebin
                 db_node.type = "parsebin"
 
@@ -2419,7 +2424,7 @@ class Graph:
         # node we skip it, so calling ``_adapt_image_set_video_pipeline``
         # twice on the same graph (or running the same conversion
         # repeatedly in the UI) does not stack up adapter pairs.
-        _device_norm_step0 = (target_device or "").upper()
+        _device_norm_step0, _ = split_device_target(target_device)
         _skip_cpu_format_force = _device_norm_step0 in {"GPU", "NPU"}
 
         def _successor_already_forces_format(decoder_id: str) -> bool:
@@ -2627,7 +2632,7 @@ class Graph:
         # ``type`` literally starts with ``video/x-raw(memory:`` —
         # there is no GStreamer element with such a name, so this
         # cannot misfire on a real element.
-        _device_norm_step1b = (target_device or "").upper()
+        _device_norm_step1b, _ = split_device_target(target_device)
         _skip_va_downgrade = _device_norm_step1b in {"GPU", "NPU"}
         for node in self.nodes:
             if _skip_va_downgrade:
@@ -2703,11 +2708,11 @@ class Graph:
             VideoEncoder,
         )
 
-        device_norm = (target_device or "").upper()
+        device_norm, device_gpu_index = split_device_target(target_device)
         wants_va_encoder = device_norm in {"GPU", "NPU"}
         encoder_device = ENCODER_DEVICE_GPU if wants_va_encoder else ENCODER_DEVICE_CPU
         encoder_element_str = VideoEncoder()._select_element(
-            encoder_device, streaming=False
+            encoder_device, streaming=False, gpu_index=device_gpu_index
         )
         # Fallback: if the requested device has no available encoder
         # (e.g. running on a CPU-only host that still requested GPU),
@@ -2992,7 +2997,7 @@ class Graph:
                 ``"NPU"``). NPU is treated like GPU for the purpose of
                 memory hand-off (the VA-API stack handles both).
         """
-        device = (target_device or "").upper()
+        device, _ = split_device_target(target_device)
         wants_va_memory = device in {"GPU", "NPU"}
 
         # Map software decoder name -> image-set node id (the
@@ -3146,7 +3151,11 @@ class Graph:
 
             vapostproc_id = str(next_id_int)
             next_id_int += 1
-            vapostproc_node = Node(id=vapostproc_id, type="vapostproc", data={})
+            vapostproc_node = Node(
+                id=vapostproc_id,
+                type=VideoDecoder().select_postproc(target_device),
+                data={},
+            )
 
             caps_id = str(next_id_int)
             next_id_int += 1

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/pipeline_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/pipeline_manager.py
@@ -25,6 +25,7 @@ from utils import (
     load_thumbnail_as_base64,
     make_output_dir,
 )
+from video_decoder import split_device_target
 from video_encoder import VideoEncoder
 from videos import OUTPUT_VIDEO_DIR
 from managers.metadata_manager import METADATA_DIR
@@ -653,6 +654,7 @@ class PipelineManager:
             # video-centric templates (parsebin, avdec_h264, container muxers, ...)
             # have to be adapted to the raw-video stream produced by the dedicated
             # image decoder; ``apply_decodebin3_replacement`` handles both cases.
+            _, target_gpu_index = split_device_target(base_graph.get_target_device())
             if base_graph.has_decodebin3() or base_graph.has_image_set_source():
                 codec = base_graph.determine_input_codec()
                 target_device = base_graph.get_target_device()
@@ -674,12 +676,12 @@ class PipelineManager:
                 # Create output subpipeline based on output mode (file or live stream)
                 if output_mode == InternalOutputMode.FILE:
                     output_subpipeline = video_encoder.create_video_output_subpipeline(
-                        video_pipeline_dir, encoder_device
+                        video_pipeline_dir, encoder_device, target_gpu_index
                     )
                 elif output_mode == InternalOutputMode.LIVE_STREAM:
                     output_subpipeline, stream_url = (
                         video_encoder.create_live_stream_output_subpipeline(
-                            pipeline_id, encoder_device, job_id
+                            pipeline_id, encoder_device, job_id, target_gpu_index
                         )
                     )
                     live_stream_urls[pipeline_id] = stream_url

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/pipeline_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/pipeline_manager.py
@@ -629,6 +629,9 @@ class PipelineManager:
             # Validate camera sources (rtspsrc, v4l2src), if present, are followed by decodebin3
             base_graph.validate_camera_sources_followed_by_decodebin3()
 
+            # Validate all VA-accelerated inference elements share one GPU render node
+            base_graph.validate_inference_devices_share_va_display()
+
             # Validate pipeline has gvametapublish when metadata publishing is enabled
             if (
                 execution_config.metadata_mode != InternalMetadataMode.DISABLED

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/graph_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/graph_test.py
@@ -3512,6 +3512,91 @@ class TestNegativeCases(unittest.TestCase):
                 )
 
 
+class TestValidateInferenceDevicesShareVaDisplay(unittest.TestCase):
+    """Test cases for Graph.validate_inference_devices_share_va_display method."""
+
+    @staticmethod
+    def _graph(detect_device, detect_backend, classify_device, classify_backend):
+        return Graph(
+            nodes=[
+                Node(id="0", type="filesrc", data={"location": "test.mp4"}),
+                Node(id="1", type="decodebin3", data={}),
+                Node(
+                    id="2",
+                    type="gvadetect",
+                    data={
+                        "model": "d.xml",
+                        "device": detect_device,
+                        "pre-process-backend": detect_backend,
+                    },
+                ),
+                Node(
+                    id="3",
+                    type="gvaclassify",
+                    data={
+                        "model": "c.xml",
+                        "device": classify_device,
+                        "pre-process-backend": classify_backend,
+                    },
+                ),
+                Node(id="4", type="fakesink", data={}),
+            ],
+            edges=[
+                Edge(id="0", source="0", target="1"),
+                Edge(id="1", source="1", target="2"),
+                Edge(id="2", source="2", target="3"),
+                Edge(id="3", source="3", target="4"),
+            ],
+        )
+
+    def test_same_indexed_gpu_is_allowed(self):
+        graph = self._graph(
+            "GPU.1", "va-surface-sharing", "GPU.1", "va-surface-sharing"
+        )
+        graph.validate_inference_devices_share_va_display()
+
+    def test_default_gpu_with_npu_is_allowed(self):
+        """NPU pins renderD128, which is what a bare GPU pipeline decodes into."""
+        graph = self._graph("GPU", "va-surface-sharing", "NPU", "va")
+        graph.validate_inference_devices_share_va_display()
+
+    def test_bare_gpu_adopts_upstream_display(self):
+        """A bare GPU element reuses the upstream display, so it fits any render node."""
+        graph = self._graph("GPU.1", "va-surface-sharing", "GPU", "va-surface-sharing")
+        graph.validate_inference_devices_share_va_display()
+
+    def test_two_different_indexed_gpus_are_rejected(self):
+        graph = self._graph(
+            "GPU.1", "va-surface-sharing", "GPU.2", "va-surface-sharing"
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            graph.validate_inference_devices_share_va_display()
+        message = str(cm.exception)
+        self.assertIn("gvaclassify", message)
+        self.assertIn("renderD129", message)
+        self.assertIn("renderD130", message)
+
+    def test_indexed_gpu_with_npu_is_rejected(self):
+        graph = self._graph("GPU.1", "va-surface-sharing", "NPU", "va")
+
+        with self.assertRaises(ValueError) as cm:
+            graph.validate_inference_devices_share_va_display()
+        message = str(cm.exception)
+        self.assertIn("NPU", message)
+        self.assertIn("renderD128", message)
+
+    def test_cpu_pipeline_is_not_checked(self):
+        """A CPU-decoded pipeline carries system memory, so there is no display to share."""
+        graph = self._graph("CPU", "opencv", "NPU", "va")
+        graph.validate_inference_devices_share_va_display()
+
+    def test_non_va_backend_is_ignored(self):
+        """An element that never touches a VA display cannot mismatch."""
+        graph = self._graph("GPU.1", "va-surface-sharing", "CPU", "opencv")
+        graph.validate_inference_devices_share_va_display()
+
+
 class TestGetRecommendedEncoderDevice(unittest.TestCase):
     """Test cases for Graph.get_recommended_encoder_device method."""
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/video_decoder_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/video_decoder_test.py
@@ -8,6 +8,8 @@ from video_decoder import (
     FOURCC_TO_CAPS_PREFIX,
     RAW_FOURCC_CODES,
     VideoDecoder,
+    render_node_element,
+    split_device_target,
 )
 
 
@@ -349,6 +351,119 @@ class TestSelectElement(unittest.TestCase):
         }
         result = decoder.select_element(field_dict, DECODER_DEVICE_CPU)
         self.assertIsNone(result)
+
+
+class TestSplitDeviceTarget(unittest.TestCase):
+    """Test video_decoder.split_device_target()."""
+
+    def test_plain_families(self):
+        self.assertEqual(split_device_target("CPU"), ("CPU", None))
+        self.assertEqual(split_device_target("NPU"), ("NPU", None))
+        self.assertEqual(split_device_target("GPU"), ("GPU", 0))
+
+    def test_indexed_gpu(self):
+        self.assertEqual(split_device_target("GPU.0"), ("GPU", 0))
+        self.assertEqual(split_device_target("GPU.1"), ("GPU", 1))
+
+    def test_lowercase_is_normalized(self):
+        self.assertEqual(split_device_target("gpu.2"), ("GPU", 2))
+
+    def test_unparseable_index_returns_none(self):
+        self.assertEqual(split_device_target("GPU.bad"), ("GPU", None))
+
+    def test_empty_device(self):
+        self.assertEqual(split_device_target(""), ("", None))
+
+
+class TestRenderNodeElement(unittest.TestCase):
+    """Test video_decoder.render_node_element()."""
+
+    def test_non_default_gpu_is_qualified(self):
+        self.assertEqual(render_node_element("vah264dec", 1), "varenderD129h264dec")
+        self.assertEqual(render_node_element("vapostproc", 2), "varenderD130postproc")
+
+    def test_default_gpu_is_not_qualified(self):
+        self.assertIsNone(render_node_element("vah264dec", 0))
+        self.assertIsNone(render_node_element("vah264dec", None))
+
+    def test_non_va_element_is_not_qualified(self):
+        self.assertIsNone(render_node_element("avdec_h264", 1))
+
+
+class TestMultiGpuDecoderSelection(unittest.TestCase):
+    """Test decoder/postproc selection for non-default GPU targets."""
+
+    def setUp(self):
+        VideoDecoder._instance = None
+
+    def tearDown(self):
+        VideoDecoder._instance = None
+
+    @patch("video_decoder.GstInspector")
+    def test_gpu_1_selects_render_node_decoder(self, mock_gst_inspector):
+        """GPU.1 selects the decoder bound to the matching render node."""
+        mock_instance = MagicMock()
+        mock_instance.elements = [
+            ("plugin", "vah264dec", "desc"),
+            ("plugin", "varenderD129h264dec", "desc"),
+            ("plugin", "avdec_h264", "desc"),
+        ]
+        mock_gst_inspector.return_value = mock_instance
+
+        decoder = VideoDecoder()
+        result = decoder.select_decoder("h264", "GPU.1")
+        self.assertEqual(result, "varenderD129h264dec")
+
+    @patch("video_decoder.GstInspector")
+    def test_gpu_0_selects_default_decoder(self, mock_gst_inspector):
+        """GPU.0 keeps the unqualified VA decoder."""
+        mock_instance = MagicMock()
+        mock_instance.elements = [
+            ("plugin", "vah264dec", "desc"),
+            ("plugin", "varenderD129h264dec", "desc"),
+        ]
+        mock_gst_inspector.return_value = mock_instance
+
+        decoder = VideoDecoder()
+        result = decoder.select_decoder("h264", "GPU.0")
+        self.assertEqual(result, "vah264dec")
+
+    @patch("video_decoder.GstInspector")
+    def test_gpu_1_falls_back_to_default_va_decoder(self, mock_gst_inspector):
+        """Missing render-node decoder falls back to the default VA decoder."""
+        mock_instance = MagicMock()
+        mock_instance.elements = [
+            ("plugin", "vah264dec", "desc"),
+            ("plugin", "avdec_h264", "desc"),
+        ]
+        mock_gst_inspector.return_value = mock_instance
+
+        decoder = VideoDecoder()
+        result = decoder.select_decoder("h264", "GPU.1")
+        self.assertEqual(result, "vah264dec")
+
+    @patch("video_decoder.GstInspector")
+    def test_select_postproc_for_gpu_1(self, mock_gst_inspector):
+        mock_instance = MagicMock()
+        mock_instance.elements = [
+            ("plugin", "vapostproc", "desc"),
+            ("plugin", "varenderD129postproc", "desc"),
+        ]
+        mock_gst_inspector.return_value = mock_instance
+
+        decoder = VideoDecoder()
+        self.assertEqual(decoder.select_postproc("GPU.1"), "varenderD129postproc")
+        self.assertEqual(decoder.select_postproc("GPU"), "vapostproc")
+        self.assertEqual(decoder.select_postproc("NPU"), "vapostproc")
+
+    @patch("video_decoder.GstInspector")
+    def test_select_postproc_falls_back_when_unavailable(self, mock_gst_inspector):
+        mock_instance = MagicMock()
+        mock_instance.elements = [("plugin", "vapostproc", "desc")]
+        mock_gst_inspector.return_value = mock_instance
+
+        decoder = VideoDecoder()
+        self.assertEqual(decoder.select_postproc("GPU.1"), "vapostproc")
 
 
 class TestConstants(unittest.TestCase):

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/video_encoder_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/video_encoder_test.py
@@ -111,6 +111,68 @@ class TestVideoEncoderClass(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch("video_encoder.GstInspector")
+    def test_select_element_gpu_index_uses_render_node_encoder(
+        self, mock_gst_inspector
+    ):
+        """Test that GPU.1 selects the encoder bound to renderD129."""
+        mock_gst_inspector_instance = MagicMock()
+        mock_gst_inspector_instance.elements = [
+            ("elem1", "vah264lpenc"),
+            ("elem2", "varenderD129h264lpenc"),
+        ]
+        mock_gst_inspector.return_value = mock_gst_inspector_instance
+
+        encoder = VideoEncoder()
+
+        result = encoder._select_element(ENCODER_DEVICE_GPU, gpu_index=1)
+        self.assertEqual(result, "varenderD129h264lpenc")
+
+    @patch("video_encoder.GstInspector")
+    def test_select_element_gpu_index_keeps_streaming_properties(
+        self, mock_gst_inspector
+    ):
+        """Test that render-node qualification preserves encoder properties."""
+        mock_gst_inspector_instance = MagicMock()
+        mock_gst_inspector_instance.elements = [("elem1", "varenderD129h264lpenc")]
+        mock_gst_inspector.return_value = mock_gst_inspector_instance
+
+        encoder = VideoEncoder()
+
+        result = encoder._select_element(
+            ENCODER_DEVICE_GPU, streaming=True, gpu_index=1
+        )
+        self.assertEqual(
+            result, "varenderD129h264lpenc bitrate=16000 target-usage=4 max-qp=30"
+        )
+
+    @patch("video_encoder.GstInspector")
+    def test_select_element_gpu_index_falls_back_to_default(self, mock_gst_inspector):
+        """Test fallback to the default VA encoder when the render node variant is missing."""
+        mock_gst_inspector_instance = MagicMock()
+        mock_gst_inspector_instance.elements = [("elem1", "vah264lpenc")]
+        mock_gst_inspector.return_value = mock_gst_inspector_instance
+
+        encoder = VideoEncoder()
+
+        result = encoder._select_element(ENCODER_DEVICE_GPU, gpu_index=1)
+        self.assertEqual(result, "vah264lpenc")
+
+    @patch("video_encoder.GstInspector")
+    def test_select_element_gpu_index_zero_uses_default(self, mock_gst_inspector):
+        """Test that GPU.0 keeps the unqualified VA encoder."""
+        mock_gst_inspector_instance = MagicMock()
+        mock_gst_inspector_instance.elements = [
+            ("elem1", "vah264lpenc"),
+            ("elem2", "varenderD129h264lpenc"),
+        ]
+        mock_gst_inspector.return_value = mock_gst_inspector_instance
+
+        encoder = VideoEncoder()
+
+        result = encoder._select_element(ENCODER_DEVICE_GPU, gpu_index=0)
+        self.assertEqual(result, "vah264lpenc")
+
+    @patch("video_encoder.GstInspector")
     def test_create_video_output_subpipeline(self, mock_gst_inspector):
         """Test creating video output subpipeline."""
         mock_gst_inspector_instance = MagicMock()

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/video_decoder.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/video_decoder.py
@@ -8,6 +8,12 @@ from explore import GstInspector
 DECODER_DEVICE_CPU = "CPU"
 DECODER_DEVICE_GPU = "GPU"
 
+# VA elements are registered per DRM render node: GPU.N maps to
+# /dev/dri/renderD(128+N) and is exposed by GStreamer as
+# varenderD129h264dec / varenderD129postproc / ... for N > 0.
+# GPU.0 (and plain "GPU") keeps the unqualified vah264dec / vapostproc names.
+RENDER_NODE_BASE = 128
+
 # Normalize various fourcc/encoding strings to a canonical codec name
 FOURCC_TO_CODEC = {
     "MJPG": "mjpg",
@@ -63,6 +69,49 @@ FOURCC_TO_CAPS_PREFIX = {
 }
 
 logger = logging.getLogger("video_decoder")
+
+
+def split_device_target(target_device: str) -> Tuple[str, Optional[int]]:
+    """Split an OpenVINO device string into its family and GPU index.
+
+    Args:
+        target_device: Device string such as "CPU", "GPU", "GPU.1" or "NPU".
+
+    Returns:
+        Tuple of (family, gpu_index). Family is the upper-cased part before
+        the dot (e.g. "GPU" for "GPU.1"). gpu_index is the parsed index for
+        GPU devices (0 for plain "GPU"), and None for every other family or
+        when the index is not a number.
+    """
+    family, _, index = (target_device or "").upper().partition(".")
+
+    if family != DECODER_DEVICE_GPU:
+        return family, None
+    if not index:
+        return family, 0
+    if not index.isdigit():
+        logger.warning(f"Unparseable GPU index in device '{target_device}'")
+        return family, None
+
+    return family, int(index)
+
+
+def render_node_element(element: str, gpu_index: Optional[int]) -> Optional[str]:
+    """Build the render-node-qualified name of a VA element for a given GPU.
+
+    Args:
+        element: Unqualified VA element name (e.g. "vah264dec", "vapostproc").
+        gpu_index: GPU index from ``split_device_target``.
+
+    Returns:
+        Qualified element name (e.g. "varenderD129h264dec" for gpu_index 1),
+        or None when the default render node applies or the element is not a
+        VA element.
+    """
+    if not gpu_index or not element.startswith("va"):
+        return None
+
+    return f"varenderD{RENDER_NODE_BASE + gpu_index}{element[len('va') :]}"
 
 
 class VideoDecoder:
@@ -130,19 +179,29 @@ class VideoDecoder:
             },
         }
 
+    def _is_available(self, element: str) -> bool:
+        """Check whether a GStreamer element is registered on this system."""
+        return any(known[1] == element for known in self.gst_inspector.elements)
+
     def select_element(
         self,
         field_dict: Dict[str, List[Tuple[str, str]]],
         decoder_device: str,
+        gpu_index: Optional[int] = None,
     ) -> Optional[str]:
         """Select an appropriate decoder element from available GStreamer elements.
 
         Iterates candidate tuples (search, result) for the given device and
         checks if the search element exists in GstInspector.elements.
 
+        For a non-default GPU the render-node-qualified variant of a VA
+        candidate (e.g. "varenderD129h264dec" for GPU.1) is preferred, so the
+        decoder runs on the same GPU as inference and VA surfaces can be shared.
+
         Args:
             field_dict: Dictionary mapping device types to lists of (search, result) tuples.
             decoder_device: Target decoder device (DECODER_DEVICE_CPU or DECODER_DEVICE_GPU).
+            gpu_index: GPU index for GPU targets, used to pick the matching render node.
 
         Returns:
             Selected decoder element string, or None if not found.
@@ -156,15 +215,43 @@ class VideoDecoder:
             return None
 
         for search, result in pairs:
-            for element in self.gst_inspector.elements:
-                if element[1] == search:
-                    self.logger.debug(f"Selected decoder element: {result}")
-                    return result
+            qualified_search = render_node_element(search, gpu_index)
+            if qualified_search is not None:
+                if self._is_available(qualified_search):
+                    qualified_result = render_node_element(result, gpu_index)
+                    self.logger.debug(f"Selected decoder element: {qualified_result}")
+                    return qualified_result
+                self.logger.warning(
+                    f"'{qualified_search}' is not available; decoding may not run "
+                    f"on GPU.{gpu_index}"
+                )
+
+            if self._is_available(search):
+                self.logger.debug(f"Selected decoder element: {result}")
+                return result
 
         self.logger.warning(
             f"No matching decoder element found for decoder_device: {decoder_device}"
         )
         return None
+
+    def select_postproc(self, target_device: str) -> str:
+        """Select the VA postprocessor matching the target GPU render node.
+
+        Args:
+            target_device: Target inference device ("GPU", "GPU.1", "NPU", ...).
+
+        Returns:
+            "varenderD129postproc"-style element for a non-default GPU when it
+            is available, otherwise "vapostproc".
+        """
+        _, gpu_index = split_device_target(target_device)
+        qualified = render_node_element("vapostproc", gpu_index)
+
+        if qualified is not None and self._is_available(qualified):
+            return qualified
+
+        return "vapostproc"
 
     def select_decoder(self, codec: str, target_device: str) -> Optional[str]:
         """Select the best available decoder element for a codec and device.
@@ -172,11 +259,11 @@ class VideoDecoder:
         Args:
             codec: Codec string (raw fourcc like "MJPG", or normalized like "h264").
                 Normalized via FOURCC_TO_CODEC. If raw format, returns None.
-            target_device: Target inference device ("CPU", "GPU", "NPU").
+            target_device: Target inference device ("CPU", "GPU", "GPU.1", "NPU").
                 NPU maps to GPU for decoder selection.
 
         Returns:
-            Decoder element name (e.g., "vah264dec"), or None if:
+            Decoder element name (e.g., "vah264dec", "varenderD129h264dec"), or None if:
             - fourcc is a raw format (no decoding needed)
             - fourcc is unknown (caller should keep decodebin3)
             - no decoder element is available
@@ -197,7 +284,7 @@ class VideoDecoder:
             return None
 
         # Map NPU to GPU for decoder selection (VA-API decoders live on GPU)
-        device = target_device.upper()
+        device, gpu_index = split_device_target(target_device)
         if device == "NPU":
             device = DECODER_DEVICE_GPU
 
@@ -214,7 +301,7 @@ class VideoDecoder:
             self.logger.warning(f"No decoder config for codec '{normalized}'")
             return None
 
-        return self.select_element(config, device)
+        return self.select_element(config, device, gpu_index)
 
     def build_caps_string(
         self, fourcc: str, width: int, height: int, fps: float

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/video_encoder.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/video_encoder.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Tuple
 
 from explore import GstInspector
 from utils import slugify_text
+from video_decoder import render_node_element
 
 # Constants for encoder device types
 ENCODER_DEVICE_CPU = "CPU"
@@ -118,6 +119,7 @@ class VideoEncoder:
         self,
         output_dir: str,
         encoder_device: str,
+        gpu_index: Optional[int] = None,
     ) -> str:
         """
         Create a sub-pipeline string for replacing a single fakesink with video encoder and file sink.
@@ -135,6 +137,8 @@ class VideoEncoder:
             encoder_device: Target encoder device. Must be one of the module constants:
                 - ENCODER_DEVICE_CPU ("CPU"): Use CPU-based encoder
                 - ENCODER_DEVICE_GPU ("GPU"): Use GPU-based encoder (VAAPI)
+            gpu_index: GPU index of the target device, used to pick the VA encoder
+                bound to the same render node (e.g. varenderD129h264lpenc for GPU.1).
 
         Returns:
             Sub-pipeline string for replacing fakesink.
@@ -144,7 +148,9 @@ class VideoEncoder:
         """
         # Select the best available h264 encoder element based on device type and
         # installed GStreamer plugins (e.g., vah264enc for GPU, openh264enc for CPU)
-        encoder_element = self._select_element(encoder_device, streaming=False)
+        encoder_element = self._select_element(
+            encoder_device, streaming=False, gpu_index=gpu_index
+        )
 
         if encoder_element is None:
             self.logger.error(
@@ -173,6 +179,7 @@ class VideoEncoder:
         pipeline_id: str,
         encoder_device: str,
         job_id: str,
+        gpu_index: Optional[int] = None,
     ) -> Tuple[str, str]:
         """
         Create a sub-pipeline string for replacing a single fakesink with live-streaming output.
@@ -189,6 +196,8 @@ class VideoEncoder:
                 - ENCODER_DEVICE_CPU ("CPU"): Use CPU-based encoder
                 - ENCODER_DEVICE_GPU ("GPU"): Use GPU-based encoder (VAAPI)
             job_id: Unique job identifier used to generate unique stream name
+            gpu_index: GPU index of the target device, used to pick the VA encoder
+                bound to the same render node (e.g. varenderD129h264lpenc for GPU.1).
 
         Returns:
             Tuple of (sub-pipeline string, live stream URL)
@@ -207,7 +216,9 @@ class VideoEncoder:
 
         # Select the best available h264 streaming encoder element based on device type
         # and installed GStreamer plugins (e.g., vah264enc for GPU, openh264enc for CPU)
-        encoder_element = self._select_element(encoder_device, streaming=True)
+        encoder_element = self._select_element(
+            encoder_device, streaming=True, gpu_index=gpu_index
+        )
 
         if encoder_element is None:
             self.logger.error(
@@ -229,11 +240,16 @@ class VideoEncoder:
         self,
         encoder_device: str,
         streaming: bool = False,
+        gpu_index: Optional[int] = None,
     ) -> Optional[str]:
         """
         Select an appropriate h264 encoder element from available GStreamer elements.
 
         Uses ENCODER_CONFIG or STREAMING_ENCODER_CONFIG based on the streaming flag.
+
+        For a non-default GPU the render-node-qualified variant of a VA encoder
+        (e.g. varenderD129h264lpenc for GPU.1) is preferred, so the encoder consumes
+        VA surfaces from the GPU that produced them.
 
         Args:
             encoder_device: Target encoder device. Must be one of the module constants:
@@ -241,6 +257,8 @@ class VideoEncoder:
                 - ENCODER_DEVICE_GPU ("GPU"): Use GPU-based encoder (VAAPI)
             streaming: If True, use low-latency streaming encoder config.
                 If False, use standard file output encoder config.
+            gpu_index: GPU index of the target device, used to pick the encoder
+                bound to the matching render node.
 
         Returns:
             Selected encoder element string with properties, or None if not found
@@ -265,11 +283,24 @@ class VideoEncoder:
             )
             return None
 
+        available = {element[1] for element in self.gst_inspector.elements}
+
         for search, result in pairs:
-            for element in self.gst_inspector.elements:
-                if element[1] == search:
-                    self.logger.debug(f"Selected encoder element: {result}")
-                    return result
+            qualified_search = render_node_element(search, gpu_index)
+            if qualified_search is not None:
+                if qualified_search in available:
+                    # ``result`` carries encoder properties, so only swap the element name.
+                    qualified_result = result.replace(search, qualified_search, 1)
+                    self.logger.debug(f"Selected encoder element: {qualified_result}")
+                    return qualified_result
+                self.logger.warning(
+                    f"'{qualified_search}' is not available; encoding may not run "
+                    f"on GPU.{gpu_index}"
+                )
+
+            if search in available:
+                self.logger.debug(f"Selected encoder element: {result}")
+                return result
 
         self.logger.warning(
             f"No matching encoder element found for encoder_device: {encoder_device}"


### PR DESCRIPTION
### Description

**Select VA elements matching the target GPU render node**

Pipelines targeting a non-default GPU (device=GPU.1) failed at runtime with "For system memory only supports ie, opencv image preprocessors", preceded by "Unknown device 'GPU.1', defaulting to CPU for decoder".

Two problems:

1. The device string was compared against the bare set {"CPU","GPU","NPU"}, so "GPU.1" matched nothing. Decoding fell back to avdec_h264 (system memory) while gvadetect/gvaclassify still requested pre-process-backend=va-surface-sharing, which requires VA memory.

2. Even once the family matched, plain vah264dec/vapostproc/vah264lpenc bind to /dev/dri/renderD128 (GPU.0). GPU.N maps to renderD(128+N) and is registered as varenderD129h264dec, varenderD129postproc, varenderD129h264lpenc, etc. Using the unqualified names would create VA surfaces on a different GPU than the one running inference.

Add split_device_target() and render_node_element() to video_decoder, route every {"GPU","NPU"} check through the parsed device family, and prefer the render-node-qualified decoder, postprocessor and encoder for an indexed GPU, falling back to the default VA element with a warning when it is not registered.

**Reject inference device combinations that cannot share VA memory**

Decoded frames live in the memory of one GPU render node, and DL Streamer cannot hand a VA surface from one physical device to another. A pipeline that mixes devices dies on the first frame might fail with:

>   Failed to submit images to inference / Unable to convert image using VA-API
>   / vaCreateSurfaces2(...) failed, sts=2 resource allocation failed

DL Streamer's createVaDisplay() pins the display per element: device=GPU.N opens /dev/dri/renderD(128+N), a bare device=GPU adopts the display created upstream, and device=NPU or device=CPU always open renderD128 regardless of what decoded the stream. So two indexed GPUs never compose, and an NPU element only composes with GPU or GPU.0.

Validate this before launching and explain it in terms the user can act on, naming the offending element, both render nodes and the NPU/CPU restriction. Only VA-accelerated elements are checked; an opencv or ie pre-process backend never attaches to a VA display, and a CPU-decoded pipeline carries system memory with no display to share.

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Added tests and manual verifications on machines with multiple GPU's.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

