### PR TITLE
Fixed unittests for RTSP/WebRTC GStreamer overlay and stream API changes

### DIFF
--- a/microservices/dlstreamer-pipeline-server/tests/test_server_rtsp_gstreamer_rtsp_destination.py
+++ b/microservices/dlstreamer-pipeline-server/tests/test_server_rtsp_gstreamer_rtsp_destination.py
@@ -59,7 +59,7 @@ class TestGStreamerRtspDestination:
         gstreamer_rtsp_destination._init_stream(mock_sample)
         assert gstreamer_rtsp_destination._frame_size == 1000
         assert gstreamer_rtsp_destination._need_data is False
-        mock_pipeline.rtsp_server.add_stream.assert_called_once_with(mock_pipeline.identifier, mock_pipeline.rtsp_path, mock_caps, gstreamer_rtsp_destination,gstreamer_rtsp_destination.overlay)
+        mock_pipeline.rtsp_server.add_stream.assert_called_once_with(mock_pipeline.identifier, mock_pipeline.rtsp_path, mock_caps, gstreamer_rtsp_destination,gstreamer_rtsp_destination.overlay, gstreamer_rtsp_destination.overlay_properties)
         assert gstreamer_rtsp_destination._last_timestamp == 500
         mock_pipeline.appsink_element.set_property.assert_called_once_with("sync", True)
 

--- a/microservices/dlstreamer-pipeline-server/tests/test_server_rtsp_gstreamer_rtsp_factory.py
+++ b/microservices/dlstreamer-pipeline-server/tests/test_server_rtsp_gstreamer_rtsp_factory.py
@@ -40,13 +40,27 @@ class TestGStreamerRtspFactory:
         assert selected_caps == expected_caps
 
     @pytest.mark.parametrize(
+        "overlay, overlay_properties, expected",
+        [
+            (False, {}, ""),
+            (True, None, " ! gvawatermark"),
+            (True, {}, " ! gvawatermark"),
+            (True, ["not", "a", "dict"], " ! gvawatermark"),
+            (True, {"enabled": True, "x": 10, "mode": "center", "ignored": None}, " ! gvawatermark displ-cfg=enabled=true,x=10,mode=center"),
+        ],
+    )
+    def test_build_gvawatermark_stage(self, gstreamer_rtsp_factory, overlay, overlay_properties, expected):
+        result = gstreamer_rtsp_factory._build_gvawatermark_stage(overlay, overlay_properties)
+        assert result == expected
+
+    @pytest.mark.parametrize(
     "to_string, is_audio, expected_launch_string,overlay,caps,launch_string",
     [
-        ("Video Pipeline", False, " ! videoconvert          ! gvawatermark ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0",True,["video/x-raw","width=1920","height=1080","framerate=30","layout=temp_layout","format=temp_format"],'appsrc name=source format=GST_FORMAT_TIME caps="video/x-raw,width=1920,height=1080,framerate=30,layout=temp_layout,format=temp_format"'),
+        ("Video Pipeline", False, " ! videoconvert  ! gvawatermark         ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0",True,["video/x-raw","width=1920","height=1080","framerate=30","layout=temp_layout","format=temp_format"],'appsrc name=source format=GST_FORMAT_TIME caps="video/x-raw,width=1920,height=1080,framerate=30,layout=temp_layout,format=temp_format"'),
         ("audio Pipeline", True, " ! queue ! decodebin ! audioresample ! audioconvert  ! avenc_aac ! queue ! mpegtsmux ! rtpmp2tpay  name=pay0 pt=96",True,["video/x-raw","width=1920","height=1080","framerate=30","layout=temp_layout","format=temp_format"],'appsrc name=source format=GST_FORMAT_TIME caps="video/x-raw,width=1920,height=1080,framerate=30,layout=temp_layout,format=temp_format"'),
         ("Video Pipeline", False, " ! videoconvert          ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0",False,["video/x-raw","width=1920","height=1080","framerate=30","layout=temp_layout","format=temp_format"],'appsrc name=source format=GST_FORMAT_TIME caps="video/x-raw,width=1920,height=1080,framerate=30,layout=temp_layout,format=temp_format"'),
         ("Video Pipeline", False, " ! rtpjpegpay name=pay0",False,["image/jpeg","width=1920","height=1080","framerate=30","layout=temp_layout","format=temp_format"],'appsrc name=source format=GST_FORMAT_TIME caps="image/jpeg,width=1920,height=1080,framerate=30,layout=temp_layout,format=temp_format"'),
-        ("Video Pipeline", False, " ! jpegdec ! videoconvert          ! gvawatermark ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0",True,["image/jpeg","width=1920","height=1080","framerate=30","layout=temp_layout","format=temp_format"],'appsrc name=source format=GST_FORMAT_TIME caps="image/jpeg,width=1920,height=1080,framerate=30,layout=temp_layout,format=temp_format"')
+        ("Video Pipeline", False, " ! jpegdec ! videoconvert  ! gvawatermark         ! jpegenc name=jpegencoder ! rtpjpegpay name=pay0",True,["image/jpeg","width=1920","height=1080","framerate=30","layout=temp_layout","format=temp_format"],'appsrc name=source format=GST_FORMAT_TIME caps="image/jpeg,width=1920,height=1080,framerate=30,layout=temp_layout,format=temp_format"')
     ])
     def test_do_create_element_audio_and_video(self, gstreamer_rtsp_factory, mock_rtsp_server,mocker,mock_gst,to_string, is_audio, expected_launch_string,overlay,caps,launch_string):
         mock_url = MagicMock()

