### PR TITLE
[ViPPET] Show GPU widgets immediately using detected devices

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/useMetrics.ts
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/metrics/useMetrics.ts
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { useAppSelector } from "@/store/hooks.ts";
+import { selectGpuDevices } from "@/store/reducers/devices.ts";
 import {
   selectCpuMetric,
   selectCpuMetrics,
@@ -21,17 +22,37 @@ export const useMetrics = () => {
   const npu = useAppSelector(selectNpuMetric);
   const npuDetailed = useAppSelector(selectNpuMetrics);
   const allMetrics = useAppSelector(selectMetrics);
+  const gpuDevices = useAppSelector(selectGpuDevices);
   const previousAvailableGpuIdsRef = useRef<string[]>([]);
   const previousGpuUsageRef = useRef<Record<string, number>>({});
   const gpuZeroStreakRef = useRef<Record<string, number>>({});
 
-  // dynamically get all available GPU IDs
-  const rawAvailableGpuIds = Array.from(
+  // Build GPU IDs from live metrics first.
+  const metricDerivedGpuIds = Array.from(
     new Set(
       allMetrics
         .filter((m) => m.name === "gpu_engine_usage_usage" && m.labels.gpu_id)
         .map((m) => m.labels.gpu_id),
     ),
+  ).sort();
+
+  // Build GPU IDs from detected devices so UI can render immediately
+  // before first GPU telemetry sample arrives.
+  const deviceDerivedGpuIds = gpuDevices
+    .map((device) => {
+      if (device.device_name === "GPU") {
+        return "0";
+      }
+      if (device.device_name.startsWith("GPU.")) {
+        return device.device_name.replace("GPU.", "");
+      }
+      return undefined;
+    })
+    .filter((id): id is string => id !== undefined)
+    .sort();
+
+  const rawAvailableGpuIds = Array.from(
+    new Set([...deviceDerivedGpuIds, ...metricDerivedGpuIds]),
   ).sort();
 
   if (rawAvailableGpuIds.length > 0) {


### PR DESCRIPTION
### Description

cherrypick #2880

Show GPU widgets immediately using detected devices

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

A/B manual testing - open vippet page and visually inspect utilization widgets on dashboard.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

