### PR TITLE
security(metrics-manager): harden runtime profiles

### DIFF
--- a/microservices/metrics-manager/Dockerfile
+++ b/microservices/metrics-manager/Dockerfile
@@ -186,6 +186,9 @@ FROM python:3.12-slim AS production
 
 ARG INSTALL_OPENVINO=false
 
+ARG METRICS_MANAGER_UID=10001
+ARG METRICS_MANAGER_GID=10001
+
 # Proxy settings (passed from docker-compose build args)
 ARG http_proxy
 ARG HTTP_PROXY
@@ -272,11 +275,20 @@ RUN sed -i 's/\r$//' /entrypoint.sh /etc/telegraf/telegraf.conf /etc/supervisor/
 # Make scripts executable
 RUN chmod +x /entrypoint.sh && \
     find /app/scripts -name "*.sh" -exec chmod +x {} + && \
-    find /app/scripts -name "*.py" -exec chmod +x {} +
+    find /app/scripts -name "*.py" -exec chmod +x {} + && \
+    groupadd --gid ${METRICS_MANAGER_GID} metrics-manager && \
+    useradd --uid ${METRICS_MANAGER_UID} --gid ${METRICS_MANAGER_GID} \
+        --create-home --shell /usr/sbin/nologin metrics-manager && \
+    chown -R ${METRICS_MANAGER_UID}:${METRICS_MANAGER_GID} \
+        /app /tmp /var/log/telegraf /etc/telegraf /etc/supervisor
 
 # Environment variables with defaults
 ENV METRICS_PORT=9090
 ENV TELEGRAF_PORT=9273
+ENV HARDWARE_TELEMETRY_ENABLED=false
+ENV QMASSA_FIFO_PATH=/app/qmassa.fifo
+ENV QMASSA_LOG_TO_STDERR=false
+ENV NPU_READER_LOG_FILE=/app/npu_reader_trace.log
 ENV LOG_LEVEL=INFO
 ENV CORS_ORIGINS="*"
 ENV CUSTOM_METRICS_DIR=/app/custom-metrics
@@ -287,6 +299,8 @@ ENV TELEGRAF_CONFIG_PATH=/etc/telegraf/telegraf.conf
 # 9273 - Telegraf Prometheus metrics
 # 8186 - Telegraf HTTP listener (InfluxDB Line Protocol)
 EXPOSE 9090 9273 8186
+
+USER ${METRICS_MANAGER_UID}:${METRICS_MANAGER_GID}
 
 # OCI image metadata - version is read from the VERSION file at build time
 # (single source of truth used by Makefile / docker compose).

--- a/microservices/metrics-manager/README.md
+++ b/microservices/metrics-manager/README.md
@@ -65,6 +65,7 @@ enumerate render nodes):
 ```bash
 docker run --rm \
   --device /dev/dri \
+  --user 0:0 \
   -p 9090:9090 -p 9273:9273 \
   -v /sys:/sys:ro -v /run:/run:ro \
   --pid host \
@@ -76,6 +77,7 @@ sysfs interface, which requires `--privileged`):
 
 ```bash
 docker run --rm --privileged \
+  --user 0:0 \
   -p 9090:9090 -p 9273:9273 \
   -v /sys:/sys:ro -v /run:/run:ro \
   --pid host \
@@ -116,6 +118,7 @@ docker build -t metrics-manager .
 docker run -d \
   --name metrics-manager \
   --privileged \
+  --user 0:0 \
   -p 9090:9090 \
   -p 9273:9273 \
   -v /sys:/sys \

--- a/microservices/metrics-manager/compose.yaml
+++ b/microservices/metrics-manager/compose.yaml
@@ -41,6 +41,7 @@ services:
         NO_PROXY: ${NO_PROXY:-}
         INSTALL_OPENVINO: ${INSTALL_OPENVINO:-false}
     container_name: metrics-manager