--- a/microservices/dlstreamer-pipeline-server/tests/test_server_rtsp_gstreamer_rtsp_server.py
+++ b/microservices/dlstreamer-pipeline-server/tests/test_server_rtsp_gstreamer_rtsp_server.py
@@ -41,7 +41,7 @@ class TestGStreamerRtspServer:
         gstreamer_rtsp_server._mount_points = mock_mount_points
         gstreamer_rtsp_server.add_stream('test_id', '/test', 'caps', 'source',True)
         assert '/test' in gstreamer_rtsp_server._streams
-        mock_stream.assert_called_once_with('source', 'caps',True)
+        mock_stream.assert_called_once_with('source', 'caps',True, None)
         gstreamer_rtsp_server._mount_points.add_factory.assert_called_once_with('/test',gstreamer_rtsp_server._factory)
         mock_logging.get_logger.return_value.info.assert_called_once_with("Created RTSP Stream for instance test_id at rtsp:://<host ip>:8888/test")
 

--- a/microservices/dlstreamer-pipeline-server/tests/test_server_webrtc_gstreamer_webrtc_destination.py
+++ b/microservices/dlstreamer-pipeline-server/tests/test_server_webrtc_gstreamer_webrtc_destination.py
@@ -63,7 +63,7 @@ class TestGStreamerWebRTCDestination:
         assert gstreamer_webrtc_destination._need_data is False
         assert gstreamer_webrtc_destination._last_timestamp == 500
         mock_pipeline.appsink_element.set_property.assert_called_once_with("sync", True)
-        gstreamer_webrtc_destination._webrtc_manager.add_stream.assert_called_once_with("peer1", mock_caps, gstreamer_webrtc_destination,True)
+        gstreamer_webrtc_destination._webrtc_manager.add_stream.assert_called_once_with("peer1", mock_caps, gstreamer_webrtc_destination,True, {})
 
     def test_on_need_data(self, gstreamer_webrtc_destination):
         gstreamer_webrtc_destination._on_need_data(None, None)

--- a/microservices/dlstreamer-pipeline-server/tests/test_server_webrtc_gstreamer_webrtc_manager.py
+++ b/microservices/dlstreamer-pipeline-server/tests/test_server_webrtc_gstreamer_webrtc_manager.py
@@ -39,7 +39,7 @@ class TestGStreamerWebRTCManager:
         gstreamer_webrtc_manager.add_stream("peer1", mock_frame, mock_destination, True)
         gstreamer_webrtc_manager._select_caps.assert_called_once_with(mock_frame.to_string())
         gstreamer_webrtc_manager._peerid_in_use.assert_called_once_with("peer1")
-        gstreamer_webrtc_manager._get_launch_string.assert_called_once_with("video/x-raw", "peer1",True)
+        gstreamer_webrtc_manager._get_launch_string.assert_called_once_with("video/x-raw", "peer1",True, None)
         mock_stream.assert_any_call("peer1", "video/x-raw", "launch_string", mock_destination, "http://10.10.10.10:8889")
         gstreamer_webrtc_manager._streams['peer1'].start.assert_called_once()
 
