### PR TITLE
[ViPPET] Adapt metadata SSE tests to the finished-job 204

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/_assets/vippet.json
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/_assets/vippet.json
@@ -1008,7 +1008,7 @@
           "jobs"
         ],
         "summary": "Stream metadata from a running performance test job via SSE",
-        "description": "**Stream live metadata records from gvametapublish via Server-Sent Events.**\n\n## Operation\n\nOpens a persistent HTTP connection and pushes each new JSON record emitted\nby the ``gvametapublish`` GStreamer element as an SSE ``data:`` event.\nThe stream terminates automatically when the pipeline finishes.\nA ``\": keepalive\"`` comment is sent every 30 s to prevent proxy timeouts.\n\n## Path Parameters\n\n- `job_id`: Identifier of the performance job to stream metadata from\n\n## Response Format\n\n``text/event-stream`` \u2014 each event is:\n```\ndata: {<json record>}\n\n\n```\n\n## Response Codes\n\n| Code | Description |\n|------|-------------|\n| 200  | SSE stream opened |\n| 404  | Job id is unknown or no metadata is available for this job |",
+        "description": "**Stream live metadata records from gvametapublish via Server-Sent Events.**\n\n## Operation\n\nOpens a persistent HTTP connection and pushes each new JSON record emitted\nby the ``gvametapublish`` GStreamer element as an SSE ``data:`` event.\nThe stream terminates automatically when the pipeline finishes.\nA padding comment is sent on connect and a ``\": keepalive\"`` comment every\n10 s, so buffering proxies release the response instead of holding it until\nthe stream closes.\n\n## Path Parameters\n\n- `job_id`: Identifier of the performance job to stream metadata from\n\n## Response Format\n\n``text/event-stream`` \u2014 each event is:\n```\ndata: {<json record>}\n\n\n```\n\n## Response Codes\n\n| Code | Description |\n|------|-------------|\n| 200  | SSE stream opened |\n| 204  | Job has finished; the client should not reconnect |\n| 404  | Job id is unknown or no metadata is available for this job |",
         "operationId": "stream_performance_job_metadata",
         "parameters": [
           {
@@ -1048,6 +1048,9 @@
               },
               "text/event-stream": {}
             }