+    user: ${CONTAINER_USER:-0:0}
 
     # Environment configuration
     environment:
@@ -69,6 +70,7 @@ services:
       - TELEGRAF_CONFIG_PATH=/etc/telegraf/telegraf.conf
       - METRICS_RETENTION_SECONDS=${METRICS_RETENTION_SECONDS:-300}
       - MAX_METRICS_BATCH_SIZE=${MAX_METRICS_BATCH_SIZE:-1000}
+      - HARDWARE_TELEMETRY_ENABLED=${HARDWARE_TELEMETRY_ENABLED:-true}
 
     # Port mappings (external:internal - internal ports are fixed)
     ports:
@@ -78,6 +80,8 @@ services:
 
     # Device access for system metrics
     privileged: ${PRIVILEGED:-true}
+    group_add:
+      - ${GPU_RENDER_GID:-992}
 
     # Security: Disable AppArmor (required when /proc is read-only or in nested containers)
     security_opt:

--- a/microservices/metrics-manager/docs/user-guide/get-started.md
+++ b/microservices/metrics-manager/docs/user-guide/get-started.md
@@ -134,6 +134,7 @@ Add `--device /dev/dri` so qmassa can access GPU devices:
 ```bash
 docker run --rm \
   --device /dev/dri \
+  --user 0:0 \
   -p 9090:9090 \
   -p 9273:9273 \
   -v /sys:/sys:ro \
@@ -154,6 +155,7 @@ Run in privileged mode to access `/sys/class/intel_pmt`:
 
 ```bash
 docker run --rm --privileged \
+  --user 0:0 \
   -p 9090:9090 \
   -p 9273:9273 \
   -v /sys:/sys:ro \
@@ -173,6 +175,7 @@ curl -s http://localhost:9273/metrics | grep npu
 ```bash
 docker run --rm --privileged \
   --device /dev/dri \
+  --user 0:0 \
   -p 9090:9090 \
   -p 9273:9273 \
   -v /sys:/sys:ro \

--- a/microservices/metrics-manager/docs/user-guide/get-started/deploy-with-helm.md
+++ b/microservices/metrics-manager/docs/user-guide/get-started/deploy-with-helm.md
@@ -1,6 +1,6 @@
 # Helm Deployment
 
-The `metrics-manager` Helm chart deploys the same container image onto a Kubernetes cluster with host-level access required to scrape CPU / GPU / NPU telemetry from the node.
+The `metrics-manager` Helm chart deploys the same container image onto a Kubernetes cluster. The secure default profile runs non-root without host-level access; enable the hardware telemetry profile when CPU / GPU / NPU telemetry from the node is required.
 
 The chart is published to the **same OCI repository as the container image**.
 
@@ -17,11 +17,23 @@ The chart is published to the **same OCI repository as the container image**.
 | Kubernetes | 1.25    | Older clusters use the legacy AppArmor pod annotation. The chart auto-detects. 1.30+ uses the native `appArmorProfile` field. |
 | kubectl    | matching K8s | For cluster interaction                                                      |
 
-**Security Requirements:**
+**Secure default profile:**
 
-The pod runs **privileged** with `hostPID: true`, mounts host paths (`/sys`, `/run`, `/dev/dri`), and disables AppArmor / seccomp confinement so it can read GPU/NPU sysfs nodes.
+The default pod runs as non-root with `hostPID: false`, `privileged: false`, a read-only root filesystem, dropped capabilities and `RuntimeDefault` AppArmor/seccomp profiles. It does not mount host paths and is intended for the restricted application profile.
 
-**PodSecurityAdmission must allow the `privileged` profile** in the target namespace:
+**Hardware telemetry profile:**
+
+To collect host CPU/GPU/NPU telemetry, enable the profile explicitly. It requires `hostPID: true`, `privileged: true`, host paths (`/sys`, `/run`, `/dev/dri`) and the GPU render group when GPU telemetry is enabled:
+
+```bash
+helm install metrics-manager \
+  oci://registry-1.docker.io/intel/metrics-manager \
+  --version 2026.1.0-helm \
+  --namespace observability --create-namespace \
+  --set hardware.telemetry.enabled=true
+```
+
+**PodSecurityAdmission must allow the `privileged` profile** in the target namespace when using the hardware telemetry profile:
 
 ```bash
 kubectl label namespace observability \
