### PR TITLE
[DOCS][DLSPS] Fix a broken relative link

### DIFF
--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/udf/Overview.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/udf/Overview.md
@@ -1,65 +1,72 @@
 # User Defined Functions (UDF)
 
-* [UDF Writing Guide](#udf-writing-guide)
-    - [How-To Guide for Writing UDF](#how-to-guide-for-writing-udf)
-    - [Configuring UDFLoader element](#configuring-udfloader-element)
-      - [Pallet Defect Detection](#pallet-defect-detection)
-      - [Add Label](#add-label)
+- [UDF Writing Guide](#udf-writing-guide)
+  - [How-To Guide for Writing UDF](#how-to-guide-for-writing-udf)
+  - [Configuring UDFLoader element](#configuring-udfloader-element)
+    - [Pallet Defect Detection](#pallet-defect-detection)
+    - [Add Label](#add-label)
 
 ## UDF Writing Guide
+
 An User Defined Function (UDF) is a chunk of user code that can transform video frames and/or manipulate metadata. For example, a UDF can act as filter, preprocessor, classifier or a detector. These User Defined Functions can be developed in Python. DL Streamer Pipeline Server provides a GStreamer plugin - `udfloader` using which users can configure and load arbitrary UDFs. These UDFs are then called once for each video frame.
 
 ## How-To Guide for Writing UDF
-A detailed guide for developing UDFs is available [here](./UDF_writing_guide).
 
-##  Configuring udfloader element
+A detailed guide for developing UDFs is available [here](./UDF_writing_guide.md).
+
+## Configuring udfloader element
+
 The `udfloader` element has a single configurable property with the name `config`. This field expects a JSON string as an input. They key/value pairs in the JSON string should correspond to the constructor arguments of the UDFs class. Currently only atomic data types are supported.
 
-**Sample UDF config**</br>
+**Sample UDF config**:
 
 The UDF config should be passed to the `udfs` key in the config file. The below example configures the `udfloader` element to load and execute a single UDF, which in this case happens to be the `geti_udf`.
 
-  ```json
-  {
-        "udfs": [
-            {
-                "name": "python.geti_udf.geti_udf",
-                "type": "python",
-                "device": "CPU",
-                "visualize": "false",
-                "deployment": "./resources/geti/person_detection/deployment",
-                "metadata_converter": null,
-            }
-        ]
-  }
-  ```
-  In order to chain multiple UDFs, simply provide the configs for UDFs as additional entries in the `udfs` array in the config file as shown below
-  ``` json
+```json
+{
+  "udfs": [
     {
-        "udfs": [
-            {
-                "name": "udf1",
-                "type": "python",
-                "arg1": "value1",
-                "arg2": "value2"
-            },
-            {
-                "name": "udf2",
-                "type": "python",
-                "arg1": "value1",
-                "arg2": "value2"
-            }
-        ]
+      "name": "python.geti_udf.geti_udf",
+      "type": "python",
+      "device": "CPU",
+      "visualize": "false",
+      "deployment": "./resources/geti/person_detection/deployment",
+      "metadata_converter": null
     }
-  ```
+  ]
+}
+```
+
+In order to chain multiple UDFs, simply provide the configs for UDFs as additional entries in the `udfs` array in the config file as shown below:
+
+```json
+{
+  "udfs": [
+    {
+      "name": "udf1",
+      "type": "python",
+      "arg1": "value1",
+      "arg2": "value2"
+    },
+    {
+      "name": "udf2",
+      "type": "python",
+      "arg1": "value1",
+      "arg2": "value2"
+    }
+  ]
+}
+```
 
 <!-- ### Anomalib
 To learn about Anomalib and how to configure Anomalib UDF, refer to this [section](./configuring_udfloader.md#anomalib). -->
 
 ### Pallet Defect Detection
+
 To learn how to configure Geti Pallet Defect Detection UDF, refer to this [section](./configuring_udfloader.md#pallet-defect-detection).
 
 ### Add Label
+
 To learn how to configure Add Label UDF, refer to this [section](./configuring_udfloader.md#add-label).
 
 <!--hide_directive

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/udf/configuring_udfloader.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/udf/configuring_udfloader.md
@@ -2,7 +2,7 @@
 
 The `udfloader` element has a single configurable property with the name `config`. This field expects a JSON string as an input. They key/value pairs in the JSON string should correspond to the constructor arguments of the UDFs class. Currently only atomic data types are supported.
 
-**Sample UDF config**</br>
+**Sample UDF config**:
 
 The UDF config should be passed to the `udfs` key in the EIS config file. The below example configures the `udfloader` element to load and execute a single UDF, which in this case happens to be the `geti_udf`.
 
@@ -20,7 +20,9 @@ The UDF config should be passed to the `udfs` key in the EIS config file. The be
         ]
   }
   ```
-  In order to chain multiple UDFs, simply provide the configs for UDFs as additional entries in the `udfs` array in the EIS config file as shown below
+
+  In order to chain multiple UDFs, simply provide the configs for UDFs as additional entries in the `udfs` array in the EIS config file as shown below:
+
   ``` json
     {
         "udfs": [
@@ -71,13 +73,11 @@ Refer the below sample configuration to run the Anomalib UDF.
 
 **Note**: `inferencer` config parameter can be used to change b/w the default openvino inferencer provided by anomalib and the openvino_nomask inferencer which inherits from openvino inferencer. -->
 
-
 ## Pallet Defect Detection
 
-This Geti™ udf supports deploying a project for local inference with OpenVINO using Intel® Geti™ SDK Python package. It uses a Geti™ based Pallet Defect Detection model.
+This Geti™ udf supports deploying a project for local inference with OpenVINO™ using Intel® Geti™ SDK Python package. It uses a Geti™ based Pallet Defect Detection model.
 
-
-Refer the below config for the default config used for this Geti udf:
+Refer to the below config for the default config used for this Geti UDF:
 
 ```json
  "udfs": [

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/index.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/index.md
@@ -18,7 +18,7 @@ pipelines.
 ## Overview
 
 DL Streamer Pipeline Server microservice is built on top of [GStreamer](https://gstreamer.freedesktop.org/documentation/)
-and [Deep Learning Streamer (DL Streamer)](https://github.com/open-edge-platform/dlstreamer/tree/main),
+and [Deep Learning Streamer (DL Streamer)](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/index.html),
 providing video ingestion and deep learning inferencing functionalities.
 
 Video analytics involves the conversion of video streams into valuable insights through the


### PR DESCRIPTION
### Description

ITEP-95498 

Fixes the first broken relative link from the ticket; the other two links have already been fixed previously on `main`/`release-2026.2.0`

- fix a broken relative link to a nearby article that was missing `.md`
- minor formatting updates
- change the DL Streamer link in `index.md` to the OEP docs website link

### How Has This Been Tested?

Links checked.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.