### PR TITLE
[ViPPET] Hide unsupported variants and pipelines

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/routes/pipelines.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/api/routes/pipelines.py
@@ -375,6 +375,10 @@ def get_pipelines():
     """
     internal_pipelines = PipelineManager().get_pipelines()
 
+    # Variants unsupported on this platform are filtered out on load, so a
+    # pipeline can end up with none - such a pipeline is not runnable here.
+    internal_pipelines = [p for p in internal_pipelines if p.variants]
+
     # If timeseries service is not available, filter to vision pipelines only
     if not _is_timeseries_service_available():
         logger.debug(

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/device.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/device.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 import logging
+import re
 
 import openvino as ov
 
@@ -228,3 +230,54 @@ class DeviceDiscovery:
     def list_devices(self):
         """List all available devices."""
         return self.devices
+
+
+def running_on_wsl() -> bool:
+    """
+    Check whether the application runs on a WSL host.
+
+    Returns:
+        bool: True if the WSL GPU device node is present, False otherwise.
+    """
+    return Path("/dev/dxg").exists()
+
+
+def is_variant_supported(variant_name: str) -> bool:
+    """
+    Check whether a pipeline variant can run on the current platform.
+
+    Variant names encode the devices they use, for example "CPU", "GPU",
+    "GPU_NPU" or "GPU (WSL)". A variant is supported when every device family
+    it requires is available and, for GPU variants, when its WSL flavour
+    matches the current platform.
+
+    Args:
+        variant_name (str): Variant name as defined in the pipeline configuration.
+
+    Returns:
+        bool: True if the variant can run on this platform, False otherwise.
+    """
+    tokens = re.split(r"[^A-Z]+", variant_name.upper())
+    required = {
+        DeviceFamily(token) for token in tokens if token in DeviceFamily.__members__
+    }
+    if not required:
+        return True
+
+    try:
+        available = {
+            device.device_family for device in DeviceDiscovery().list_devices()
+        }
+    except Exception:
+        logger.exception(
+            "Device discovery failed, assuming variant '%s' is supported", variant_name
+        )
+        return True
+
+    if not required.issubset(available):
+        return False
+
+    if DeviceFamily.GPU in required and ("WSL" in tokens) != running_on_wsl():
+        return False
+
+    return True

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/pipeline_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/pipeline_manager.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Optional, List
 
 from graph import Graph, OUTPUT_PLACEHOLDER, graph_is_metadata_only
+from device import is_variant_supported
 from internal_types import (
     InternalExecutionConfig,
     InternalOutputMode,
@@ -457,6 +458,14 @@ class PipelineManager:
                     raise ValueError(
                         f"Variant name cannot be empty in pipeline '{pipeline_name}'"
                     )
+
+                if not is_variant_supported(variant_name):
+                    self.logger.info(
+                        "Skipping variant '%s' of pipeline '%s': not supported on this platform",
+                        variant_name,
+                        pipeline_name,
+                    )
+                    continue
 
                 variant_pipeline_desc = variant_config.get(
                     "pipeline_description", ""

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/pipeline_manager_test.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/unit/managers_tests/pipeline_manager_test.py
@@ -337,10 +337,10 @@ class TestPipelineManager(unittest.TestCase):
         self.assertIsInstance(pipelines, list)
         self.assertGreaterEqual(len(pipelines), 1)
 
-        # Check that predefined pipelines have variants
+        # Variants unsupported on the current platform are filtered out on load,
+        # so a predefined pipeline may legitimately expose no variants here.
         for pipeline in pipelines:
             if pipeline.source == InternalPipelineSource.PREDEFINED:
-                self.assertGreater(len(pipeline.variants), 0)
                 for variant in pipeline.variants:
                     self.assertIsNotNone(variant.id)
                     self.assertIsNotNone(variant.name)


### PR DESCRIPTION
Pipeline variants are now filtered at load time based on the devices available on the host (is_variant_supported() in device.py) — a variant is kept only when all device families encoded in its name (CPU/GPU/NPU) are present and its WSL flavour matches the platform. Pipelines left with no supported variants are excluded from GET /pipelines so the UI does not show pipelines that cannot run.