### PR TITLE
[ViPPET] Cherry-pick smart NVR output video resolution to release-2026.2.0

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/smart-nvr.yaml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/smart-nvr.yaml
@@ -46,7 +46,7 @@ variants:
       gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       videoscale !
-      video/x-raw,width=320,height=240 !
+      video/x-raw,width=1280,height=720 !
       fakesink name=default_output_sink
   - name: GPU
     pipeline_description: >-
@@ -89,7 +89,7 @@ variants:
       gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       vapostproc !
-      video/x-raw(memory:VAMemory),width=320,height=240 !
+      video/x-raw(memory:VAMemory),width=1280,height=720 !
       fakesink name=default_output_sink
   - name: GPU (WSL)
     pipeline_description: >-
@@ -132,7 +132,7 @@ variants:
       gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       videoscale !
-      video/x-raw,width=320,height=240 !
+      video/x-raw,width=1280,height=720 !
       fakesink name=default_output_sink
   - name: NPU
     pipeline_description: >-
@@ -174,7 +174,7 @@ variants:
       gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       vapostproc !
-      video/x-raw(memory:VAMemory),width=320,height=240 !
+      video/x-raw(memory:VAMemory),width=1280,height=720 !
       fakesink name=default_output_sink
   - name: GPU_NPU
     pipeline_description: >-
@@ -216,7 +216,7 @@ variants:
       gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       vapostproc !
-      video/x-raw(memory:VAMemory),width=320,height=240 !
+      video/x-raw(memory:VAMemory),width=1280,height=720 !
       fakesink name=default_output_sink
   - name: NPU_GPU
     pipeline_description: >-
@@ -258,5 +258,5 @@ variants:
       gvametaconvert add-empty-results=true format=json !
       gvametapublish method=file file-path=/dev/null !
       vapostproc !
-      video/x-raw(memory:VAMemory),width=320,height=240 !
+      video/x-raw(memory:VAMemory),width=1280,height=720 !
       fakesink name=default_output_sink


### PR DESCRIPTION
## Summary
Cherry-pick of smart NVR quality update from `KaliszWiktoria:smart_nvr_quality` onto `release-2026.2.0`.

## Changes
- Update smart NVR output video resolution in `tools/visual-pipeline-and-platform-evaluation-tool/vippet/pipelines/smart-nvr.yaml`

## Source
- Original commit: `6f8ec2d7` (fork/smart_nvr_quality)
- Cherry-picked as: `012dc4b8` on this branch
