### PR TITLE
[DOCS] Update DLS references to release tag - 26.2

### DIFF
--- a/microservices/dlstreamer-pipeline-server/.github/skills/dlsps-user/SKILL.md
+++ b/microservices/dlstreamer-pipeline-server/.github/skills/dlsps-user/SKILL.md
@@ -34,7 +34,7 @@ the REST API.
 
 > **Not this skill:** If the user wants to *write new* DL Streamer applications,
 > create custom GStreamer pipelines from scratch, or develop Python/C++ video analytics
-> code, use the [`dlstreamer-coding-agent`](https://github.com/open-edge-platform/dlstreamer/tree/main/.github/skills/dlstreamer-coding-agent) skill instead.
+> code, use the [`dlstreamer-coding-agent`](https://github.com/open-edge-platform/dlstreamer/tree/v2026.2.0/.github/skills/dlstreamer-coding-agent) skill instead.
 
 ## Architecture at a Glance
 
@@ -155,7 +155,7 @@ Pipeline definitions live in a `config.json` mounted into the container:
 | `udfloader` | Load Python User Defined Functions |
 | `appsink` | Application sink (required, `name=appsink`) |
 
-For DL Streamer inference, decode and metadata conversion and publishing elements see the [`dlstreamer-coding-agent`](https://github.com/open-edge-platform/dlstreamer/tree/main/.github/skills/dlstreamer-coding-agent) skill.
+For DL Streamer inference, decode and metadata conversion and publishing elements see the [`dlstreamer-coding-agent`](https://github.com/open-edge-platform/dlstreamer/tree/v2026.2.0/.github/skills/dlstreamer-coding-agent) skill.
 
 ## Common Mistakes to Avoid
 
@@ -199,7 +199,7 @@ Read the matching example file — it contains the exact compact response format
 4. Show RTSP URL, status-check command, and stop command
 
 **GPU/NPU rules:**
-For GPU/NPU inference or decodeing devices see the [`dlstreamer-coding-agent`](https://github.com/open-edge-platform/dlstreamer/tree/main/.github/skills/dlstreamer-coding-agent) skill.
+For GPU/NPU inference or decodeing devices see the [`dlstreamer-coding-agent`](https://github.com/open-edge-platform/dlstreamer/tree/v2026.2.0/.github/skills/dlstreamer-coding-agent) skill.
 - RTSP/MQTT with GPU: add `vapostproc ! video/x-raw` before `appsink`
 
 Read reference files only when needed for advanced configuration details:

--- a/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/rest_api/defining_pipelines.md
+++ b/microservices/dlstreamer-pipeline-server/docs/user-guide/advanced-guide/detailed_usage/rest_api/defining_pipelines.md
@@ -768,7 +768,7 @@ If such a file exists, the Pipeline Server automatically looks for this file in 
 
 For more information on DL Streamer `model-proc` files and samples for common models, see the
 DL Streamer [documentation](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/dlstreamer/dev_guide/how_to_create_model_proc_file.html).
-and [samples](https://github.com/open-edge-platform/dlstreamer/tree/main/samples).
+and [samples](https://github.com/open-edge-platform/dlstreamer/tree/v2026.2.0/samples).
 
 #### FFmpeg Video Analytics
 

--- a/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/optimization_manager.py
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/vippet/managers/optimization_manager.py
@@ -84,7 +84,7 @@ class OptimizationRunner:
             PipelineOptimizationResult: Result containing the preprocessed GStreamer pipeline string.
         """
         # Import from /opt/intel/dlstreamer/scripts/optimizer/optimizer.py provided in DLStreamer image
-        # https://github.com/open-edge-platform/dlstreamer/tree/main/scripts/optimizer
+        # https://github.com/open-edge-platform/dlstreamer/tree/v2026.2.0/scripts/optimizer
         import optimizer  # pyright: ignore[reportMissingImports]
 
         optimized_pipeline = optimizer.preprocess_pipeline(pipeline_description)
@@ -118,7 +118,7 @@ class OptimizationRunner:
                 pipeline string and measured total FPS.
         """
         # Import from /opt/intel/dlstreamer/scripts/optimizer/optimizer.py provided in DLStreamer image
-        # https://github.com/open-edge-platform/dlstreamer/tree/main/scripts/optimizer/optimizer.py
+        # https://github.com/open-edge-platform/dlstreamer/tree/v2026.2.0/scripts/optimizer/optimizer.py
         import optimizer  # pyright: ignore[reportMissingImports]
 
         opt = optimizer.DLSOptimizer()


### PR DESCRIPTION
### Description

Update DLS GH link targets to use the release tag (`v2026.2.0`).

### How Has This Been Tested?

Links checked.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.