@@ -75,7 +87,8 @@ helm show values oci://registry-1.docker.io/intel/metrics-manager \
 ```bash
 helm install metrics-manager oci://registry-1.docker.io/intel/metrics-manager \
   --version 2026.1.0-helm \
-  --set controller.kind=DaemonSet
+  --set controller.kind=DaemonSet \
+  --set hardware.telemetry.enabled=true
 ```
 
 ### CPU / NPU only host (no GPU)
@@ -83,7 +96,8 @@ helm install metrics-manager oci://registry-1.docker.io/intel/metrics-manager \
 ```bash
 helm install metrics-manager oci://registry-1.docker.io/intel/metrics-manager \
   --version 2026.1.0-helm \
-  --set hardware.gpu.enabled=false
+  --set hardware.gpu.enabled=false \
+  --set hardware.telemetry.enabled=true
 ```
 
 ### Stable Hostname Label Across Pod Restarts

--- a/microservices/metrics-manager/entrypoint.sh
+++ b/microservices/metrics-manager/entrypoint.sh
@@ -10,13 +10,14 @@ set -e
 echo "[INFO] Starting Metrics Manager..."
 
 # Ensure directories exist
-mkdir -p /app/custom-metrics
+mkdir -p /app/custom-metrics 2>/dev/null || true
 
 # Ensure named pipe for qmassa exists
-if [ ! -p /app/qmassa.fifo ]; then
-    mkfifo /app/qmassa.fifo 2>/dev/null || true
+QMASSA_FIFO_PATH="${QMASSA_FIFO_PATH:-/app/qmassa.fifo}"
+if [ ! -p "$QMASSA_FIFO_PATH" ]; then
+    mkfifo "$QMASSA_FIFO_PATH" 2>/dev/null || true
 fi
-chmod 666 /app/qmassa.fifo 2>/dev/null || true
+chmod 666 "$QMASSA_FIFO_PATH" 2>/dev/null || true
 
 # Check if custom telegraf config is mounted
 if [ -n "$TELEGRAF_CONFIG_PATH" ] && [ -f "$TELEGRAF_CONFIG_PATH" ]; then

--- a/microservices/metrics-manager/helm/metrics-manager/templates/configmap-telegraf.yaml
+++ b/microservices/metrics-manager/helm/metrics-manager/templates/configmap-telegraf.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "metrics-manager.fullname" . }}-telegraf
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-manager.labels" . | nindent 4 }}
 data:

--- a/microservices/metrics-manager/helm/metrics-manager/templates/deployment.yaml
+++ b/microservices/metrics-manager/helm/metrics-manager/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: {{ $kind }}
 metadata:
   name: {{ include "metrics-manager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-manager.labels" . | nindent 4 }}
 spec:
