### PR TITLE
[ViPPET] Add WSL documentation

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/build-from-source.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/build-from-source.md
@@ -23,6 +23,10 @@ For GPU and/or NPU usage, appropriate drivers must be installed. The recommended
 script, which detects available devices and installs the required drivers. Follow the `Prerequisites` section in
 [Install Guide Ubuntu](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/install/install_guide_ubuntu.html#prerequisites).
 
+> **Note:** The same steps apply to Ubuntu 24.04 running under WSL 2 on Windows - run all commands
+> inside the WSL distribution. On WSL, only the CPU and GPU (WSL) variants are supported. See
+> [System Requirements](./system-requirements.md#windows-subsystem-for-linux-wsl).
+
 This guide assumes basic familiarity with Git commands and terminal usage. For more information, see
 [Git Documentation](https://git-scm.com/doc).
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/docker-compose.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/docker-compose.md
@@ -18,6 +18,10 @@ For GPU and/or NPU usage, appropriate drivers must be installed. The recommended
 script, which detects available devices and installs the required drivers. Follow the `Prerequisites` section in
 [Install Guide Ubuntu - Prerequisites](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/install/install_guide_ubuntu.html#prerequisites).
 
+> **Note:** The same steps apply to Ubuntu 24.04 running under WSL 2 on Windows - run all commands
+> inside the WSL distribution. On WSL, only the CPU and GPU (WSL) variants are supported. See
+> [System Requirements](./system-requirements.md#windows-subsystem-for-linux-wsl).
+
 This guide assumes basic familiarity with terminal usage.
 
 Before starting the setup, review the [Pre-Installation Steps](./pre-installation-steps.md)

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/system-requirements.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/system-requirements.md
@@ -14,8 +14,30 @@ efficiently.
 
 ## Software Requirements
 
-- OS: Ubuntu 24.04.1 LTS
+- OS: Ubuntu 24.04.1 LTS (native installation, or as a WSL 2 distribution on Windows).
 - Docker Engine version 20.10 or higher.
 - For GPU and/or NPU usage, appropriate drivers must be installed. The recommended method is to use the DL Streamer installation
 script, which detects available devices and installs the required drivers. Follow the **Prerequisites** section in
 [DL Streamer Install Guide - Ubuntu](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/install/install_guide_ubuntu.html#prerequisites).
+
+## Windows Subsystem for Linux (WSL)
+
+Ubuntu 24.04 running under WSL 2 on Windows is supported. The installation steps are identical
+to a native Ubuntu installation - run all commands
+([Use Pre-Built Docker Images](./docker-compose.md) or [Build from Source](./build-from-source.md))
+inside the Ubuntu 24.04 WSL distribution.
+
+`setup_env.sh` detects `/dev/dxg` and selects the `gpu-wsl` Compose profile automatically, so no
+manual configuration is required.
+
+### Supported pipeline variants under WSL
+
+| **Variant**   | **Supported under WSL** |
+|---------------|-------------------------|
+| CPU           | Yes                     |
+| GPU (WSL)     | Yes                     |
+| GPU (native)  | No                      |
+| NPU           | No                      |
+
+Pipelines expose a dedicated **GPU (WSL)** variant that is shown only when the application runs
+under WSL. Native GPU and NPU variants are hidden in that environment.


### PR DESCRIPTION
### Description

Documents support for running ViPPET on Ubuntu 24.04 under WSL 2. Adds a "Windows Subsystem for Linux (WSL)" section to the system requirements page, covering automatic gpu-wsl profile detection via /dev/dxg and a table of supported pipeline variants (CPU and GPU (WSL) only). Adds cross-reference notes to the Docker Compose and build-from-source installation guides. Docs-only change.

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

ViPPET was run on WSL.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code. 