@@ -51,12 +51,22 @@ class TestGStreamerWebRTCManager:
     def test_get_launch_string(self, gstreamer_webrtc_manager):
         mock_caps = ['video/x-raw', 'width=1920', 'height=1080']
         result2 = gstreamer_webrtc_manager._get_launch_string(mock_caps, "peer1",True)
-        assert result2 == ' appsrc name=webrtc_source format=GST_FORMAT_TIME  caps="video/x-raw,width=1920,height=1080"  ! videoconvert ! gvawatermark  ! openh264enc complexity=low name=h264enc ! video/x-h264,profile=baseline  ! whipclientsink signaller::whip-endpoint= http://10.10.10.10:8889/peer1/whip'
+        assert result2 == ' appsrc name=webrtc_source format=GST_FORMAT_TIME  caps="video/x-raw,width=1920,height=1080"  ! videoconvert ! video/x-raw,format=I420 ! gvawatermark  ! vp9enc name=vp9enc cpu-used=4 lag-in-frames=0  ! video/x-vp9  ! whipclientsink signaller::whip-endpoint= http://10.10.10.10:8889/peer1/whip'
         result = gstreamer_webrtc_manager._get_launch_string(mock_caps, "peer1",False)
-        assert result == ' appsrc name=webrtc_source format=GST_FORMAT_TIME  caps="video/x-raw,width=1920,height=1080"  ! videoconvert  ! openh264enc complexity=low name=h264enc ! video/x-h264,profile=baseline  ! whipclientsink signaller::whip-endpoint= http://10.10.10.10:8889/peer1/whip'
+        assert result == ' appsrc name=webrtc_source format=GST_FORMAT_TIME  caps="video/x-raw,width=1920,height=1080"  ! videoconvert ! video/x-raw,format=I420   ! vp9enc name=vp9enc cpu-used=4 lag-in-frames=0  ! video/x-vp9  ! whipclientsink signaller::whip-endpoint= http://10.10.10.10:8889/peer1/whip'
         mock_caps = ['image/jpeg', 'width=1920', 'height=1080']
         result_jpeg = gstreamer_webrtc_manager._get_launch_string(mock_caps, "peer1",True)
-        assert result_jpeg == ' appsrc name=webrtc_source format=GST_FORMAT_TIME  caps="image/jpeg,width=1920,height=1080"  ! jpegdec ! videoconvert ! gvawatermark  ! openh264enc complexity=low name=h264enc  ! video/x-h264,profile=baseline  ! whipclientsink signaller::whip-endpoint= http://10.10.10.10:8889/peer1/whip'
+        assert result_jpeg == ' appsrc name=webrtc_source format=GST_FORMAT_TIME  caps="image/jpeg,width=1920,height=1080"  ! jpegdec ! videoconvert ! video/x-raw,format=I420 ! gvawatermark  ! vp9enc name=vp9enc cpu-used=4 lag-in-frames=0  ! video/x-vp9  ! whipclientsink signaller::whip-endpoint= http://10.10.10.10:8889/peer1/whip'
+
+    def test_build_gvawatermark_stage_with_properties(self, gstreamer_webrtc_manager):
+        result = gstreamer_webrtc_manager._build_gvawatermark_stage(True, {"show-time": True, "line-thickness": 2, "unused": None})
+        assert result == "! gvawatermark displ-cfg=show-time=true,line-thickness=2"
+
+    def test_select_webrtcvideo_pipeline_cpu_fallback(self, gstreamer_webrtc_manager):
+        result = gstreamer_webrtc_manager._select_webrtcvideo_pipeline_cpu(False)
+        assert result == gstreamer_webrtc_manager._WebRTCVideoPipeline
+        result_jpeg = gstreamer_webrtc_manager._select_webrtcvideo_pipeline_cpu(False, jpeg=True)
+        assert result_jpeg == gstreamer_webrtc_manager._WebRTCVideoPipeline_jpeg
     
     def test_remove_stream(self, gstreamer_webrtc_manager):
         mock_stream = MagicMock()


### PR DESCRIPTION
### Description

Fixed Unittests that were broken while adding gvawatermark overlay properties and vp9enc

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

