### PR TITLE
[ViPPET] Add missing directories

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/docker-compose.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/docker-compose.md
@@ -38,6 +38,8 @@ For alternative ways to set up the sample application, refer to
    mkdir -p visual-pipeline-and-platform-evaluation-tool/shared/models
    mkdir -p visual-pipeline-and-platform-evaluation-tool/shared/videos
    mkdir -p visual-pipeline-and-platform-evaluation-tool/shared/onvif
+   mkdir -p visual-pipeline-and-platform-evaluation-tool/shared/scripts
+   mkdir -p visual-pipeline-and-platform-evaluation-tool/vippet/api/static
    cd visual-pipeline-and-platform-evaluation-tool
    ```
 


### PR DESCRIPTION
This pull request updates the Docker Compose installation instructions to ensure all necessary directories are created before setup. Two new directories are now included in the setup steps.

Installation documentation improvements:

* Updated the Docker Compose installation guide to include creation of the `shared/scripts` and `vippet/api/static` directories, ensuring all required paths exist before proceeding.