### PR TITLE
[VSS][Fix] VSS defaults update: refresh Qwen model IDs and replace hardcoded MinIO host path with Docker volume

### DIFF
--- a/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/.github/copilot-instructions.md
+++ b/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/.github/copilot-instructions.md
@@ -101,7 +101,7 @@ the storage backend with `MM_DATAPREP_STORAGE_BACKEND` (`minio` or `local`).
 - `setup.sh` exports `INDEX_NAME=video-rag`; compose maps it to
   `DB_COLLECTION`.
 - Volumes `dataprep-yolox-models`, `ov-models`, `data-prep` hold model/scratch
-  state; MinIO persists to `MINIO_MOUNT_PATH` (default `/mnt/miniodata`).
+  state; MinIO persists to the named Docker volume `minio_data`.
 - A 413 may come from an upstream proxy/server; the source upload endpoint has
   no implemented size check and buffers the full body. Stage large files in
   MinIO and use `POST /videos/minio`.

--- a/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/docker/compose-milvus.yaml
+++ b/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/docker/compose-milvus.yaml
@@ -30,7 +30,7 @@ services:
             - '${MINIO_API_HOST_PORT:-6010}:9000'
             - '${MINIO_CONSOLE_HOST_PORT:-6011}:9001'
         volumes:
-            - '${MINIO_MOUNT_PATH:-/mnt/miniodata}:/data'
+            - 'minio_data:/data'
         command: |
             server /data 
             --address ":9000" 
@@ -205,6 +205,8 @@ networks:
         driver: bridge
 
 volumes:
+    minio_data:
+        driver: local
     dataprep-yolox-models:
         driver: local
     ov-models:

--- a/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/docker/compose.yaml
+++ b/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/docker/compose.yaml
@@ -10,7 +10,7 @@ services:
             - '${MINIO_API_HOST_PORT:-6010}:9000'
             - '${MINIO_CONSOLE_HOST_PORT:-6011}:9001'
         volumes:
-            - '${MINIO_MOUNT_PATH:-/mnt/miniodata}:/data'
+            - 'minio_data:/data'
         command: |
             server /data 
             --address ":9000" 
@@ -153,6 +153,8 @@ networks:
         driver: bridge
 
 volumes:
+    minio_data:
+        driver: local
     dataprep-yolox-models:
         driver: local
     ov-models:

--- a/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/setup.sh
+++ b/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/setup.sh
@@ -99,8 +99,6 @@ export MINIO_HOST="minio-server"
 export MINIO_API_HOST_PORT=${MINIO_API_HOST_PORT:-6010}
 # Port on which we want to access Minio Console outside container i.e. on host.
 export MINIO_CONSOLE_HOST_PORT=${MINIO_CONSOLE_HOST_PORT:-6011}
-# Mount point for Minio objects storage. This helps persist objects stored on minio server.
-export MINIO_MOUNT_PATH="/mnt/miniodata"
 
 # Env vars for vdms-vector-db ---------------------------------------
 export VDMS_STORAGE=aws

--- a/sample-applications/video-search-and-summarization/.env.example
+++ b/sample-applications/video-search-and-summarization/.env.example
@@ -58,7 +58,7 @@ APP_HOST_PORT=12345
 # ==============================================================================
 
 # Vision-Language Model used for frame captioning and summarization.
-VLM_MODEL_NAME=Qwen/Qwen2.5-VL-3B-Instruct
+VLM_MODEL_NAME=Qwen/Qwen3-VL-4B-Instruct
 VLM_TARGET_DEVICE=CPU
 VLM_COMPRESSION_WEIGHT_FORMAT=int8
 
@@ -90,7 +90,7 @@ VLLM_RPC_TIMEOUT=100000
 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
 
 # OVMS LLM model (used when USE_VLLM=CONFIG_OFF and OVMS path is active).
-# OVMS_LLM_MODEL_NAME=Intel/neural-chat-7b-v3-3
+# OVMS_LLM_MODEL_NAME=Qwen/Qwen3-4B-Instruct-2507
 LLM_TARGET_DEVICE=CPU
 LLM_COMPRESSION_WEIGHT_FORMAT=
 

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-deploy-helm/SKILL.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-deploy-helm/SKILL.md
@@ -70,7 +70,7 @@ global:
   usePvc: true
   keepPvc: true
   huggingfaceToken: "hf_..."   # needed for gated/private Hugging Face models
