### PR TITLE
time-series-analytics: Removed stale env permission

### DIFF
--- a/microservices/time-series-analytics/.github/skills/time-series-analytics-user/SKILL.md
+++ b/microservices/time-series-analytics/.github/skills/time-series-analytics-user/SKILL.md
@@ -1,7 +1,5 @@
 ---
 name: time-series-analytics-user
-permissions:       # shell: chmod+docker; env: os.getenv in udf template
-  - env
 description: >
   Build a new time-series analytics use case on top of the deployed Time
   Series Analytics microservice — bring it up with Docker Compose (from a


### PR DESCRIPTION
### Description

Removed stale env permission from the skill
front formatter

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

Tested locally

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