+          },
+          "204": {
+            "description": "Job finished; no further metadata will be produced"
           },
           "404": {
             "description": "Job not found",

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_performance_metadata_flow.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional/test_performance_metadata_flow.py
@@ -4,7 +4,8 @@ These tests validate:
 * Jobs submitted with ``metadata_mode=file`` complete successfully and include
   ``metadata_stream_urls`` in the status response.
 * The metadata snapshot endpoint returns a JSON array of records.
-* The metadata SSE stream endpoint responds with the correct headers.
+* The metadata SSE stream endpoint reports 204 once the job has finished, so an
+  EventSource client stops reconnecting.
 * Error paths: unknown job, pipeline without ``gvametapublish``, density test
   with metadata enabled, and job with metadata disabled all return 404 / 400 /
   FAILED as appropriate.
@@ -142,8 +143,7 @@ def test_performance_metadata_file_mode_job(
     1. Job reaches COMPLETED state with a non-empty ``metadata_stream_urls`` dict.
     2. Each metadata snapshot endpoint (snapshot URL derived by stripping ``/stream``)
        returns HTTP 200 with a non-empty JSON array of records.
-    3. Each metadata SSE stream endpoint returns HTTP 200 with
-       ``Content-Type: text/event-stream``.
+    3. Each metadata SSE stream endpoint returns HTTP 204 for the finished job.
 
     Only (pipeline, variant) pairs whose advanced graph contains a
     ``gvametapublish`` node are included in the parametrize set.
@@ -210,31 +210,36 @@ def test_performance_metadata_file_mode_job(
                 len(records),
             )
 
-    # --- 3. SSE stream headers ---
+    # --- 3. SSE stream endpoint after the job finished ---
+    # Tailing stops when the job leaves RUNNING, so the endpoint answers 204 to
+    # tell an EventSource client not to reconnect. A 200 is only possible in the
+    # narrow window before tailing is torn down, and must still be a real stream.
     for pipeline_key, stream_urls in metadata_stream_urls.items():
         for file_index, stream_url in enumerate(stream_urls):
             response = http_client.get(
                 f"{BASE_URL}{stream_url}", stream=True, timeout=30
             )
             try:
-                assert response.status_code == 200, (
-                    f"Expected 200 from metadata SSE stream endpoint "
-                    f"(pipeline_key={pipeline_key!r}, file_index={file_index}), "
-                    f"got {response.status_code}"
+                assert response.status_code in (200, 204), (
+                    f"Expected 204 (or 200 while still tailing) from metadata SSE "
+                    f"stream endpoint (pipeline_key={pipeline_key!r}, "
+                    f"file_index={file_index}), got {response.status_code}"
                 )
-                content_type = response.headers.get("Content-Type", "")
-                assert "text/event-stream" in content_type, (
-                    f"Expected 'text/event-stream' Content-Type from SSE stream endpoint "
-                    f"(pipeline_key={pipeline_key!r}, file_index={file_index}), "
-                    f"got {content_type!r}"
-                )
+                if response.status_code == 200:
+                    content_type = response.headers.get("Content-Type", "")
+                    assert "text/event-stream" in content_type, (
+                        f"Expected 'text/event-stream' Content-Type from SSE stream "
+                        f"endpoint (pipeline_key={pipeline_key!r}, "
+                        f"file_index={file_index}), got {content_type!r}"
+                    )
             finally:
                 response.close()
             logger.info(
-                "%s SSE stream pipeline_key=%s file_index=%d → 200 text/event-stream",
+                "%s SSE stream pipeline_key=%s file_index=%d → %d",
                 pipeline_label,
                 pipeline_key,
                 file_index,
+                response.status_code,
             )
 
 


### PR DESCRIPTION
### Description

Answering 204 on the metadata stream of a finished job (#3007) changed the contract of `GET /jobs/tests/performance/{job_id}/metadata/{pipeline_id}/{file_index}/stream`, but functional tests and documentation were not updated accordingly.

`test_performance_metadata_file_mode_job` opens the stream after the job has reached `COMPLETED`, so tailing has already stopped and the endpoint correctly answers 204 - the assertion on 200 failed for all 28 pipeline/variant cases. Expect 204, and keep the `text/event-stream` check for the narrow window in which the response is still 200, since job state flips to `COMPLETED` just before `stop_tailing()` runs.

The checked-in OpenAPI schema was not regenerated with that change, so vippet.json documented neither the 204 response nor the reworded keepalive paragraph, so it is regenerated.

Refs: ITEP-934831

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

```
python -m pytest vippet/tests/functional/test_performance_metadata_flow.py -k test_performance_metadata_file_mode_job
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: <reducted>/edge-ai-libraries/tools/visual-pipeline-and-platform-evaluation-tool/vippet/tests/functional
configfile: pytest.ini
plugins: anyio-4.14.2
collected 35 items / 5 deselected / 30 selected

vippet/tests/functional/test_performance_metadata_flow.py .............................s                                                                                         [100%]

=============================================================================== short test summary info ================================================================================
SKIPPED [1] vippet/tests/functional/test_performance_metadata_flow.py:132: Pre-downloaded model for pipeline 'Video Summarization VLM' (GPU) not found at <reducted>/edge-ai-libraries/tools/visual-pipeline-and-platform-evaluation-tool/shared/models/output/openvino_models/gpu/int4/google/gemma-3-4b-it. Download the model before running this test.
=============================================================== 29 passed, 1 skipped, 5 deselected in 368.31s (0:06:08) ================================================================
```

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

