### PR TITLE
docs(audio-analyzer): document external MinIO configuration

### DIFF
--- a/microservices/audio-analyzer/docs/user-guide/get-started/configuration.md
+++ b/microservices/audio-analyzer/docs/user-guide/get-started/configuration.md
@@ -33,6 +33,7 @@ AUDIO_ANALYZER__MODELS__ASR__DEVICE=GPU python main.py
 - `models.asr`: backend provider, model name, device, export precision, decoding settings
 - `audio_preprocessing`: chunk size, silence detection, denoise settings, chunk directory
 - `audio_util`: max file size, allowed extensions, upload read chunk size
+- `minio`: external MinIO endpoint/credentials, used only by `POST /transcriptions` when a MinIO source is supplied instead of a direct file upload
 - `pipeline.delete_chunks_after_use`: whether temporary chunks are removed after processing
 - `sentiment`: enablement, provider, model, device, aggregation settings
 
@@ -110,3 +111,67 @@ Provider-specific `models.asr` fields:
 
 - `weight_format`: used by `openvino` for IR export precision and by `whispercpp` for model quantization.
 - `beam_size`, `best_of`, `threads`, `word_timestamps`: used only by `whispercpp`.
+
+## MinIO (External Dependency)
+
+MinIO is **not bundled** with Audio Analyzer. It is not defined as a service
+in `docker-compose.yml` and is not started, managed, or shipped by this
+component. When a caller invokes `POST /transcriptions` with a MinIO source
+(`minio_bucket`/`video_id`/`video_name`) instead of uploading a file directly,
+the service downloads that single source audio/video object from the bucket,
+transcribes it locally, and uploads the resulting transcript back into the
+**same bucket**. Only the source object and the final transcript object move
+through MinIO — internal ASR chunking (`audio_preprocessing.chunk_duration_sec`)
+happens entirely on local/container storage and is never written to MinIO.
+See the [API Reference](../api-reference.md) for full request/response
+details.
+
+To use that path, run MinIO as a separate, externally managed service (your
+own container, Compose stack, or existing deployment) and provide its
+endpoint/credentials to Audio Analyzer through configuration. Audio Analyzer
+never starts or bundles MinIO itself.
+
+Config keys (`config.yaml`):
+
+```yaml
+minio:
+  endpoint: ""       # e.g. "minio-server:9000"; empty disables MinIO support
+  access_key: ""
+  secret_key: ""
+  secure: false
+```
+
+Equivalent environment variable overrides (targeted `AUDIO_ANALYZER__...`
+overrides, per [Load Order](#load-order)):
+
+- `AUDIO_ANALYZER__MINIO__ENDPOINT`
+- `AUDIO_ANALYZER__MINIO__ACCESS_KEY`
+- `AUDIO_ANALYZER__MINIO__SECRET_KEY`
+- `AUDIO_ANALYZER__MINIO__SECURE`
+
+Example (do not commit real credentials; use a local `.env` file or your
+secret-management mechanism):
+
+```bash
+AUDIO_ANALYZER__MINIO__ENDPOINT=minio-server:9000
+AUDIO_ANALYZER__MINIO__ACCESS_KEY=<your-access-key>
+AUDIO_ANALYZER__MINIO__SECRET_KEY=<your-secret-key>
+AUDIO_ANALYZER__MINIO__SECURE=false
+```
+
+This form applies directly to standalone runs (`python main.py`). For Docker
+Compose, `docker-compose.yml` only forwards the environment variables it
+explicitly lists, so setting these in `.env` alone does not reach the
+container — see
+[MinIO (External Object Storage)](./run-container.md#minio-external-object-storage)
+for the Compose-specific options (editing `config.yaml` directly, or adding
+these variables under `services.audio-analyzer.environment`).
+
+If `minio.endpoint` is left empty, MinIO support is disabled and a MinIO
+source request to `POST /transcriptions` returns `503`.
+
+The Audio Analyzer container must be able to reach the configured MinIO
+`endpoint` over the network (for example, the same Docker network or a
+routable host/port). For container-to-container setups, verify and
+troubleshoot connectivity as described in
+[Run With Docker Compose](./run-container.md#minio-external-object-storage).

--- a/microservices/audio-analyzer/docs/user-guide/get-started/run-container.md
+++ b/microservices/audio-analyzer/docs/user-guide/get-started/run-container.md
@@ -60,6 +60,82 @@ Without a valid `HF_TOKEN` and gate acceptance, speaker diarization will not ini
 continues running, logs a warning, and disables diarization for that session.
 If diarization is disabled in `config.yaml`, `HF_TOKEN` is not required.
 
+### MinIO (External Object Storage)
+
+MinIO is an **external dependency** for the `POST /transcriptions` endpoint's
+object-storage source/sink mode: it is not defined as a service in
+`docker-compose.yml`, and Audio Analyzer does not start, bundle, or manage
+it. When a caller supplies `minio_bucket`/`video_id`/`video_name` instead of
+uploading a file directly, Audio Analyzer downloads that one source
+audio/video object from the bucket, transcribes it, and uploads the
+resulting transcript back into the same bucket — no other endpoint touches
+MinIO, and no audio chunks are stored in MinIO (chunking is an internal,
+local processing step). Run MinIO as a separate container (or use an
+existing MinIO deployment) and provide its endpoint/credentials to Audio
+Analyzer through configuration. For full details on the config keys and env
+vars, see the
+[MinIO section of the Configuration Guide](./configuration.md#minio-external-dependency).
+
+`docker-compose.yml` only forwards the specific environment variables it
+lists under `services.audio-analyzer.environment`; values placed in `.env`
+are not automatically injected into the container unless referenced there.
+To supply MinIO settings to the running container, either:
+
+- Edit the bind-mounted `config.yaml` directly (`minio.endpoint`,
+  `minio.access_key`, `minio.secret_key`, `minio.secure`) and
+  `docker compose restart audio-analyzer`; or
+- Add the `AUDIO_ANALYZER__MINIO__*` variables under
+  `services.audio-analyzer.environment` in `docker-compose.yml` so Compose
+  passes them into the container.
+
+Example: run MinIO as its own container on the same Docker network Audio
+Analyzer uses, then supply its connection details via `config.yaml`:
+
+```bash
+docker run -d --name minio-server --network <your-network> \
+  -p 9000:9000 -p 9001:9001 \
+  -e MINIO_ROOT_USER=<your-access-key> \
+  -e MINIO_ROOT_PASSWORD=<your-secret-key> \
+  minio/minio server /data --console-address ":9001"
+```
+
+```yaml
+# config.yaml
+minio:
+  endpoint: "minio-server:9000"
+  access_key: "<your-access-key>"
+  secret_key: "<your-secret-key>"
+  secure: false
+```
+
+Verification steps:
+
+```bash
+# 1. MinIO is running
+docker ps --filter name=minio-server
+curl --noproxy '*' http://127.0.0.1:9000/minio/health/live
+
+# 2. MinIO configuration was passed to Audio Analyzer
+#    (config.yaml is bind-mounted; inspect the mounted file, or if using the
+#    environment-variable approach, check the container's environment)
+docker compose exec audio-analyzer cat /app/audio_analyzer/config.yaml | grep -A4 '^minio:'
+docker compose exec audio-analyzer env | grep AUDIO_ANALYZER__MINIO__
+
+# 3. Audio Analyzer resolved the MinIO endpoint
+docker compose logs audio-analyzer | grep -i minio
+
+# 4. Audio Analyzer can reach MinIO's health endpoint from inside the container
+docker compose exec audio-analyzer python3 -c \
+  "import urllib.request; urllib.request.urlopen('http://minio-server:9000/minio/health/live', timeout=5).read()"
+```
+
+If step 4 fails but MinIO is otherwise reachable, check whether
+`http_proxy`/`https_proxy` are set in the container environment and whether
+`no_proxy`/`NO_PROXY` includes the MinIO hostname — a proxy can block direct
+container-to-container requests even when the network path itself is fine.
+This is a proxy/environment configuration matter, not an Audio Analyzer or
+MinIO defect.
+
 ## Run the Container
 
 ### Pull And Start

--- a/microservices/audio-analyzer/docs/user-guide/get-started/run-container.md
+++ b/microservices/audio-analyzer/docs/user-guide/get-started/run-container.md
@@ -96,7 +96,7 @@ docker run -d --name minio-server --network <your-network> \
   -p 9000:9000 -p 9001:9001 \
   -e MINIO_ROOT_USER=<your-access-key> \
   -e MINIO_ROOT_PASSWORD=<your-secret-key> \
-  minio/minio server /data --console-address ":9001"
+  minio/minio:RELEASE.2025-02-07T23-21-09Z-cpuv1 server /data --console-address ":9001"
 ```
 
 ```yaml


### PR DESCRIPTION
## Description

Document the expected external MinIO configuration for Audio Analyzer.

## Changes

- Document MinIO as an external dependency.
- Document MinIO configuration through Audio Analyzer config/environment values.
- Document required MinIO configuration variables.
- Document Docker/container connectivity requirements.
- Add MinIO setup and verification commands.
- Document proxy/no_proxy considerations for container connectivity.

MinIO is not bundled or started by the Audio Analyzer deployment.