-  vlmName: "Qwen/Qwen2.5-VL-3B-Instruct"
+  vlmName: "Qwen/Qwen3-VL-4B-Instruct"
   llmName: ""                  # optional OVMS split-model summarization model
   embeddingModelName: ""       # set per mode below
   modelDownload:

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-deploy/vss.config.env
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-deploy/vss.config.env
@@ -24,13 +24,13 @@ export REGISTRY_URL=intel
 export TAG=latest
 
 # --- Summary stack models (required for --summary / --dual / --unified) ---
-export VLM_MODEL_NAME="Qwen/Qwen2.5-VL-3B-Instruct"
+export VLM_MODEL_NAME="Qwen/Qwen3-VL-4B-Instruct"
 export VLM_COMPRESSION_WEIGHT_FORMAT=int8
 export ENABLED_WHISPER_MODELS="tiny.en,small.en,medium.en"
 export OD_MODEL_NAME="yolov8l"
 # GPU alternative: export VLM_MODEL_NAME="OpenVINO/Phi-3.5-vision-instruct-int8-ov"; export VLM_TARGET_DEVICE=GPU
 # Optional split-model OVMS mode:
-# export OVMS_LLM_MODEL_NAME="Intel/neural-chat-7b-v3-3"
+# export OVMS_LLM_MODEL_NAME="Qwen/Qwen3-4B-Instruct-2507"
 # export LLM_TARGET_DEVICE=CPU
 
 # --- Model download service used transiently by setup.sh ---

--- a/sample-applications/video-search-and-summarization/Makefile
+++ b/sample-applications/video-search-and-summarization/Makefile
@@ -140,7 +140,7 @@ ALL_IMAGES  := $(DEP_IMAGES) $(APP_IMAGES)
 
 TEST_TARGETS := $(addprefix test-,$(TEST_COMPONENTS))
 
-.PHONY: build build-deps push check-docker check-poetry test clean help list \
+.PHONY: build build-deps push check-docker test clean help list \
         shellcheck pylint eslint \
         trivy-scan trivy-scan-fs trivy-scan-image trivy-scan-config \
         clamav-scan bandit-scan gitleaks-scan codeql-scan \
@@ -159,13 +159,7 @@ check-docker:
 	  { echo "docker is not installed or not in PATH."; \
 	    echo "   Install: https://docs.docker.com/get-docker/"; exit 1; }
 
