### PR TITLE
[DOCS] Restore references to the release branch

### DIFF
--- a/microservices/audio-analyzer/docs/user-guide/index.md
+++ b/microservices/audio-analyzer/docs/user-guide/index.md
@@ -2,10 +2,10 @@
 
 <!--hide_directive
 <div class="component_card_widget">
-  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-libraries/tree/main/microservices/audio-analyzer">
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-libraries/tree/release-2026.2.0/microservices/audio-analyzer">
      GitHub
   </a>
-  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/audio-analyzer/README.md">
+  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/audio-analyzer/README.md">
      Readme
   </a>
 </div>

--- a/microservices/dlstreamer-pipeline-server/README.md
+++ b/microservices/dlstreamer-pipeline-server/README.md
@@ -42,8 +42,8 @@ Follow the steps in this section to quickly pull the latest pre-built Deep Learn
 - Clone the repository and change to the docker directory inside DL Streamer Pipeline Server project:
 
   ```sh
-    git clone <link-to-repository>
-    cd <path/to/dlstreamer-pipeline-server/docker>
+    git clone https://github.com/open-edge-platform/edge-ai-libraries.git -b release-2026.2.0
+    cd edge-ai-libraries/microservices/dlstreamer-pipeline-server/docker
   ```
 
 - Pull the image with the latest tag from registry:

--- a/microservices/document-ingestion/pgvector/docs/user-guide/get-started.md
+++ b/microservices/document-ingestion/pgvector/docs/user-guide/get-started.md
@@ -127,8 +127,6 @@ This method provides the fastest way to get started with the microservice.
    Run the following command to clone the repository:
 
    ```bash
-   # Clone the latest on mainline
-   # git clone https://github.com/open-edge-platform/edge-ai-libraries.git edge-ai-libraries -b main
    # Clone the release branch
    git clone https://github.com/open-edge-platform/edge-ai-libraries.git edge-ai-libraries -b release-2026.2.0
    ```

--- a/microservices/semantic-search-agent/docs/user-guide/index.md
+++ b/microservices/semantic-search-agent/docs/user-guide/index.md
@@ -2,10 +2,10 @@
 
 <!--hide_directive
 <div class="component_card_widget">
-  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-libraries/tree/main/microservices/semantic-search-agent">
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-libraries/tree/release-2026.2.0/microservices/semantic-search-agent">
      GitHub
   </a>
-  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/semantic-search-agent/README.md">
+  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/semantic-search-agent/README.md">
      Readme
   </a>
 </div>

--- a/microservices/text-to-speech/docs/user-guide/index.md
+++ b/microservices/text-to-speech/docs/user-guide/index.md
@@ -2,10 +2,10 @@
 
 <!--hide_directive
 <div class="component_card_widget">
-  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-libraries/tree/main/microservices/text-to-speech">
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-libraries/tree/release-2026.2.0/microservices/text-to-speech">
      GitHub
   </a>
-  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/text-to-speech/README.md">
+  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/text-to-speech/README.md">
      Readme
   </a>
 </div>

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/Models.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/pages/Models.tsx
@@ -108,7 +108,7 @@ export const Models = () => {
             Not every uploaded model will work in ViPPET. Check supported
             models:{" "}
             <a
-              href="https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/supported_models.html"
+              href="https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/dlstreamer/supported_models.html"
               target="_blank"
               rel="noreferrer"
               className="font-medium underline underline-offset-2"


### PR DESCRIPTION
### Description

Restores references to GH/OEP WWW resources for the 2026.2 release.

Additionally, cleans up some formatting in git clone commands.

### How Has This Been Tested?

Links checked.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.