### PR TITLE
Update TAG to 2026.2.0-rc3 in MME, MM-Dataprep

### DIFF
--- a/microservices/multimodal-embedding-serving/docs/user-guide/get-started.md
+++ b/microservices/multimodal-embedding-serving/docs/user-guide/get-started.md
@@ -68,7 +68,7 @@ Refer to the [Supported Models](./supported-models.md) list for additional choic
 
 ```bash
 export REGISTRY_URL=intel
-export TAG=2026.2.0-rc2
+export TAG=2026.2.0-rc3
 ```
 
 ### Configuration Examples

--- a/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/docs/user-guide/get-started.md
+++ b/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/docs/user-guide/get-started.md
@@ -158,7 +158,7 @@ The Multimodal DataPrep microservice uses the registry URL and tag to pull the r
 
     ```bash
     export REGISTRY_URL=intel
-    export TAG=2026.2.0-rc2
+    export TAG=2026.2.0-rc3
     ```
 
 1. **Clone the repository and enter the project.**


### PR DESCRIPTION

### Description

Update TAG to 2026.2.0-rc3 in MME, MM-Dataprep

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Tested in dev env.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

