### PR TITLE
[ViPPET] Fix live preview WHEP URL on browsers that mis-parse rtsp://

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/webrtc/WebRTCVideoPlayer.tsx
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/webrtc/WebRTCVideoPlayer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { MediaMTXWebRTCReader } from "./MediaMTXWebRTCReader.ts";
+import { buildWhepUrl } from "./whepUrl.ts";
 
 interface WebRTCVideoPlayerProps {
   pipelineId?: string;
@@ -46,30 +47,17 @@ const WebRTCVideoPlayer = ({
       return;
     }
 
-    let whepPath: string;
-    if (streamUrl) {
-      // Convert RTSP URL to WHEP URL
-      // RTSP format: rtsp://mediamtx:8554/stream-name
-      // Extract stream name and build relative WHEP URL for proxy
-      if (streamUrl.startsWith("rtsp://")) {
-        const rtspUrl = new URL(streamUrl);
-        const streamName = rtspUrl.pathname.substring(1); // Remove leading '/'
-        // Use relative URL to leverage Vite/nginx proxy
-        whepPath = `/${streamName}/whep`;
-      } else {
-        // Assume it's already a WHEP URL
-        whepPath = streamUrl;
-      }
-    } else {
-      // Build URL from pipelineId
-      whepPath = `/stream_${pipelineId}/whep`;
+    const whepUrl = buildWhepUrl(window.location.origin, streamUrl, pipelineId);
+    if (!whepUrl) {
+      setMessage(
+        "Live preview unavailable: the pipeline reported an unusable stream address. Restart the pipeline, and check the vippet service logs if it persists.",
+      );
+      if (videoRef.current) videoRef.current.controls = false;
+      return;
     }
 
-    // Convert relative path to absolute URL
-    const absoluteUrl = new URL(whepPath, window.location.origin).toString();
-
     const reader = new MediaMTXWebRTCReader({
-      url: absoluteUrl,
+      url: whepUrl,
       onError: (err: string) => {
         setMessage(err);
         if (videoRef.current) videoRef.current.controls = false;

--- a/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/webrtc/whepUrl.ts
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/ui/src/features/webrtc/whepUrl.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolve the same-origin WHEP endpoint for a live stream. MediaMTX is only reachable
+ * through the nginx/Vite proxy, so the result is always `<origin>/<stream-name>/whep`.
+ *
+ * The scheme is rewritten to `http:` before parsing because `rtsp:` is a non-special
+ * scheme: browsers disagree on whether `new URL()` puts the authority in `host` or leaves
+ * it in `pathname`. Older Firefox does the latter, which yielded a protocol-relative path
+ * and pointed the browser at the internal `mediamtx:8554` address instead of the proxy.
+ *
+ * Returns `null` when no stream name can be derived, so callers never fall back to a
+ * cross-origin URL.
+ */
+export const buildWhepUrl = (
+  origin: string,
+  streamUrl?: string,
+  pipelineId?: string,
+): string | null => {
+  if (!streamUrl) {
+    return pipelineId
+      ? new URL(`/stream_${pipelineId}/whep`, origin).toString()
+      : null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(streamUrl.replace(/^rtsps?:/i, "http:"), origin);
+  } catch {
+    return null;
+  }
+
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  const last = segments[segments.length - 1];
+  const streamName = last === "whep" ? segments[segments.length - 2] : last;
+
+  return streamName ? new URL(`/${streamName}/whep`, origin).toString() : null;
+};


### PR DESCRIPTION
### Description

The WHEP endpoint was derived by passing the backend-supplied RTSP URL to new URL() and slicing its pathname. "rtsp:" is a non-special scheme, and browsers disagree on whether the authority lands in `host` or stays in `pathname`. On engines that do the latter (reproduced on Firefox 129) the derived path became protocol-relative:

    rtsp://mediamtx:8554/stream-x  ->  //mediamtx:8554/stream-x/whep

which then resolved against the page origin to `http://mediamtx:8554/...` The browser cannot resolve the internal compose hostname, so live preview failed with a bare "NetworkError when attempting to fetch resource" while the same deployment worked in Chrome.

Extract the stream name in buildWhepUrl() instead, rewriting the scheme to "http:" first so every engine parses the authority identically, and rebuild the endpoint from window.location.origin unconditionally. This also removes the "assume it is already a WHEP URL" branch, which let a backend-supplied absolute URL override the origin. A value from the API can no longer send the browser off-origin.

Show an actionable message when no stream name can be derived, instead of letting the request fail as a generic network error.

The helper lives in its own module because eslint's react-refresh/only-export-components rejects a non-component export from a component file.

This treats the symptom. The underlying issue is that the API publishes an internal container address in live_stream_urls, which no client outside the compose network can resolve; correcting that is an API contract change and is tracked separately.

Refs: ITEP-96342

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

Typical automated tests, plus manual verification that there is no regression on modern browser (from localhost and another machine in subnet).

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