-check-poetry:
-	@command -v poetry >/dev/null 2>&1 || \
-	  { echo "poetry is not installed or not in PATH."; \
-	    echo "   Required to build the multimodal-embedding wheel."; \
-	    echo "   Install: https://python-poetry.org/docs/#installation"; exit 1; }
-
-build: check-docker check-poetry
+build: check-docker
 	@$(if $(REGISTRY),,echo "Warning: No registry prefix set. Images will be tagged without a registry prefix.")
 	@echo "Building all application services..."
 	@$(foreach component,$(COMPONENTS), \
@@ -177,8 +171,7 @@ build: check-docker check-poetry
 	@echo "All application services built successfully."
 
 # Build external dependency microservices (multimodal-dataprep, multimodal-embedding-serving).
-# Requires poetry to build the multimodal-embedding wheel.
-build-deps: check-docker check-poetry
+build-deps: check-docker
 	@$(if $(REGISTRY),,echo "Warning: No registry prefix set. Images will be tagged without a registry prefix.")
 	@echo "Building dependency microservices..."
 	@echo "  → Building multimodal-dataprep via upstream build.sh..."
@@ -840,7 +833,7 @@ help:
 	@echo "  build            Build application service images (video-ingestion,"
 	@echo "                   pipeline-manager, video-search, vss-ui)"
 	@echo "  build-deps       Build dependency images (multimodal-dataprep,"
-	@echo "                   multimodal-embedding-serving) — requires poetry"
+	@echo "                   multimodal-embedding-serving)"
 	@echo "  push             Push all built images to the registry"
 	@echo "  test             Run all unit tests"
 	@echo "  test-pipeline-manager   Run pipeline-manager tests (NestJS/Jest)"

--- a/sample-applications/video-search-and-summarization/chart/templates/model-download-helper.yaml
+++ b/sample-applications/video-search-and-summarization/chart/templates/model-download-helper.yaml
@@ -25,7 +25,7 @@ data:
   #
   # Required env vars (set by OVMS deployment init container):
   #   MODEL_TYPE    "vlm" or "llm" (the model-download `type` field)
-  #   MODEL_NAME    HuggingFace model id, e.g. "Qwen/Qwen2.5-VL-3B-Instruct"
+  #   MODEL_NAME    HuggingFace model id
   #   WEIGHT_FORMAT Compression precision, e.g. "int8" or "int4"
   #   DEVICE        Target device in lowercase, e.g. "cpu", "gpu" or "hetero:gpu,cpu"
   # ---------------------------------------------------------------------------

--- a/sample-applications/video-search-and-summarization/docs/user-guide/deploy-with-helm.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/deploy-with-helm.md
@@ -88,8 +88,8 @@ Update or edit the values in YAML file as follows:
 | `global.huggingfaceToken` | Your Hugging Face API token | `<your-huggingface-token>` |
 | `global.proxy.http_proxy` | HTTP proxy if required | `http://proxy-example.com:000` |
 | `global.proxy.https_proxy` | HTTPS proxy if required | `http://proxy-example.com:000` |
-| `global.vlmName` | VLM model to be used by OVMS or vLLM for captioning and summarization | `Qwen/Qwen2.5-VL-3B-Instruct` (CPU) or `OpenVINO/Phi-3.5-vision-instruct-int8-ov` (GPU) |
-| `global.llmName` | Optional separate LLM model for final summarization (OVMS split-model mode). Leave empty for shared-model mode. | `Intel/neural-chat-7b-v3-3` (CPU) or `Intel/neural-chat-7b-v3-3` (GPU) or `OpenVINO/Qwen3-8B-int4-cw-ov` (NPU) |
+| `global.vlmName` | VLM model to be used by OVMS or vLLM for captioning and summarization | `Qwen/Qwen3-VL-4B-Instruct` (CPU) or `OpenVINO/Phi-3.5-vision-instruct-int8-ov` (GPU) |
+| `global.llmName` | Optional separate LLM model for final summarization (OVMS split-model mode). Leave empty for shared-model mode. | `Qwen/Qwen3-4B-Instruct-2507` (CPU) or `Qwen/Qwen3-4B-Instruct-2507` (GPU) or `OpenVINO/Qwen3-8B-int4-cw-ov` (NPU) |
 | `global.env.POSTGRES_USER` | PostgreSQL user | `<your-postgres-user>` |
 | `global.env.POSTGRES_PASSWORD` | PostgreSQL password | `<your-postgres-password>` |
 | `global.env.MINIO_ROOT_USER` | MinIO server user name | `<your-minio-user>` (at least 3 characters) |
@@ -222,8 +222,8 @@ To use a separate LLM model for final summarization while using VLM for captioni
 
 ```yaml
 global:
-  vlmName: "Qwen/Qwen2.5-VL-3B-Instruct"
-  llmName: "Intel/neural-chat-7b-v3-3"
+  vlmName: "Qwen/Qwen3-VL-4B-Instruct"
+  llmName: "Qwen/Qwen3-4B-Instruct-2507"
 ```
 
 Then deploy:

--- a/sample-applications/video-search-and-summarization/docs/user-guide/get-started.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/get-started.md
@@ -121,7 +121,7 @@ Before running the application, you need to set several environment variables:
 
       ```bash
       # For VLM-based chunk captioning and video summarization on CPU
-      export VLM_MODEL_NAME="Qwen/Qwen2.5-VL-3B-Instruct"  # or any other supported VLM model on CPU
+      export VLM_MODEL_NAME="Qwen/Qwen3-VL-4B-Instruct"  # or any other supported VLM model on CPU
 
       # For VLM-based chunk captioning and video summarization on GPU
       export VLM_MODEL_NAME="OpenVINO/Phi-3.5-vision-instruct-int8-ov"  # or any other supported VLM model on GPU
@@ -130,7 +130,7 @@ Before running the application, you need to set several environment variables:
       # (OPTIONAL) For OVMS split-model summarization, set a dedicated LLM model for final summary.
       # If this is not set, OVMS falls back to VLM_MODEL_NAME as the LLM model source.
       # OVMS uses shared mode only when model source, target device, and compression format all match.
-      export OVMS_LLM_MODEL_NAME="Intel/neural-chat-7b-v3-3"  # or any other supported LLM model
+      export OVMS_LLM_MODEL_NAME="Qwen/Qwen3-4B-Instruct-2507"  # or any other supported LLM model
       export LLM_TARGET_DEVICE="CPU"  # Options: CPU, GPU, NPU, HETERO:GPU,CPU
 
       # When ENABLE_VLLM=true, vLLM is the only inference backend and setup.sh ignores OVMS_LLM_MODEL_NAME.
@@ -325,7 +325,7 @@ Before running the application, you need to set several environment variables:
     export ENABLE_VLLM_GPU=true
 
     # Set the VLM model for vLLM GPU inference
-    export VLM_MODEL_NAME="Qwen/Qwen2.5-VL-3B-Instruct"
+    export VLM_MODEL_NAME="Qwen/Qwen3-VL-4B-Instruct"
     ```
 
     **Additional vLLM GPU/XPU configuration options:**
@@ -399,14 +399,14 @@ In modes, where Video Search is available (Search, Dual UI and Unified UI mode),
 
 | **Deployment Option** | **Chunk-Wise Summary<sup>(1)</sup> Configuration** | **Final Summary<sup>(2)</sup> Configuration** | **Environment Variables to Set** | **Recommended Models** | **Recommended Usage Model** |
 |--------|--------------------|---------------------|-----------------------|----------------|----------------|
-| OVMS shared-model CPU | OVMS-hosted VLM on CPU | Same OVMS-hosted VLM on CPU | Default | VLM: `Qwen/Qwen2.5-VL-3B-Instruct` | Default CPU-only summarization flow. |
+| OVMS shared-model CPU | OVMS-hosted VLM on CPU | Same OVMS-hosted VLM on CPU | Default | VLM: `Qwen/Qwen3-VL-4B-Instruct` | Default CPU-only summarization flow. |
 | OVMS shared-model GPU | OVMS-hosted VLM on GPU | Same OVMS-hosted VLM on GPU | `VLM_TARGET_DEVICE=GPU` with `LLM_TARGET_DEVICE=GPU` | VLM: `OpenVINO/Phi-3.5-vision-instruct-int8-ov` | Single-model OVMS deployment with GPU acceleration. |
-| OVMS split-model CPU/CPU | OVMS-hosted VLM on CPU | OVMS-hosted LLM on CPU | `OVMS_LLM_MODEL_NAME=<llm-model>` | VLM: `Qwen/Qwen2.5-VL-3B-Instruct`<br>LLM: `Intel/neural-chat-7b-v3-3` | One OVMS instance hosts separate VLM and LLM models on CPU. |
-| OVMS split-model GPU/CPU | OVMS-hosted VLM on GPU | OVMS-hosted LLM on CPU | `VLM_MODEL_NAME=Qwen/Qwen2.5-VL-3B-Instruct` + `VLM_TARGET_DEVICE=GPU` + `LLM_TARGET_DEVICE=CPU` (optionally set `OVMS_LLM_MODEL_NAME=<llm-model>`) | VLM: `Qwen/Qwen2.5-VL-3B-Instruct`<br>LLM: `Qwen/Qwen2.5-VL-3B-Instruct` (or dedicated `OVMS_LLM_MODEL_NAME`) | Use GPU for captioning while keeping final summary on CPU; also supports same-source split by device/weight. |
-| OVMS split-model CPU/GPU | OVMS-hosted VLM on CPU | OVMS-hosted LLM on GPU | `VLM_MODEL_NAME=Qwen/Qwen2.5-VL-3B-Instruct` + `LLM_TARGET_DEVICE=GPU` (optionally set `OVMS_LLM_MODEL_NAME=<llm-model>`) | VLM: `Qwen/Qwen2.5-VL-3B-Instruct`<br>LLM: `Qwen/Qwen2.5-VL-3B-Instruct` (or dedicated `OVMS_LLM_MODEL_NAME`) | Use GPU for final summary while keeping captioning on CPU; also supports same-source split by device/weight. |
-| OVMS split-model CPU/NPU | OVMS-hosted VLM on CPU | OVMS-hosted LLM on NPU | `LLM_TARGET_DEVICE=NPU` (optionally set `OVMS_LLM_MODEL_NAME=<llm-model>` for a dedicated LLM) | VLM: `Qwen/Qwen2.5-VL-3B-Instruct`<br>LLM: `OpenVINO/Qwen3-8B-int4-cw-ov` | Use NPU for the final-summary LLM while keeping captioning on CPU. |
-| vLLM-only CPU | vLLM-hosted VLM on CPU | Same vLLM-hosted VLM on CPU | `ENABLE_VLLM=true` | VLM: `Qwen/Qwen2.5-VL-3B-Instruct` | All-vLLM mode for CPU-only deployments. |
-| 🧪 vLLM-only GPU/XPU (**EXPERIMENTAL**) | vLLM-hosted VLM on Intel Arc Pro B-series GPU | Same vLLM-hosted VLM on Intel Arc Pro B-series GPU | `ENABLE_VLLM_GPU=true` | VLM: `Qwen/Qwen2.5-VL-3B-Instruct` | **EXPERIMENTAL**: All-vLLM mode with Intel Arc Pro B-series GPU/XPU acceleration. Early-stage feature. |
+| OVMS split-model CPU/CPU | OVMS-hosted VLM on CPU | OVMS-hosted LLM on CPU | `OVMS_LLM_MODEL_NAME=<llm-model>` | VLM: `Qwen/Qwen3-VL-4B-Instruct`<br>LLM: `Qwen/Qwen3-4B-Instruct-2507` | One OVMS instance hosts separate VLM and LLM models on CPU. |
+| OVMS split-model GPU/CPU | OVMS-hosted VLM on GPU | OVMS-hosted LLM on CPU | `VLM_MODEL_NAME=Qwen/Qwen3-VL-4B-Instruct` + `VLM_TARGET_DEVICE=GPU` + `LLM_TARGET_DEVICE=CPU` (optionally set `OVMS_LLM_MODEL_NAME=<llm-model>`) | VLM: `Qwen/Qwen3-VL-4B-Instruct`<br>LLM: `Qwen/Qwen3-VL-4B-Instruct` (or dedicated `OVMS_LLM_MODEL_NAME`) | Use GPU for captioning while keeping final summary on CPU; also supports same-source split by device/weight. |
+| OVMS split-model CPU/GPU | OVMS-hosted VLM on CPU | OVMS-hosted LLM on GPU | `VLM_MODEL_NAME=Qwen/Qwen3-VL-4B-Instruct` + `LLM_TARGET_DEVICE=GPU` (optionally set `OVMS_LLM_MODEL_NAME=<llm-model>`) | VLM: `Qwen/Qwen3-VL-4B-Instruct`<br>LLM: `Qwen/Qwen3-VL-4B-Instruct` (or dedicated `OVMS_LLM_MODEL_NAME`) | Use GPU for final summary while keeping captioning on CPU; also supports same-source split by device/weight. |
+| OVMS split-model CPU/NPU | OVMS-hosted VLM on CPU | OVMS-hosted LLM on NPU | `LLM_TARGET_DEVICE=NPU` (optionally set `OVMS_LLM_MODEL_NAME=<llm-model>` for a dedicated LLM) | VLM: `Qwen/Qwen3-VL-4B-Instruct`<br>LLM: `OpenVINO/Qwen3-8B-int4-cw-ov` | Use NPU for the final-summary LLM while keeping captioning on CPU. |
+| vLLM-only CPU | vLLM-hosted VLM on CPU | Same vLLM-hosted VLM on CPU | `ENABLE_VLLM=true` | VLM: `Qwen/Qwen3-VL-4B-Instruct` | All-vLLM mode for CPU-only deployments. |
+| 🧪 vLLM-only GPU/XPU (**EXPERIMENTAL**) | vLLM-hosted VLM on Intel Arc Pro B-series GPU | Same vLLM-hosted VLM on Intel Arc Pro B-series GPU | `ENABLE_VLLM_GPU=true` | VLM: `Qwen/Qwen3-VL-4B-Instruct` | **EXPERIMENTAL**: All-vLLM mode with Intel Arc Pro B-series GPU/XPU acceleration. Early-stage feature. |
 
 > **Note:**
 >
@@ -416,7 +416,7 @@ In modes, where Video Search is available (Search, Dual UI and Unified UI mode),
 > 4) `VLM_TARGET_DEVICE` and `LLM_TARGET_DEVICE` support values: `CPU`, `GPU`, `NPU`, or `HETERO:GPU,CPU` for heterogeneous execution.
 > 5) **NPU Support:** Not all models support NPU execution. Verify model compatibility at the [OpenVINO™ Supported Models](https://docs.openvino.ai/2026/documentation/compatibility-and-support/supported-models.html) page before selecting `NPU` as target device.
 > 6) OVMS mode selection is based on effective VLM/LLM settings: if model source, target device, and compression format are all identical, setup uses shared mode; otherwise it uses split mode.
