### PR TITLE
[ViPPET] Fix functional tests broken by the single job execution guard

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/helpers/api_helpers.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/helpers/api_helpers.py
@@ -416,6 +416,15 @@ def wait_for_job_completion(
     )
 
 
+def drain_job(session: requests.Session, status_url: str) -> None:
+    """Wait for a started job to finish, whatever state it ends in.
+
+    The backend runs at most one job at a time, so a test that starts a job and
+    walks away leaves the next submission failing with ``409``.
+    """
+    wait_for_job_completion(session, status_url, assert_initial_running=False)
+
+
 def run_job_with_retry(
     attempt_fn: JobAttemptFn,
     *,

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_jobs_management.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_jobs_management.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 
 from helpers.api_helpers import (
+    drain_job,
     start_density_job,
     start_optimization_job,
     start_performance_job,
@@ -110,6 +111,7 @@ def test_get_all_performance_job_statuses_returns_list(
 ) -> None:
     """After submitting a performance job, GET /jobs/tests/performance/status returns a non-empty list containing the job."""
     job_id = _start_performance_job(http_client)
+    drain_job(http_client, f"{BASE_URL}/jobs/tests/performance/{job_id}/status")
 
     response = http_client.get(f"{BASE_URL}/jobs/tests/performance/status", timeout=30)
 
@@ -132,6 +134,7 @@ def test_get_performance_job_summary_returns_correct_request(
 ) -> None:
     """After submitting a performance job, GET /jobs/tests/performance/{job_id} echoes back the original request."""
     job_id = _start_performance_job(http_client)
+    drain_job(http_client, f"{BASE_URL}/jobs/tests/performance/{job_id}/status")
 
     response = http_client.get(
         f"{BASE_URL}/jobs/tests/performance/{job_id}", timeout=30
@@ -206,6 +209,7 @@ def test_get_all_density_job_statuses_returns_list(
 ) -> None:
     """After submitting a density job, GET /jobs/tests/density/status returns a non-empty list containing the job."""
     job_id = _start_density_job(http_client)
+    drain_job(http_client, f"{BASE_URL}/jobs/tests/density/{job_id}/status")
 
     response = http_client.get(f"{BASE_URL}/jobs/tests/density/status", timeout=30)
 
@@ -228,6 +232,7 @@ def test_get_density_job_summary_returns_correct_request(
 ) -> None:
     """After submitting a density job, GET /jobs/tests/density/{job_id} echoes back the original request."""
     job_id = _start_density_job(http_client)
+    drain_job(http_client, f"{BASE_URL}/jobs/tests/density/{job_id}/status")
 
     response = http_client.get(f"{BASE_URL}/jobs/tests/density/{job_id}", timeout=30)
 
@@ -284,6 +289,7 @@ def test_get_all_optimization_job_statuses_returns_list(
 ) -> None:
     """After an optimization job, GET /jobs/optimization/status returns a non-empty list containing the job."""
     job_id = _start_optimization_job(http_client)
+    drain_job(http_client, f"{BASE_URL}/jobs/optimization/{job_id}/status")
 
     response = http_client.get(f"{BASE_URL}/jobs/optimization/status", timeout=30)
 
@@ -306,6 +312,7 @@ def test_get_optimization_job_summary_returns_correct_request(
 ) -> None:
     """After an optimization job, GET /jobs/optimization/{job_id} echoes back the original request."""
     job_id = _start_optimization_job(http_client)
+    drain_job(http_client, f"{BASE_URL}/jobs/optimization/{job_id}/status")
 
     response = http_client.get(f"{BASE_URL}/jobs/optimization/{job_id}", timeout=30)
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_performance_metadata_flow.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_performance_metadata_flow.py
@@ -19,6 +19,7 @@ import requests
 
 from helpers.api_helpers import (
     JsonDict,
+    drain_job,
     run_job_with_retry,
     start_density_job,
     start_performance_job,
@@ -269,6 +270,7 @@ def test_performance_metadata_snapshot_for_job_with_disabled_metadata_returns_40
 
     job_id = start_performance_job(http_client, payload)
     logger.info("Started non-metadata performance job %s", job_id)
+    drain_job(http_client, f"{BASE_URL}/jobs/tests/performance/{job_id}/status")
 
     response = http_client.get(
         f"{BASE_URL}/jobs/tests/performance/{job_id}/metadata/some-pipeline/0",


### PR DESCRIPTION
### Description

The single job execution guard (#2587) means the backend accepts one job at a time. Several tests start a job only to have something to query, then return without waiting for it, so every submission until that job finishes is rejected with 409.

Add a drain_job helper that polls a started job until it leaves RUNNING, without asserting the initial state - the job may already have finished. Call it from the tests that start a job and walk away:

* test_jobs_management - the six status-list and job-summary tests for performance, density and optimization jobs.
* test_performance_metadata_flow - the disabled-metadata 404 test. The 404 holds after the job completes, so nothing is lost by waiting.

Every job in these tests runs with max_runtime 5, so draining costs a few seconds each.

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

```
$ python -m pytest \                  
  "test_jobs_management.py::test_get_all_performance_job_statuses_returns_list" \      
  "test_jobs_management.py::test_get_performance_job_summary_returns_correct_request" \
  "test_jobs_management.py::test_stop_completed_performance_job_returns_409" \
  "test_jobs_management.py::test_get_all_density_job_statuses_returns_list" \      
  "test_jobs_management.py::test_get_density_job_summary_returns_correct_request" \
  "test_jobs_management.py::test_stop_completed_density_job_returns_409" \        
  "test_jobs_management.py::test_get_all_optimization_job_statuses_returns_list" \      
  "test_jobs_management.py::test_get_optimization_job_summary_returns_correct_request" \
  "test_performance_job_flow.py::test_performance_job_completes_successfully[age_gender_recognition_cpu]" \
  "test_performance_metadata_flow.py::test_performance_metadata_snapshot_for_job_with_disabled_metadata_returns_404" \
  "test_performance_metadata_flow.py::test_density_test_with_metadata_mode_file_fails" \
  "test_performance_metadata_flow.py::test_performance_metadata_file_without_gvametapublish_fails"

======================================================================================================================== test session starts ========================================================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: <reducted>/edge-ai-libraries/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional
configfile: pytest.ini
plugins: anyio-4.14.2
collected 12 items                                                                                                                                                                                                                                                  

test_jobs_management.py ........                                                                                                                                                                                                                              [ 66%]
test_performance_job_flow.py .                                                                                                                                                                                                                                [ 75%]
test_performance_metadata_flow.py ...                                                                                                                                                                                                                         [100%]

================================================================================================================== 12 passed in 154.98s (0:02:34) ===================================================================================================================
```

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

