### PR TITLE
fix(audio-analyzer): align OpenVINO dependencies

### DIFF
--- a/microservices/audio-analyzer/requirements.txt
+++ b/microservices/audio-analyzer/requirements.txt
@@ -12,7 +12,7 @@ torch==2.8.0+cpu
 torchaudio==2.8.0+cpu
 torchvision==0.23.0+cpu
 onnx==1.21.0
-transformers==5.3.0
+transformers==4.53.3
 uvicorn==0.35.0
 # WebSocket transport for uvicorn — required by the realtime transcription
 # endpoint (api/realtime_endpoints.py); uvicorn has no WS support without it.
@@ -20,14 +20,14 @@ websockets==15.0.1
 fsspec>=2023.1.0,<=2025.3.0
 openai-whisper==20250625
 numpy==2.2.6
-optimum==2.3.0
-optimum-intel[openvino]==2.1.0
+optimum==2.1.0
+optimum-intel[openvino]==1.27.0
 nncf==3.1.0
 psutil==7.1.3
 ultralytics==8.3.201
 speechbrain==1.0.3
 pyannote.audio==4.0.4
-huggingface-hub>=1.3.0,<2.0
+huggingface-hub==0.34.4
 hf_xet==1.4.3
 librosa==0.11.0
 # numba/llvmlite are pulled in transitively via librosa. Newer numba (0.66.x)


### PR DESCRIPTION
## Summary

- Align Audio Analyzer OpenVINO-related dependencies for NPU support.
- Update Transformers, Optimum, Optimum Intel, and Hugging Face Hub versions to compatible versions.

## Changes

- transformers: 5.3.0 → 4.53.3
- optimum: 2.3.0 → 2.1.0
- optimum-intel[openvino]: 2.1.0 → 1.27.0
- huggingface-hub: >=1.3.0,<2.0 → 0.34.4

## Validation

- Rebuilt the Audio Analyzer image with the updated dependencies.
- Verified the Audio Analyzer NPU-related functionality.