### PR TITLE
[ViPPET] bump dlstreamer and metrics-manager dependencies version to 2026.2.0-rc3

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/compose.yml
@@ -181,7 +181,7 @@ services:
     ports:
       - "7860:7860"
   metrics-manager:
-    image: docker.io/intel/metrics-manager:2026.2.0-rc2
+    image: docker.io/intel/metrics-manager:2026.2.0-rc3
     container_name: metrics-manager
     init: true
     ports:

--- a/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/video_generator/Dockerfile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.2.0-ubuntu24-rc2
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc3
 
 # Switch to root user to install dependencies
 USER root

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/Dockerfile
@@ -17,7 +17,7 @@
 # syntax=docker/dockerfile:1.7
 
 # Use DLStreamer as the base image
-FROM intel/dlstreamer:2026.2.0-ubuntu24-rc2 AS prod
+FROM intel/dlstreamer:2026.2.0-ubuntu24-rc3 AS prod
 
 # Switch to root user to install dependencies
 USER root


### PR DESCRIPTION
### Description

bump dlstreamer and metrics-manager dependencies version to 2026.2.0-rc3

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

Automated tests (`make test`, `make test-smoke`)

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

