### PR TITLE
fix(metrics-manager): restore root as the image default user

### DIFF
--- a/microservices/metrics-manager/.env.example
+++ b/microservices/metrics-manager/.env.example
@@ -61,6 +61,10 @@ HOST_TELEGRAF_HTTP_PORT=8186
 # hosts; set to `false` if you only need CPU/RAM/temperature metrics.
 PRIVILEGED=true
 
+# UID:GID the container runs as. Root by default; 10001:10001 drops NPU and
+# DMI metrics, which need root-only host reads.
+#CONTAINER_USER=10001:10001
+
 # Custom Telegraf config files mounted into the container (host paths).
 # Override TELEGRAF_CONFIG to ship a completely custom telegraf.conf:
 #TELEGRAF_CONFIG=./my-telegraf.conf

--- a/microservices/metrics-manager/Dockerfile
+++ b/microservices/metrics-manager/Dockerfile
@@ -300,7 +300,8 @@ ENV TELEGRAF_CONFIG_PATH=/etc/telegraf/telegraf.conf
 # 8186 - Telegraf HTTP listener (InfluxDB Line Protocol)
 EXPOSE 9090 9273 8186
 
-USER ${METRICS_MANAGER_UID}:${METRICS_MANAGER_GID}
+# No USER directive: host telemetry (PMT sysfs, dmidecode) is readable only by
+# root, so the image defaults to root; override with CONTAINER_USER to opt out.
 
 # OCI image metadata - version is read from the VERSION file at build time
 # (single source of truth used by Makefile / docker compose).

--- a/microservices/metrics-manager/README.md
+++ b/microservices/metrics-manager/README.md
@@ -65,7 +65,6 @@ enumerate render nodes):
 ```bash
 docker run --rm \
   --device /dev/dri \
-  --user 0:0 \
   -p 9090:9090 -p 9273:9273 \
   -v /sys:/sys:ro -v /run:/run:ro \
   --pid host \
@@ -77,7 +76,6 @@ sysfs interface, which requires `--privileged`):
 
 ```bash
 docker run --rm --privileged \
-  --user 0:0 \
   -p 9090:9090 -p 9273:9273 \
   -v /sys:/sys:ro -v /run:/run:ro \
   --pid host \
@@ -118,7 +116,6 @@ docker build -t metrics-manager .
 docker run -d \
   --name metrics-manager \
   --privileged \
-  --user 0:0 \
   -p 9090:9090 \
   -p 9273:9273 \
   -v /sys:/sys \

--- a/microservices/metrics-manager/docs/user-guide/get-started.md
+++ b/microservices/metrics-manager/docs/user-guide/get-started.md
@@ -134,7 +134,6 @@ Add `--device /dev/dri` so qmassa can access GPU devices:
 ```bash
 docker run --rm \
   --device /dev/dri \
-  --user 0:0 \
   -p 9090:9090 \
   -p 9273:9273 \
   -v /sys:/sys:ro \
@@ -155,7 +154,6 @@ Run in privileged mode to access `/sys/class/intel_pmt`:
 
 ```bash
 docker run --rm --privileged \
-  --user 0:0 \
   -p 9090:9090 \
   -p 9273:9273 \
   -v /sys:/sys:ro \
@@ -175,7 +173,6 @@ curl -s http://localhost:9273/metrics | grep npu
 ```bash
 docker run --rm --privileged \
   --device /dev/dri \
-  --user 0:0 \
   -p 9090:9090 \
   -p 9273:9273 \
   -v /sys:/sys:ro \


### PR DESCRIPTION
### Description

PR #2983 added `USER 10001:10001` to the production image.
Platform telemetry needs host reads that no capability short of root satisfies: PMT NPU counters in `/sys/class/intel_pmt/telem*/telem` and dmidecode's `/sys/firmware/dmi` tables are both mode `0400 root:root` with no group to join.

Removing the USER directive restores the previous default.

The hardening is kept and stays opt-in:

- the metrics-manager user (uid/gid 10001) and its file ownership are still created in the image, so CONTAINER_USER=10001:10001 works without a rebuild;
- compose.yaml already exposes `user: ${CONTAINER_USER:-0:0}`, now documented in .env.example;

The `--user 0:0` flags added to the docker run examples are dropped as they are now redundant.

Fixes:
npu_reader.py exits 1 on EACCES, Telegraf's execd input restarts it every ~10s with `Process /opt/venv/bin/python3 exited: exit status 1` in the log.

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

Build image from codebase and run with sample service that uses/relies on metrics-manager (ViPPET).
Verified that service runs without issues, and NPU metrics were available on app interface.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

