### PR TITLE
[ViPPET] Fix NPU detection glob pattern

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/setup_env.sh
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/setup_env.sh
@@ -13,7 +13,7 @@ TIMESERIES_ANALYTICS_MICROSERVICE_WEEKLY_BUILD_DATE="20260721"
 HOST_IPS="$(hostname -I | xargs | tr ' ' ',')"
 
 # Check for NPU device
-if compgen -G "/dev/accel*" > /dev/null; then
+if compgen -G "/dev/accel/accel*" > /dev/null; then
     # NPU device found, using NPU profile and render group
     COMPOSE_PROFILES="npu"
     RENDER_GROUP_ID=$(getent group render | awk -F: '{printf "%s\n", $3}')


### PR DESCRIPTION
### Description

The hardware check used the /dev/accel* glob, which matches the accel directory itself even when no NPU device node is present, so the npu compose profile could be selected on machines without an NPU. The glob is now /dev/accel/accel*, so detection is based on the actual device nodes.

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Verified manually.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code. 