### PR TITLE
time-series-analytics: Enable the dependabot.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
-
   # ─────────────────────────────────────────
   # Python (pip) — Microservices
   # ─────────────────────────────────────────
@@ -92,6 +91,58 @@ updates:
     schedule:
       interval: "weekly"
     versioning-strategy: lockfile-only
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      python-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/microservices/time-series-analytics"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      python-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/microservices/time-series-analytics/simulator"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      python-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/microservices/time-series-analytics/tests-functional"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    groups:
+      python-deps:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/microservices/time-series-analytics/tests"
+    schedule:
+      interval: "weekly"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 5


### PR DESCRIPTION
### Description

Changes:

Added Dependabot pip rule for:
1. /microservices/time-series-analytics
2. /microservices/time-series-analytics/simulator
3. /microservices/time-series-analytics/tests-functional
4. /microservices/time-series-analytics/tests

Fixes # (issue)

### Any Newly Introduced Dependencies

NA
### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