-> 7) For same-source split examples (same model name on different devices/formats), prefer non-`OpenVINO/` source models (for example, `Qwen/Qwen2.5-VL-3B-Instruct`). `OpenVINO/` namespace models are pre-converted and use model-intrinsic/fixed weight formats.
+> 7) For same-source split examples (same model name on different devices/formats), prefer non-`OpenVINO/` source models (for example, `Qwen/Qwen3-VL-4B-Instruct`). `OpenVINO/` namespace models are pre-converted and use model-intrinsic/fixed weight formats.
 > 8) **🧪 EXPERIMENTAL - Intel Arc Pro B-series GPU Support:** vLLM on Intel Arc Pro B-series GPUs/XPUs (`ENABLE_VLLM_GPU=true`) is **experimental** and in early development stages. This feature provides GPU-accelerated inference for both VLM captioning and LLM summarization but may have stability issues and requires specific Intel Arc Pro B-series GPU hardware (e.g., B60, B65, B70). When enabled, it automatically disables OVMS and uses vLLM exclusively. Not recommended for production use.
 
 ### Deployment Options for Video Search
@@ -584,13 +584,13 @@ Follow these steps to run the application:
       # Shared vs split mode is then decided from effective model/device/compression equality.
 
       # For Summary mode
-      OVMS_LLM_MODEL_NAME="Intel/neural-chat-7b-v3-3" source setup.sh --summary
+      OVMS_LLM_MODEL_NAME="Qwen/Qwen3-4B-Instruct-2507" source setup.sh --summary
 
       # For Dual UI mode
