### PR TITLE
[ViPPET] Cherry-pick supported models comment change to release-2026.2.0

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/Models.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/Models.tsx
@@ -104,6 +104,19 @@ export const Models = () => {
           <p className="text-muted-foreground mt-2">
             Ready-to-use models available in the platform
           </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Not every uploaded model will work in ViPPET. Check supported
+            models:{" "}
+            <a
+              href="https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/supported_models.html"
+              target="_blank"
+              rel="noreferrer"
+              className="font-medium underline underline-offset-2"
+            >
+              DL Streamer supported models
+            </a>
+            .
+          </p>
         </div>
 
         <MultiFileUploader


### PR DESCRIPTION
## Summary
Cherry-pick of supported models comment update from `KaliszWiktoria:sup_models_comment` onto `release-2026.2.0`.

## Changes
- Link supported models in ViPPET models UI page