### PR TITLE
fix(metrics-manager): remediate runtime vulnerabilities

### DIFF
--- a/microservices/metrics-manager/Dockerfile
+++ b/microservices/metrics-manager/Dockerfile
@@ -70,11 +70,11 @@ RUN cargo install --locked --git https://github.com/ulissesf/qmassa --tag qmassa
 # -----------------------------------------------------------------------------
 # Built from source (instead of the upstream .deb) to patch known CVEs in
 # bundled Go dependencies:
-# Using golang:1.26 (1.26.3+) also resolves stdlib CVEs fixed in Go 1.26.3.
+# Using golang:1.26 (1.26.6+) also resolves stdlib CVEs fixed in Go 1.26.6.
 # Digest pinned for reproducible builds — decoupled from Docker Hub tag updates.
-FROM golang:1.26.4@sha256:68cb6d68bed024785b69195b89af7ac7a444f27791435f98647edff595aa0479 AS telegraf-builder
+FROM golang:1.26.6@sha256:0d1d3a794be25f809dd2cb3160d8c73276c4056a9f8242a138e908ddeee7b6b6 AS telegraf-builder
 
-ARG TELEGRAF_VERSION=1.38.4
+ARG TELEGRAF_VERSION=1.39.3
 
 ARG http_proxy
 ARG HTTP_PROXY
@@ -103,25 +103,8 @@ WORKDIR /telegraf
 # Cache Go module downloads across builds to avoid re-fetching on every run.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go get github.com/rclone/rclone@v1.73.5 && \
-    go get github.com/go-git/go-billy/v5@v5.9.0 && \
+    go get github.com/moby/go-archive@v0.3.0 && \
     go mod tidy
-# NOTE: CVE-2026-34040 (HIGH) and CVE-2026-33997 (MEDIUM) in github.com/docker/docker
-# cannot be patched yet — fix requires v29.3.1 which does not exist in the Go
-# module proxy (latest: v28.5.2+incompatible). Transitive Telegraf dependency.
-# Revisit when moby/moby v29.3.1 is published to the Go module registry.
-
-# fs.LogOutput was removed from rclone/fs in rclone 1.71+; the remotefile
-# plugin used it only for trace logging so dropping the assignment is safe.
-# The outer `if` is a no-op if a future Telegraf release already adapts to
-# the new API; the inner grep catches a block size change at build time.
-RUN if grep -q 'fs\.LogOutput = func' plugins/outputs/remotefile/remotefile.go; then \
-        sed -i '/fs\.LogOutput = func/,+2d' plugins/outputs/remotefile/remotefile.go; \
-        if grep -q 'fs\.LogOutput' plugins/outputs/remotefile/remotefile.go; then \
-            echo "ERROR: sed patch incomplete — fs.LogOutput block may have changed size in this Telegraf version" >&2; \
-            exit 1; \
-        fi; \
-    fi
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -241,13 +224,19 @@ RUN apt-get update && \
         packages="$packages vainfo intel-media-va-driver"; \
     fi; \
     apt-get install --yes --no-install-recommends $packages && \
-    pip install --no-cache-dir pip==26.1 supervisor==4.3.0 && \
+    pip install --no-cache-dir pip==26.2.1 supervisor==4.3.0 && \
+    rm -rf /usr/local/lib/python3.12/site-packages/pip \
+        /usr/local/lib/python3.12/site-packages/pip-*.dist-info \
+        /usr/local/lib/python3.12/site-packages/setuptools* \
+        /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.12 && \
     (dpkg -s perl-base >/dev/null 2>&1 && dpkg --purge --force-remove-essential perl-base || true) && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Create Telegraf config directories
-RUN mkdir -p /etc/telegraf /etc/telegraf/telegraf.d /var/log/telegraf
+RUN mkdir -p /etc/telegraf /etc/telegraf/telegraf.d /var/log/telegraf \
+        /etc/supervisor/conf.d && \
+    touch /etc/supervisor/conf.d/placeholder.conf
 
 # Clear proxy from final image (not needed at runtime, set via environment)
 ENV http_proxy= \

--- a/microservices/metrics-manager/docs/user-guide/get-started.md
+++ b/microservices/metrics-manager/docs/user-guide/get-started.md
@@ -24,7 +24,7 @@ docker pull intel/metrics-manager:2026.1.0
 
 The image is based on `python:3.12-slim` and includes:
 
-- Telegraf 1.37.3 (system metrics agent)
+- Telegraf 1.39.3 (system metrics agent)
 - qmassa 1.3.1 (Intel® GPU telemetry)
 - Intel® NPU reader (`npu_reader.py`)
 - Python 3.12 runtime with FastAPI