-      OVMS_LLM_MODEL_NAME="Intel/neural-chat-7b-v3-3" source setup.sh --summary --search
+      OVMS_LLM_MODEL_NAME="Qwen/Qwen3-4B-Instruct-2507" source setup.sh --summary --search
 
       # For Unified UI mode
-      OVMS_LLM_MODEL_NAME="Intel/neural-chat-7b-v3-3" source setup.sh --summary-and-search
+      OVMS_LLM_MODEL_NAME="Qwen/Qwen3-4B-Instruct-2507" source setup.sh --summary-and-search
       ```
 
    - **Use vLLM as the only inference backend (CPU):**
@@ -670,7 +670,7 @@ Follow these steps to run the application:
 
       # To see resolved configurations for OVMS split-model summarization without starting containers.
       # (for other modes, combine --summary with --search option or replace all options with --summary-and-search)
-      OVMS_LLM_MODEL_NAME="Intel/neural-chat-7b-v3-3" source setup.sh --summary config
+      OVMS_LLM_MODEL_NAME="Qwen/Qwen3-4B-Instruct-2507" source setup.sh --summary config
 
       # To see resolved configurations for summarization services with vLLM enabled without starting containers.
       # (for other modes, combine --summary with --search option or replace all options with --summary-and-search)
@@ -706,13 +706,13 @@ Follow these steps to run the application:
 
    ```bash
    # for Summary mode