@@ -50,7 +51,16 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "metrics-manager.serviceAccountName" . }}
-      hostPID: {{ .Values.pod.hostPID }}
+      hostPID: {{ if .Values.hardware.telemetry.enabled }}true{{ else }}{{ .Values.pod.hostPID }}{{ end }}
+      securityContext:
+        fsGroup: {{ .Values.pod.fsGroup }}
+        {{- if .Values.hardware.telemetry.enabled }}
+        supplementalGroups:
+          - {{ .Values.hardware.gpuRenderGroup }}
+        {{- else if .Values.pod.supplementalGroups }}
+        supplementalGroups:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       hostNetwork: {{ .Values.pod.hostNetwork }}
       {{- /*
         dnsPolicy:
@@ -94,9 +104,16 @@ spec:
           image: {{ include "metrics-manager.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            privileged: {{ .Values.securityContext.privileged }}
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            privileged: {{ if .Values.hardware.telemetry.enabled }}true{{ else }}{{ .Values.securityContext.privileged }}{{ end }}
+            allowPrivilegeEscalation: {{ if .Values.hardware.telemetry.enabled }}true{{ else }}{{ .Values.securityContext.allowPrivilegeEscalation }}{{ end }}
+            runAsNonRoot: {{ if .Values.hardware.telemetry.enabled }}false{{ else }}{{ .Values.securityContext.runAsNonRoot }}{{ end }}
+            runAsUser: {{ if .Values.hardware.telemetry.enabled }}0{{ else }}{{ .Values.securityContext.runAsUser }}{{ end }}
+            runAsGroup: {{ if .Values.hardware.telemetry.enabled }}0{{ else }}{{ .Values.securityContext.runAsGroup }}{{ end }}
+            readOnlyRootFilesystem: {{ if .Values.hardware.telemetry.enabled }}false{{ else }}{{ .Values.securityContext.readOnlyRootFilesystem }}{{ end }}
+            {{- with .Values.securityContext.capabilities }}
+            capabilities:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             {{- /*
               appArmorProfile is a native field starting with Kubernetes
               1.30. On older API servers it is silently dropped or rejected,
@@ -113,11 +130,19 @@ spec:
             {{- $apparmorNative := or (.Values.securityContext.appArmorProfileForce) (and (ge $kubeMajor 1) (ge $kubeMinor 30)) }}
             {{- if and .Values.securityContext.appArmorProfile $apparmorNative }}
             appArmorProfile:
+              {{- if .Values.hardware.telemetry.enabled }}
+              type: Unconfined
+              {{- else }}
               {{- toYaml .Values.securityContext.appArmorProfile | nindent 14 }}
+              {{- end }}
             {{- end }}
             {{- with .Values.securityContext.seccompProfile }}
             seccompProfile:
+              {{- if $.Values.hardware.telemetry.enabled }}
+              type: Unconfined
+              {{- else }}
               {{- toYaml . | nindent 14 }}
+              {{- end }}
             {{- end }}
           ports:
             - name: metrics
@@ -146,6 +171,14 @@ spec:
               value: {{ .Values.config.metricsRetentionSeconds | quote }}
             - name: MAX_METRICS_BATCH_SIZE
               value: {{ .Values.config.maxMetricsBatchSize | quote }}
+            - name: HARDWARE_TELEMETRY_ENABLED
+              value: {{ if .Values.hardware.telemetry.enabled }}"true"{{ else }}{{ .Values.config.hardwareTelemetryEnabled | quote }}{{ end }}
+            - name: QMASSA_FIFO_PATH
+              value: {{ if .Values.hardware.telemetry.enabled }}"/app/qmassa.fifo"{{ else }}"/tmp/qmassa.fifo"{{ end }}
+            - name: QMASSA_LOG_TO_STDERR
+              value: {{ if .Values.hardware.telemetry.enabled }}"false"{{ else }}"true"{{ end }}
+            - name: NPU_READER_LOG_FILE
+              value: {{ if .Values.hardware.telemetry.enabled }}"/app/npu_reader_trace.log"{{ else }}"/tmp/npu_reader_trace.log"{{ end }}
             - name: METRICS_MANAGER_HOSTNAME
               value: {{ .Values.config.hostnameOverride | quote }}
             - name: CUSTOM_METRICS_DIR
@@ -168,13 +201,17 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.hardware.telemetry.enabled }}
             - name: sys
               mountPath: /sys
               readOnly: true
             - name: run
               mountPath: /run
               readOnly: true
-            {{- if .Values.hardware.gpu.enabled }}
+            {{- end }}
+            {{- if and .Values.hardware.telemetry.enabled .Values.hardware.gpu.enabled }}
             - name: dev-dri
               mountPath: /dev/dri
             {{- end }}
@@ -189,6 +226,9 @@ spec:
               mountPath: /app/custom-metrics
             {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.hardware.telemetry.enabled }}
         - name: sys
           hostPath:
             path: /sys
@@ -197,7 +237,8 @@ spec:
           hostPath:
             path: /run
             type: Directory
-        {{- if .Values.hardware.gpu.enabled }}
+          {{- end }}
+          {{- if and .Values.hardware.telemetry.enabled .Values.hardware.gpu.enabled }}
         - name: dev-dri
           hostPath:
             path: /dev/dri

--- a/microservices/metrics-manager/helm/metrics-manager/templates/pvc.yaml
+++ b/microservices/metrics-manager/helm/metrics-manager/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "metrics-manager.fullname" . }}-custom-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-manager.labels" . | nindent 4 }}
 spec:

--- a/microservices/metrics-manager/helm/metrics-manager/templates/service.yaml
+++ b/microservices/metrics-manager/helm/metrics-manager/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "metrics-manager.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-manager.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/microservices/metrics-manager/helm/metrics-manager/templates/serviceaccount.yaml
+++ b/microservices/metrics-manager/helm/metrics-manager/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "metrics-manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "metrics-manager.labels" . | nindent 4 }}
   {{- with .Values.pod.serviceAccount.annotations }}

--- a/microservices/metrics-manager/helm/metrics-manager/values.yaml
+++ b/microservices/metrics-manager/helm/metrics-manager/values.yaml
@@ -12,7 +12,7 @@
 # Container image
 # -----------------------------------------------------------------------------
 image:
-  repository: intel/metrics-manager
+  repository: docker.io/intel/metrics-manager
   # tag defaults to .Chart.AppVersion (kept in sync with ./VERSION).
   # Override only when running a custom build.
   tag: ""
@@ -44,7 +44,9 @@ pod:
   # Required for the bundled npu_reader to read /proc/<pid>/... and the
   # Telegraf [[inputs.system]] / [[inputs.processes]] plugins to see all
   # processes on the host. Equivalent to `pid: host` in compose.yaml.
-  hostPID: true
+  hostPID: false
+  fsGroup: 10001
+  supplementalGroups: []
   # CPU/RAM/temperature/GPU/NPU readers all read sysfs from the host.
   # The pod itself does not need hostNetwork, but exposing the API on the
   # host's network namespace can simplify scraping by node-local agents.
@@ -69,17 +71,20 @@ pod:
 # -----------------------------------------------------------------------------
 # Container security context
 # -----------------------------------------------------------------------------
-# `privileged: true` matches the documented `docker run --privileged`
-# invocation that allows the bundled npu_reader to access
-# /sys/class/intel_pmt and the qmassa GPU monitor to enumerate render nodes.
-# Disable only if you are running CPU/RAM/temperature collection only.
+# Secure defaults run the container as non-root without host namespaces or
+# privileged access. Enable hardware.telemetry for full host telemetry.
 securityContext:
-  privileged: true
-  runAsNonRoot: false
-  readOnlyRootFilesystem: false
-  # AppArmor / seccomp Unconfined matches the compose.yaml `security_opt:
-  # apparmor:unconfined` knob (required when /proc is read-only or in
-  # nested containers).
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  # Secure defaults use RuntimeDefault profiles. The hardware telemetry
+  # profile switches to Unconfined to match the Compose hardware mode.
   #
   # `appArmorProfile` is a native container security-context field added in
   # Kubernetes 1.30. The chart auto-detects the API version and renders
@@ -89,18 +94,22 @@ securityContext:
   # even when KubeVersion reports an older minor (useful for `helm template`
   # when targeting a specific cluster).
   appArmorProfile:
-    type: Unconfined
+    type: RuntimeDefault
   appArmorProfileForce: false
   seccompProfile:
-    type: Unconfined
+    type: RuntimeDefault
 
 # -----------------------------------------------------------------------------
 # Hardware access
 # -----------------------------------------------------------------------------
 hardware:
-  # Mount /dev/dri so qmassa can enumerate Intel(R) GPU render nodes.
-  # On NPU-only or CPU-only hosts leave this disabled - qmassa will
-  # detect the absence of the device and idle silently.
+  # Set to true to enable host-level GPU/NPU and system telemetry. This
+  # requires privileged access, hostPID and hostPath mounts.
+  telemetry:
+    enabled: false
+  gpuRenderGroup: 992
+  # Mount /dev/dri so qmassa can enumerate Intel(R) GPU render nodes when
+  # hardware telemetry is enabled.
   gpu:
     enabled: true
   # NPU telemetry comes from /sys/class/intel_pmt which is exposed via
@@ -135,6 +144,7 @@ config:
   corsOrigins: "*"
   metricsRetentionSeconds: 300
   maxMetricsBatchSize: 1000
+  hardwareTelemetryEnabled: false
   # Optional: stable host label for Telegraf, qmassa_reader and npu_reader.
   # Empty -> kernel hostname (default Telegraf behaviour).
   hostnameOverride: ""

--- a/microservices/metrics-manager/scripts/npu_reader.py
+++ b/microservices/metrics-manager/scripts/npu_reader.py
@@ -40,7 +40,7 @@ INTERVAL_S = 1.0
 # instead of restarting the process every Telegraf execd retry (~10s). This
 # keeps the Telegraf log quiet on hosts without an Intel NPU.
 IDLE_SLEEP_S = 3600
-DEBUG_LOG = "/app/npu_reader_trace.log"
+DEBUG_LOG = os.environ.get("NPU_READER_LOG_FILE", "/app/npu_reader_trace.log")
 
 file_handler = logging.FileHandler(DEBUG_LOG)
 file_handler.setFormatter(

--- a/microservices/metrics-manager/scripts/qmassa_reader.py
+++ b/microservices/metrics-manager/scripts/qmassa_reader.py
@@ -18,7 +18,7 @@ import time
 from logging.handlers import RotatingFileHandler
 
 # === Constants ===
-FIFO_FILE = "/app/qmassa.fifo"
+FIFO_FILE = os.environ.get("QMASSA_FIFO_PATH", "/app/qmassa.fifo")
 DEBUG_LOG = os.environ.get("QMASSA_LOG_FILE", "/app/qmassa_reader_trace.log")
 # Hostname used in the `host=` tag of every emitted line. Defaults to the
 # kernel hostname (matches Telegraf's default behaviour) but can be overridden

--- a/microservices/metrics-manager/supervisord.conf
+++ b/microservices/metrics-manager/supervisord.conf
@@ -22,7 +22,6 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisord]
 nodaemon=true
-user=root
 loglevel=warn
 logfile=/dev/null
 pidfile=/tmp/supervisord.pid
@@ -70,7 +69,7 @@ stopwaitsecs=2
 
 # qmassa - GPU metrics collection (Intel GPUs)
 [program:qmassa]
-command=qmassa --ms-interval 1000 --no-tui --to-json /app/qmassa.fifo
+command=/bin/sh -c 'if [ "%(ENV_HARDWARE_TELEMETRY_ENABLED)s" = "true" ]; then exec qmassa --ms-interval 1000 --no-tui --to-json %(ENV_QMASSA_FIFO_PATH)s; else exec python3 -c "import signal; signal.pause()"; fi'
 autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout

--- a/microservices/metrics-manager/tests/test_helm_chart.py
+++ b/microservices/metrics-manager/tests/test_helm_chart.py
@@ -98,9 +98,34 @@ def test_helm_template_renders() -> None:
     rendered = result.stdout
     assert "kind: Deployment" in rendered
     assert "kind: Service" in rendered
-    # Privileged hostPID profile must always be rendered.
+    assert "hostPID: false" in rendered
+    assert "privileged: false" in rendered
+    assert "runAsNonRoot: true" in rendered
+    assert "readOnlyRootFilesystem: true" in rendered
+    assert "allowPrivilegeEscalation: false" in rendered
+    assert "type: RuntimeDefault" in rendered
+    assert "hostPath:" not in rendered
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm CLI not installed")
+def test_helm_template_hardware_telemetry_profile() -> None:
+    result = subprocess.run(
+        [
+            "helm", "template", "test", str(CHART_DIR),
+            "--set", "hardware.telemetry.enabled=true",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    rendered = result.stdout
     assert "hostPID: true" in rendered
     assert "privileged: true" in rendered
+    assert "runAsNonRoot: false" in rendered
+    assert "readOnlyRootFilesystem: false" in rendered
+    assert "mountPath: /sys" in rendered
+    assert "mountPath: /dev/dri" in rendered
 
 
 @pytest.mark.skipif(shutil.which("helm") is None, reason="helm CLI not installed")


### PR DESCRIPTION
## Summary

Harden the Metrics Manager container image and Helm deployment against container security misconfiguration findings while preserving the existing GPU/NPU hardware telemetry mode.

## Changes

- Add a dedicated non-root `metrics-manager` user with UID/GID `10001`.
- Configure secure Helm defaults:
  - `runAsNonRoot: true`
  - `runAsUser: 10001`
  - `runAsGroup: 10001`
  - `allowPrivilegeEscalation: false`
  - `readOnlyRootFilesystem: true`
  - `capabilities.drop: ["ALL"]`
  - `seccompProfile: RuntimeDefault`
  - `hostPID: false`
  - `privileged: false`
- Add writable `/tmp` handling for Supervisor runtime files and secure-mode reader paths.
- Add an explicit hardware telemetry profile:
  ```bash
  --set hardware.telemetry.enabled=true
  ```
- Preserve the existing hardware telemetry mode for GPU/NPU deployments, including:
  - `hostPID`
  - `privileged`
  - `/sys`
  - `/run`
  - `/dev/dri`
  - qmassa
  - NPU reader
- Add configurable GPU render-device group handling.
- Add explicit release namespaces to namespaced Helm resources.
- Update Docker and Helm documentation for secure and hardware telemetry profiles.
- Update Helm tests to validate both secure defaults and the hardware telemetry profile.

## Compatibility

- REST API endpoints and response formats remain unchanged.
- Ports `9090`, `9273`, and `8186` remain unchanged.
- JSON, InfluxDB Line Protocol, OTLP, Prometheus, and SSE interfaces remain unchanged.
- Docker Compose preserves the existing hardware telemetry behavior by default.
- GPU telemetry and qmassa remain available in the explicit hardware telemetry profile.
- Existing custom metrics and Telegraf configuration paths remain unchanged.

## Security Validation

Trivy misconfiguration scan:

```text
HIGH:   0
MEDIUM: 1
LOW:    0
```

Resolved High findings:

- `DS-0002`
- `KSV-0010`
- `KSV-0014`
- `KSV-0017`
- `KSV-0118`
- `KSV-0121`

The remaining Medium finding is:

```text
KSV-0125 - image from an untrusted registry
```

The image is currently published on Docker Hub. Resolving this finding requires either an approved mirror registry or adding the official registry to the Trivy trusted-registry policy. No `.trivyignore` entry was added.

## Validation

- Dockerfile Trivy scan: passed with `0` findings.
- High-severity misconfiguration findings: `0`.
- Low-severity misconfiguration findings: `0`.
- Helm lint: passed.
- Secure non-root/read-only container startup: passed.
- CPU happy path: passed.
- GPU happy path: passed.
- Metrics Manager, Telegraf, and qmassa verified running in the compatible hardware mode.
- REST, InfluxDB, OTLP, SSE, Prometheus, rate limiting, and metric ingestion flows verified.
- Focused tests: `36 passed, 3 skipped`.
