### PR TITLE
[ViPPET] [docs] Document required internet connectivity

### DIFF
--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/build-from-source.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/build-from-source.md
@@ -14,6 +14,10 @@ This guide is intended for developers working directly with the source code.
 Before starting, ensure the following:
 
 - **System requirements**: The system meets the [minimum requirements](./system-requirements.md).
+- **Internet access**: The host has outbound internet connectivity. Base images, apt and Python packages, npm
+  dependencies, sample videos, and models are downloaded during the build and on first start. Offline or
+  air-gapped installation is not supported. See
+  [Network Requirements](./system-requirements.md#network-requirements).
 - **Docker platform**: **Docker Engine** is installed. On Linux, install it from the Docker apt repository, see
   [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/), then complete the
   [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) to run Docker as a non-root user.

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/docker-compose.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/docker-compose.md
@@ -9,6 +9,9 @@ for evaluation, demos, and API exploration.
 Before starting, ensure the following:
 
 - **System requirements**: The system meets the [minimum requirements](./system-requirements.md).
+- **Internet access**: The host has outbound internet connectivity. Container images, sample videos, models, and
+  the Python packages used by the `model-download` service are downloaded on first start. Offline or air-gapped
+  installation is not supported. See [Network Requirements](./system-requirements.md#network-requirements).
 - **Docker platform**: **Docker Engine** is installed. On Linux, install it from the Docker apt repository, see
   [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/), then complete the
   [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) to run Docker as a non-root user.

--- a/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/system-requirements.md
+++ b/tools/visual-pipeline-and-platform-evaluation-tool/docs/user-guide/get-started/installation/system-requirements.md
@@ -21,6 +21,36 @@ efficiently.
 script, which detects available devices and installs the required drivers. Follow the **Prerequisites** section in
 [DL Streamer Install Guide - Ubuntu](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/dlstreamer/install/install_guide_ubuntu.html#prerequisites).
 
+## Network Requirements
+
+**An outbound internet connection is required.** ViPPET is not supported in air-gapped or fully offline
+environments: container images, sample videos, models, and Python packages are all fetched on demand and
+are not bundled with the tool.
+
+| **When**                | **What is downloaded**                                              | **From**                                                       |
+|-------------------------|---------------------------------------------------------------------|----------------------------------------------------------------|
+| Installation            | Docker Engine, GPU/NPU drivers, `git`, `make`, `curl`               | Ubuntu and Docker apt repositories                              |
+| Installation            | ViPPET repository sources                                            | `github.com`                                                    |
+| First `make run`        | Pre-built container images                                           | `docker.io` (Docker Hub)                                        |
+| First start             | `model-download` plugin virtual environments (Python packages)       | `pypi.org`, `files.pythonhosted.org`                            |
+| First start             | Default sample recordings listed in `shared/videos/default_recordings.yaml` | `storage.openvinotoolkit.org`, `github.com`, `pexels.com` |
+| Model installation      | Model weights and metadata for the selected hub                      | `huggingface.co`, `ultralytics.com`, `storage.openvinotoolkit.org`, Intel® Geti™ |
+| Build from source       | Base images, apt packages, Python and npm dependencies               | `docker.io`, distribution and language package registries        |
+| UI and API docs in use  | Web fonts and the Swagger UI bundle                                  | `fonts.googleapis.com`, `cdn.jsdelivr.net`                       |
+
+Notes:
+
+- Downloaded artifacts are cached under `shared/`, so subsequent starts need far less bandwidth. A connection
+  is still needed whenever a new model or sample video is installed, or after `make clean`.
+- The first start can take several minutes and download several GB, depending on the selected models.
+- Behind a corporate proxy, export `http_proxy`, `https_proxy`, and `no_proxy` in the shell before running
+  `make run`, and configure the [Docker daemon proxy](https://docs.docker.com/engine/daemon/proxy/) so that
+  image pulls succeed. `compose.yml` already appends the internal service names to `no_proxy`.
+- Access to the Hugging Face Hub additionally requires a token for gated or private repositories. See
+  [Pre-Installation Steps](./pre-installation-steps.md).
+- Inbound access is not required. The UI is served on port `80` and is reachable at `http://localhost` or
+  `http://<HOST-IP>` on the local network.
+
 ## Windows Subsystem for Linux (WSL)
 
 Ubuntu 24.04 running under WSL 2 on Windows is supported. The installation steps are identical


### PR DESCRIPTION
### Description

The System Requirements page does not state that outbound internet access is needed. Add a Network Requirements section listing what is downloaded and from where (container images, model-download plugin virtual environments, default sample recordings, model weights, UI fonts and the Swagger bundle), note that artifacts are cached under shared/, and add proxy configuration guidance.

Also add an "Internet access" prerequisite to both installation guides.

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

N/A - Documentation notice only.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

