### PR TITLE
[metrics-manager] Enable hardware telemetry by default in the image

### DIFF
--- a/microservices/metrics-manager/.env.example
+++ b/microservices/metrics-manager/.env.example
@@ -61,6 +61,11 @@ HOST_TELEGRAF_HTTP_PORT=8186
 # hosts; set to `false` if you only need CPU/RAM/temperature metrics.
 PRIVILEGED=true
 
+# Start the qmassa GPU collector. Set to `false` on hosts where /dev/dri is
+# unavailable to avoid a restarting collector; CPU/RAM/temperature/NPU metrics
+# are unaffected.
+HARDWARE_TELEMETRY_ENABLED=true
+
 # UID:GID the container runs as. Root by default; 10001:10001 drops NPU and
 # DMI metrics, which need root-only host reads.
 #CONTAINER_USER=10001:10001

--- a/microservices/metrics-manager/Dockerfile
+++ b/microservices/metrics-manager/Dockerfile
@@ -285,7 +285,9 @@ RUN chmod +x /entrypoint.sh && \
 # Environment variables with defaults
 ENV METRICS_PORT=9090
 ENV TELEGRAF_PORT=9273
-ENV HARDWARE_TELEMETRY_ENABLED=false
+# Gates the qmassa GPU collector in supervisord. Set to false for deployments
+# that cannot grant /dev/dri access (the Helm chart does this explicitly).
+ENV HARDWARE_TELEMETRY_ENABLED=true
 ENV QMASSA_FIFO_PATH=/app/qmassa.fifo
 ENV QMASSA_LOG_TO_STDERR=false
 ENV NPU_READER_LOG_FILE=/app/npu_reader_trace.log

--- a/microservices/metrics-manager/docs/user-guide/get-started/environment-variables.md
+++ b/microservices/metrics-manager/docs/user-guide/get-started/environment-variables.md
@@ -17,6 +17,7 @@ Configuration is managed via environment variables. All variables map directly t
 | `CORS_ORIGINS` | `*` | Allowed CORS origins (comma-separated or JSON array). Set to `http://localhost:3000,http://my-dashboard:3000` to restrict |
 | `CORS_ALLOW_CREDENTIALS` | `false` | Allow credentials in CORS requests (cookies, etc.) |
 | `METRICS_MANAGER_HOSTNAME` | _(unset)_ | Override the `host=` tag stamped on every metric (Telegraf, qmassa_reader.py, npu_reader.py). Unset = use kernel hostname. Set to a stable value (e.g., `lab-node-42`) to keep Grafana dashboards stable across reboots |
+| `HARDWARE_TELEMETRY_ENABLED` | `true` | Start the `qmassa` GPU collector under supervisord. Set to `false` where `/dev/dri` cannot be mapped into the container; CPU, memory, temperature and NPU metrics are unaffected |
 
 ## Metrics Storage
 


### PR DESCRIPTION
### Description

cherry-pick #3084

Enable hardware telemetry by default in the image

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

