### PR TITLE
fix(text-to-speech): pin RELEASE_TAG in .env.example to match committ…

### DIFF
--- a/microservices/audio-analyzer/.env.example
+++ b/microservices/audio-analyzer/.env.example
@@ -18,7 +18,7 @@
 # ownership, so no host UID/GID configuration is required.
 
 REGISTRY=intel
-RELEASE_TAG=latest
+RELEASE_TAG=2026.2.0-rc2
 
 # Host-side Intel NPU device node for Docker device mapping.
 # Compose maps this host path to the fixed container path /dev/accel/accel0.

--- a/microservices/audio-analyzer/docs/user-guide/release-notes.md
+++ b/microservices/audio-analyzer/docs/user-guide/release-notes.md
@@ -3,7 +3,7 @@
 This page tracks releases of the Audio Analyzer microservice. The most
 recent release is listed first; older entries are preserved for history.
 
-## Version 1.5.0
+## Version 2026.2.0
 
 **Release Date:** September 9, 2026
 

--- a/microservices/text-to-speech/.env.example
+++ b/microservices/text-to-speech/.env.example
@@ -19,5 +19,5 @@
 # ownership, so no host UID/GID configuration is required.
 
 REGISTRY=intel
-RELEASE_TAG=latest
+RELEASE_TAG=2026.2.0-rc2
 RENDER_GID=992

--- a/microservices/text-to-speech/docs/user-guide/release-notes.md
+++ b/microservices/text-to-speech/docs/user-guide/release-notes.md
@@ -3,7 +3,7 @@
 This page tracks releases of the Text To Speech microservice. The most
 recent release is listed first; older entries are preserved for history.
 
-## v1.1.0
+## Version 2026.2.0
 
 **Release Date:** September 9, 2026
 


### PR DESCRIPTION
…ed .env

The documented 'cp .env.example .env' step overwrote the pinned release tag with 'latest', contradicting run-container.md's claim that the committed RELEASE_TAG pins the current release. Align .env.example's RELEASE_TAG with the committed .env value (2026.2.0-rc2).


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