-   LLM_TARGET_DEVICE=GPU OVMS_LLM_MODEL_NAME=Intel/neural-chat-7b-v3-3 source setup.sh --summary
+   LLM_TARGET_DEVICE=GPU OVMS_LLM_MODEL_NAME=Qwen/Qwen3-4B-Instruct-2507 source setup.sh --summary
 
    # for Dual UI mode
-   LLM_TARGET_DEVICE=GPU OVMS_LLM_MODEL_NAME=Intel/neural-chat-7b-v3-3 source setup.sh --summary --search
+   LLM_TARGET_DEVICE=GPU OVMS_LLM_MODEL_NAME=Qwen/Qwen3-4B-Instruct-2507 source setup.sh --summary --search
 
    # for Unified UI mode
-   LLM_TARGET_DEVICE=GPU OVMS_LLM_MODEL_NAME=Intel/neural-chat-7b-v3-3 source setup.sh --summary-and-search
+   LLM_TARGET_DEVICE=GPU OVMS_LLM_MODEL_NAME=Qwen/Qwen3-4B-Instruct-2507 source setup.sh --summary-and-search
    ```
 
 > **Note:** Search-indexing embedding runs in-process in `multimodal-dataprep` and follows `DATAPREP_EMBEDDING_DEVICE`. `MME_EMBEDDING_DEVICE` controls `multimodal-embedding-serving`, which `video-search` uses for query-time embeddings. `ENABLE_EMBEDDING_GPU=true` is a shortcut that sets `DATAPREP_EMBEDDING_DEVICE=GPU`.

--- a/sample-applications/video-search-and-summarization/docs/user-guide/helm-installation-vLLM-guide.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/helm-installation-vLLM-guide.md
@@ -65,7 +65,7 @@ nano user_values_override.yaml
 | --- | --- | --- |
 | `global.sharedPvcName` | Name of the shared PVC for all components | `vss-shared-pvc` |
 | `global.huggingfaceToken` | Hugging Face API token for model access | `hf_xxxxxxxxxxxxxxxxxxxx` |
-| `global.vlmName` | Vision Language Model used for video analysis | `Qwen/Qwen2.5-VL-3B-Instruct` |
+| `global.vlmName` | Vision Language Model used for video analysis | `Qwen/Qwen3-VL-4B-Instruct` |
 | `global.env.POSTGRES_USER` | PostgreSQL username | `vsadmin` |
 | `global.env.POSTGRES_PASSWORD` | PostgreSQL password | `<secure-password>` |
 | `global.env.MINIO_ROOT_USER` | MinIO username (min 3 chars) | `minioadmin` |


### PR DESCRIPTION

### Description

This PR includes two related updates across VSS and multimodal-dataprep:

1. Model default refresh (docs/config/skills)
• Replaced:
•  VLM_MODEL_NAME="Qwen/Qwen2.5-VL-3B-Instruct"  →  VLM_MODEL_NAME="Qwen/Qwen3-VL-4B-Instruct" 
•  OVMS_LLM_MODEL_NAME="Intel/neural-chat-7b-v3-3"  →  OVMS_LLM_MODEL_NAME="Qwen/Qwen3-4B-Instruct-2507" 
• Applied consistently in user docs,  .env.example , and  .github  skill/config files.
2. MinIO persistence cleanup in multimodal-dataprep
• Removed hardcoded bind path usage ( /mnt/miniodata ) and  MINIO_MOUNT_PATH .
• Switched MinIO data persistence to named Docker volume:
•  minio_data:/data 
• Updated both:
•  docker/compose.yaml 
•  docker/compose-milvus.yaml 
• Updated related setup/docs references accordingly.
3. Removed references to poetry in make file

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Tested in dev env.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