@@ -88,7 +88,7 @@ This passes proxy settings both to the Docker build and to the running container
 docker compose up --build
 ```
 
-First build takes 3–10 minutes (downloads Rust toolchain to compile qmassa, Telegraf .deb, Python packages). Subsequent builds are cached and take under a minute.
+First build takes 3–10 minutes (compiles qmassa and Telegraf, then installs Python packages). Subsequent builds are cached and take under a minute.
 
 To run in the background:
 

--- a/microservices/metrics-manager/docs/user-guide/get-started/build-from-source.md
+++ b/microservices/metrics-manager/docs/user-guide/get-started/build-from-source.md
@@ -37,9 +37,10 @@ docker compose build
 This runs a multi-stage build:
 
 1. **Stage 1**: Compiles qmassa (Intel GPU reader) from Rust source
-2. **Stage 2**: Installs Python dependencies (production only, no test packages)
-3. **Stage 3**: Creates a test image with test dependencies (optional)
-4. **Stage 4**: Production image based on `python:3.12-slim` with Telegraf, qmassa, and supervisord
+2. **Stage 2**: Compiles Telegraf from Go source with patched dependencies
+3. **Stage 3**: Installs Python dependencies (production only, no test packages)
+4. **Stage 4**: Creates a test image with test dependencies (optional)
+5. **Stage 5**: Creates the production image based on `python:3.12-slim` with Telegraf, qmassa, and supervisord
 
 **First build duration**: 3–10 minutes (depends on download speeds and CPU)
 

--- a/microservices/metrics-manager/docs/user-guide/release-notes.md
+++ b/microservices/metrics-manager/docs/user-guide/release-notes.md
@@ -103,7 +103,7 @@ None at this release. See GitHub issues for feature requests and discussions.
 ### Current Image
 
 - Intel® Metrics Manager **2026.1.0**
-- Telegraf **1.37.3** (system metrics agent)
+- Telegraf **1.39.3** (system metrics agent)
 - qmassa **1.3.1** (Intel® GPU telemetry via named pipe)
 - qmmd **0.1.1** _(optional)_ — Lightweight Prometheus GPU exporter (bundled but **not started by default**; use only if you need a separate GPU metrics port)
 - Intel® NPU telemetry via bundled `npu_monitor_tool` / `npu_reader`

--- a/microservices/metrics-manager/pyproject.toml
+++ b/microservices/metrics-manager/pyproject.toml
@@ -7,7 +7,7 @@ version = "2026.1.0"
 description = "Unified metrics collection, ingestion, and relay service with OpenTelemetry support"
 requires-python = ">=3.12"
 dependencies = [
-    "fastapi[standard]==0.128.0",
+    "fastapi[standard]==0.141.1",
     "uvicorn==0.40.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",


### PR DESCRIPTION
Summary
Remediates all fixable Trivy findings in the Metrics Manager runtime image. Scope is strictly limited to security: no application code, API, configuration, or tests are changed.

Changes
Build / image (Dockerfile)

Upgrade Telegraf 1.38.4 → 1.39.3, which natively uses the maintained Moby modules (moby/moby/api, moby/moby/client) instead of the vulnerable legacy github.com/docker/docker, resolving https://github.com/advisories/GHSA-x744-4wpc-v9h2 and https://github.com/advisories/GHSA-pxq6-2prw-chj9.
Bump Go builder 1.26.4 → 1.26.6 to pick up stdlib fixes.
Remove now-unnecessary manual dependency overrides (rclone, go-billy) and the remotefile source patch — Telegraf 1.39.3 handles these upstream.
Remove pip/setuptools from the final image to clear packaging-tool findings (runtime uses stdlib importlib.metadata).
Bump build-time pip 26.1 → 26.2.1.
Dependencies (pyproject.toml)

Upgrade FastAPI 0.128.0 → 0.141.1, pulling in a non-vulnerable Starlette.
Documentation

Update Telegraf version references and the multi-stage build description in get-started.md, build-from-source.md, and release-notes.md.
Compatibility
Telegraf inputs.docker, inputs.docker_log, and inputs.ecs plugins are preserved, so custom Telegraf configurations continue to work.
All consumer contracts are unchanged and verified live: REST API (:9090 /health, /api/v1/capabilities, /api/v1/metrics, /api/v1/metrics/simple, /metrics/stream), Prometheus scrape (:9273/metrics), and the Telegraf HTTP listener (:8186/write). Metric names are unchanged.
Validation
Trivy (--ignore-unfixed, fresh DB): 0 vulnerabilities, 0 secrets (all severities).
Production container starts healthy; telegraf, metrics-manager, and qmassa all RUNNING.
Unit test suite passes (excluding two failures that pre-exist on main and are unrelated to this change).
End-to-end metric ingestion verified through the SSE stream and Prometheus endpoint.