### PR TITLE
[VSS] Update image tags and documentation for release 2026.2.0

### DIFF
--- a/microservices/multimodal-embedding-serving/.github/copilot-instructions.md
+++ b/microservices/multimodal-embedding-serving/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ file.
 Multimodal Embedding Serving generates embeddings for **text, images, and
 videos** in a shared semantic space (FastAPI + PyTorch/OpenVINO). It is
 consumable two ways: as a **REST service** (prebuilt
-`intel/multimodal-embedding-serving:latest` on Docker Hub, port 9777) and as a
+`intel/multimodal-embedding-serving:2026.2.0` on Docker Hub, port 9777) and as a
 **Python SDK wheel** (`multimodal_embedding_serving`, built with
 `poetry build`) for in-process use. Deeper user docs live under
 [`docs/user-guide/`](../docs/user-guide/); this file is the agent-facing map.

--- a/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/SKILL.md
+++ b/microservices/multimodal-embedding-serving/.github/skills/multimodal-embedding-serving-user/SKILL.md
@@ -89,7 +89,7 @@ Load these existing docs only when needed:
    `--no-build` prevents a source build. Run in the background — first start
    downloads the model:
    ```bash
-   bash -c 'export EMBEDDING_MODEL_NAME="CLIP/clip-vit-b-32" REGISTRY_URL=intel TAG=latest \
+   bash -c 'export EMBEDDING_MODEL_NAME="CLIP/clip-vit-b-32" REGISTRY_URL=intel TAG=2026.2.0 \
      && source setup.sh && docker compose -f docker/compose.yaml up -d --no-build'
    ```
    Intel GPU: also `export EMBEDDING_DEVICE=GPU` (setup.sh then auto-enables

--- a/microservices/multimodal-embedding-serving/docs/user-guide/get-started.md
+++ b/microservices/multimodal-embedding-serving/docs/user-guide/get-started.md
@@ -68,7 +68,7 @@ Refer to the [Supported Models](./supported-models.md) list for additional choic
 
 ```bash
 export REGISTRY_URL=intel
-export TAG=2026.2.0-rc3
+export TAG=2026.2.0
 ```
 
 ### Configuration Examples

--- a/microservices/vector-retriever/vector-retriever/docker/compose.faiss.yaml
+++ b/microservices/vector-retriever/vector-retriever/docker/compose.faiss.yaml
@@ -3,7 +3,7 @@
 
 services:
   multimodal-embedding-serving:
-    image: intel/multimodal-embedding-serving:2026.2.0-rc2
+    image: intel/multimodal-embedding-serving:2026.2.0
     container_name: multimodal-embedding-serving
     ports:
       - '${EMBEDDING_SERVER_PORT:-9777}:8000'

--- a/microservices/vector-retriever/vector-retriever/docker/compose.milvus.yaml
+++ b/microservices/vector-retriever/vector-retriever/docker/compose.milvus.yaml
@@ -3,7 +3,7 @@
 
 services:
   multimodal-embedding-serving:
-    image: intel/multimodal-embedding-serving:2026.2.0-rc2
+    image: intel/multimodal-embedding-serving:2026.2.0
     container_name: multimodal-embedding-serving
     ports:
       - '${EMBEDDING_SERVER_PORT:-9777}:8000'

--- a/microservices/vector-retriever/vector-retriever/docker/compose.pgvector.yaml
+++ b/microservices/vector-retriever/vector-retriever/docker/compose.pgvector.yaml
@@ -3,7 +3,7 @@
 
 services:
   multimodal-embedding-serving:
-    image: intel/multimodal-embedding-serving:2026.2.0-rc2
+    image: intel/multimodal-embedding-serving:2026.2.0
     container_name: multimodal-embedding-serving
     ports:
       - '${EMBEDDING_SERVER_PORT:-9777}:8000'

--- a/microservices/vector-retriever/vector-retriever/docker/compose.vdms.yaml
+++ b/microservices/vector-retriever/vector-retriever/docker/compose.vdms.yaml
@@ -3,7 +3,7 @@
 
 services:
   multimodal-embedding-serving:
-    image: intel/multimodal-embedding-serving:2026.2.0-rc2
+    image: intel/multimodal-embedding-serving:2026.2.0
     container_name: multimodal-embedding-serving
     ports:
       - '${EMBEDDING_SERVER_PORT:-9777}:8000'

--- a/microservices/vector-retriever/vector-retriever/docs/user-guide/get-started.md
+++ b/microservices/vector-retriever/vector-retriever/docs/user-guide/get-started.md
@@ -151,7 +151,7 @@ hide_directive-->
 
 ```bash
 export REGISTRY_URL=intel
-export TAG=2026.2.0-rc2
+export TAG=2026.2.0
 ```
 
 ### Optional Environment Variables

--- a/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/.github/copilot-instructions.md
+++ b/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/.github/copilot-instructions.md
@@ -18,14 +18,14 @@ extracts video frames, optionally creates YOLOX object crops, generates
 multimodal embeddings in-process, and stores vectors plus metadata through a
 pluggable VDMS or Milvus backend. Raw media uses MinIO or local storage. The
 service handles ingestion only; search and query are separate concerns.
-Prebuilt image: `intel/multimodal-dataprep:latest`. Deeper user docs live under
+Prebuilt image: `intel/multimodal-dataprep:2026.2.0`. Deeper user docs live under
 [`docs/user-guide/`](../docs/user-guide/); this file is the agent-facing map.
 
 ## The Stack
 
 | Service | Image | Host port → container |
 |---|---|---|
-| multimodal-dataprep | `intel/multimodal-dataprep:latest` (or local build) | `6007` → 8000, API under `/v1/dataprep` |
+| multimodal-dataprep | `intel/multimodal-dataprep:2026.2.0` (or local build) | `6007` → 8000, API under `/v1/dataprep` |
 | vdms-vector-db | `intellabs/vdms:v2.12.0` | `6020` → 55555 |
 | milvus-standalone | Milvus | `19530` → 19530 when that backend is selected |
 | minio-server | MinIO | `6010` → 9000 (API), `6011` → 9001 (console) |

--- a/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/.github/skills/multimodal-dataprep-user/SKILL.md
+++ b/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/.github/skills/multimodal-dataprep-user/SKILL.md
@@ -78,7 +78,7 @@ export MINIO_ROOT_USER='<user>'
 export MINIO_ROOT_PASSWORD='<strong-password>'
 export EMBEDDING_MODEL_NAME='CLIP/clip-vit-b-32'
 export REGISTRY_URL='docker.io/intel'
-export TAG='latest'
+export TAG='2026.2.0'
 
 source ./setup.sh --nosetup
 docker compose -f docker/compose.yaml up -d --no-build

--- a/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/docs/user-guide/get-started.md
+++ b/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/docs/user-guide/get-started.md
@@ -158,7 +158,7 @@ The Multimodal DataPrep microservice uses the registry URL and tag to pull the r
 
     ```bash
     export REGISTRY_URL=intel
-    export TAG=2026.2.0-rc3
+    export TAG=2026.2.0
     ```
 
 1. **Clone the repository and enter the project.**

--- a/microservices/vlm-openvino-serving/.github/copilot-instructions.md
+++ b/microservices/vlm-openvino-serving/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ VLM OpenVINO Serving is an **OpenAI-API-compatible** microservice (FastAPI +
 OpenVINO GenAI) that serves Vision Language Models — image and video chat
 completions — on Intel CPUs and GPUs. It targets VLMs not yet supported by
 OpenVINO Model Server. A prebuilt image is published as
-`intel/vlm-openvino-serving:latest` on Docker Hub. Deeper user docs live under
+`intel/vlm-openvino-serving:2026.2.0` on Docker Hub. Deeper user docs live under
 [`docs/user-guide/`](../docs/user-guide/); this file is the agent-facing map.
 
 ## Run Interfaces

--- a/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/SKILL.md
+++ b/microservices/vlm-openvino-serving/.github/skills/vlm-openvino-serving-user/SKILL.md
@@ -87,7 +87,7 @@ Load these existing docs only when needed:
    skill's job). Run in the background — the first start downloads and
    converts the model, which can take many minutes:
    ```bash
-   bash -c 'export VLM_MODEL_NAME="Qwen/Qwen2.5-VL-3B-Instruct" VLM_DEVICE=CPU REGISTRY_URL=intel TAG=latest \
+   bash -c 'export VLM_MODEL_NAME="Qwen/Qwen2.5-VL-3B-Instruct" VLM_DEVICE=CPU REGISTRY_URL=intel TAG=2026.2.0 \
      && source setup.sh && docker compose -f docker/compose.yaml up -d --no-build'
    ```
    For Intel GPU: also `export VLM_DEVICE=GPU` (that exact value makes

--- a/microservices/vlm-openvino-serving/docs/user-guide/environment-variables.md
+++ b/microservices/vlm-openvino-serving/docs/user-guide/environment-variables.md
@@ -420,7 +420,7 @@ export no_proxy_env=localhost,127.0.0.1,.local
 **Examples**:
 
 ```bash
-export TAG=latest              # Docker image tag
+export TAG=2026.2.0            # Docker image tag
 export REGISTRY_URL=docker.io/     # Docker registry URL
 export PROJECT_NAME=my_project   # Docker project name
 ```

--- a/microservices/vlm-openvino-serving/docs/user-guide/get-started.md
+++ b/microservices/vlm-openvino-serving/docs/user-guide/get-started.md
@@ -86,7 +86,7 @@ The user has an option to either [build the docker images](./how-to-build-from-s
 
  ```bash
  export REGISTRY_URL=intel
- export TAG=latest
+ export TAG=2026.2.0
  ```
 
 ## Running the Server with CPU

--- a/sample-applications/video-search-and-summarization/.env.example
+++ b/sample-applications/video-search-and-summarization/.env.example
@@ -38,7 +38,7 @@
 # Set both to push to a registry: REGISTRY_URL=myregistry.io  PROJECT_NAME=myproject
 REGISTRY_URL=intel/
 PROJECT_NAME=
-TAG=2026.2.0-rc2
+TAG=2026.2.0
 
 
 # ==============================================================================

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-deploy-helm/SKILL.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-deploy-helm/SKILL.md
@@ -97,7 +97,7 @@ global:
   modelDownload:
     image:
       repository: intel/model-download
-      tag: "2026.2.0-rc2"
+      tag: "2026.2.0"
       pullPolicy: IfNotPresent
     ovmsReleaseTag: "v2026.1"
   proxy:

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-deploy-helm/references/helm-values-map.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-deploy-helm/references/helm-values-map.md
@@ -57,7 +57,7 @@ This map is grounded in `chart/Chart.yaml`, `chart/values.yaml`, the override fi
 | `global.vlmName` | empty | VLM model used by OVMS or vLLM; required in summary/unified. |
 | `global.llmName` | empty | Optional separate OVMS LLM model; empty means shared VLM model. |
 | `global.embeddingModelName` | empty | Required for search/unified; drives embedding service, dataprep, video search. |
-| `global.modelDownload.image.repository/tag/pullPolicy` | `intel/model-download` / `2026.2.0-rc2` / `IfNotPresent` | Image used by model-download init containers for OVMS VLM/LLM and video-ingestion OD models. |
+| `global.modelDownload.image.repository/tag/pullPolicy` | `intel/model-download` / `2026.2.0` / `IfNotPresent` | Image used by model-download init containers for OVMS VLM/LLM and video-ingestion OD models. |
 | `global.modelDownload.ovmsReleaseTag` | `v2026.1` | OVMS export version used by the model-download OpenVINO plugin. |
 | `global.vdmsIndexName` | empty | Set by search/unified override files to choose VDMS collection. |
 | `global.devices.multimodalEmbedding.device/key` | `CPU` / empty | GPU scheduling for multimodal embedding service. |
@@ -69,7 +69,7 @@ This map is grounded in `chart/Chart.yaml`, `chart/values.yaml`, the override fi
 | `global.env.POSTGRES_USER/PASSWORD` | empty | Required credentials. |
 | `global.env.MINIO_ROOT_USER/PASSWORD` | empty | Required credentials. |
 | `global.env.RABBITMQ_DEFAULT_USER/PASS` | empty | Required credentials for summary modes. |
-| `pipelinemanager.image.repository/tag` | `intel/pipeline-manager` / `2026.2.0-rc2` | Main backend image. |
+| `pipelinemanager.image.repository/tag` | `intel/pipeline-manager` / `2026.2.0` | Main backend image. |
 | `pipelinemanager.env.USE_VLLM` | `CONFIG_OFF` | Must be `CONFIG_ON` when `vllm.enabled=true`; set by `xeon_vllm_values.yaml`. |
 | `pipelinemanager.env.SUMMARY_FEATURE` | `FEATURE_OFF` | Turned on by summary/unified/dual overrides. |
 | `pipelinemanager.env.SEARCH_FEATURE` | `FEATURE_OFF` | Turned on by search/unified/dual overrides. |
@@ -90,15 +90,15 @@ This map is grounded in `chart/Chart.yaml`, `chart/values.yaml`, the override fi
 | `vllm.model.tensorParallelSize` | `1` | vLLM tensor parallel size. |
 | `rabbitmq.enabled` | `false` | Enabled by summary/unified. Service name `rabbitmq`. |
 | `audioanalyzer.enabled` | `false` | Enabled by summary/unified. Image `intel/audio-analyzer:1.3.3`. |
-| `videoingestion.enabled` | `false` | Enabled by summary/unified. Image `intel/video-ingestion:2026.2.0-rc2`. |
-| `multimodalembeddingms.enabled` | `false` | Enabled by search/unified. Image `intel/multimodal-embedding-serving:2026.2.0-rc2`. |
-| `multimodaldataprep.enabled` | `false` | Enabled by search/unified. Image `intel/multimodal-dataprep:2026.2.0-rc2`. |
+| `videoingestion.enabled` | `false` | Enabled by summary/unified. Image `intel/video-ingestion:2026.2.0`. |
+| `multimodalembeddingms.enabled` | `false` | Enabled by search/unified. Image `intel/multimodal-embedding-serving:2026.2.0`. |
+| `multimodaldataprep.enabled` | `false` | Enabled by search/unified. Image `intel/multimodal-dataprep:2026.2.0`. |
 | `vectorretriever.enabled` | `false` | Enabled by search/unified. Image `intel/vector-retriever-<backend>:<tag>`. |
 | `vdmsvectordb.enabled` | `false` | Enabled by search/unified. Image `intellabs/vdms:v2.12.0`. |
-| `videosearch.enabled` | `false` | Enabled by search/unified. Image `intel/video-search:2026.2.0-rc2`. |
+| `videosearch.enabled` | `false` | Enabled by search/unified. Image `intel/video-search:2026.2.0`. |
 | `summaryui.enabled`, `searchui.enabled` | `false` | UI aliases. `summaryui` becomes summary or unified UI; `searchui` is separate Search UI in search/dual. |
 | `global.metricsManager.enabled` | `false` | Enables the Metrics Manager subchart, nginx health/SSE routes, and DataPrep publisher environment. |
-| `metricsmanager.image.repository/tag` | `intel/metrics-manager` / `2026.2.0-rc2` | Metrics Manager runtime image. |
+| `metricsmanager.image.repository/tag` | `intel/metrics-manager` / `2026.2.0` | Metrics Manager runtime image. |
 
 ## Rendered resource names with release `vss`
 

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-deploy/references/env-vars.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-deploy/references/env-vars.md
@@ -29,7 +29,7 @@ Sources: `setup.sh`, `.env.example`, `docker/compose.*.yaml`, `README.md`, `docs
 | `REGISTRY_URL` | empty | `setup.sh` trims/adds a trailing slash, combines with `PROJECT_NAME`, and exports `REGISTRY`. |
 | `PROJECT_NAME` | empty | Also normalized with trailing slash before composing `${REGISTRY_URL}${PROJECT_NAME}`. |
 | `REGISTRY` | derived | Prefix for images such as `${REGISTRY:-}pipeline-manager:${TAG:-latest}`. |
-| `TAG` | `latest` in `setup.sh`; docs example `2026.2.0-rc2` | Image tag for app images. |
+| `TAG` | `latest` in `setup.sh`; docs example `2026.2.0` | Image tag for app images. |
 
 ## Model download service
 

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-deploy/vss.config
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-deploy/vss.config
@@ -21,7 +21,7 @@
 
 # --- Registry / image tag ---
 export REGISTRY_URL=intel
-export TAG=latest
+export TAG=2026.2.0
 
 # --- Summary stack models (required for --summary / --dual / --unified) ---
 export VLM_MODEL_NAME="Qwen/Qwen3-VL-4B-Instruct"
@@ -35,7 +35,7 @@ export OD_MODEL_NAME="yolov8l"
 # export LLM_TARGET_DEVICE=CPU
 
 # --- Model download service used transiently by setup.sh ---
-export MODEL_DOWNLOAD_IMAGE="intel/model-download:latest"
+export MODEL_DOWNLOAD_IMAGE="intel/model-download:2026.2.0"
 export MODEL_DOWNLOAD_OVMS_TAG="v2026.1"
 export MODEL_DOWNLOAD_HOST_PORT=8640
 export MODEL_DOWNLOAD_JOB_TIMEOUT=5400

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-dlstreamer-pipeline/references/evam-pipelines.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-dlstreamer-pipeline/references/evam-pipelines.md
@@ -7,7 +7,7 @@ This reference is grounded in the Video Search & Summarization sample applicatio
 | Concern | Repo path | Notes |
 |---|---|---|
 | Pipeline definitions | `video-ingestion/resources/conf/config.json` | Copied into the image as `/home/pipeline-server/config.json`. |
-| Pipeline Server image | `video-ingestion/docker/Dockerfile` | `FROM intel/dlstreamer-pipeline-server:2026.2.0-ubuntu24-rc2`. |
+| Pipeline Server image | `video-ingestion/docker/Dockerfile` | `FROM intel/dlstreamer-pipeline-server:2026.2.0-ubuntu24`. |
 | Python publisher used by `gvapython` | `video-ingestion/src/publish.py` | Copied to `/home/pipeline-server/gvapython/publisher/`. |
 | EVAM request DTO and pipeline enum | `pipeline-manager/src/evam/models/evam.model.ts` | Defines `ChunkingRequestDTO`, `EVAMPipelines`. |
 | EVAM HTTP client | `pipeline-manager/src/evam/services/evam.service.ts` | Builds POST URL/body and polls status. |
@@ -285,7 +285,7 @@ To add `my_pipeline`:
 6. Update UI/API tests or config docs that enumerate valid EVAM pipelines.
 7. Rebuild `video-ingestion`; its Dockerfile copies the config file into the image.
 
-If a required DL Streamer element, model-proc file, or post-processing setup lives only inside `intel/dlstreamer-pipeline-server:2026.2.0-ubuntu24-rc2`, say so explicitly in docs and use this repo's integration seam (`config.json`, model mount, Python publisher, and request payload) rather than pretending the external image internals are in this repository.
+If a required DL Streamer element, model-proc file, or post-processing setup lives only inside `intel/dlstreamer-pipeline-server:2026.2.0-ubuntu24`, say so explicitly in docs and use this repo's integration seam (`config.json`, model mount, Python publisher, and request payload) rather than pretending the external image internals are in this repository.
 
 ## Validation commands
 

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-observability/SKILL.md
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-observability/SKILL.md
@@ -28,7 +28,7 @@ VSS has two independent paths:
 1. Live system and dataprep metrics use Metrics Manager. Set
    `ENABLE_METRICS_MANAGER=true` in a search-enabled Compose deployment.
    `docker/compose.metrics-manager.yaml` starts
-   `docker.io/intel/metrics-manager:2026.2.0-rc2`. DataPrep sends
+   `docker.io/intel/metrics-manager:2026.2.0`. DataPrep sends
    `dataprep_embeddings_per_second` to its simple-metrics REST API, and the UI
    consumes its SSE stream through nginx.
 2. Pipeline Manager traces use the Node OpenTelemetry SDK. `OTLP_TRACE_URL`

--- a/sample-applications/video-search-and-summarization/.github/skills/vss-observability/evals/evals.json
+++ b/sample-applications/video-search-and-summarization/.github/skills/vss-observability/evals/evals.json
@@ -10,7 +10,7 @@
       "expectations": [
         "Mentions setting ENABLE_METRICS_MANAGER=true before sourcing setup.sh, with a supported mode such as source setup.sh --search or source setup.sh --summary --search.",
         "Names the optional compose overlay file docker/compose.metrics-manager.yaml.",
-        "Identifies the added service/container as metrics-manager and notes it uses docker.io/intel/metrics-manager:2026.2.0-rc2.",
+        "Identifies the added service/container as metrics-manager and notes it uses docker.io/intel/metrics-manager:2026.2.0.",
         "References the health and SSE routes through nginx and/or Prometheus output on port 9273.",
         "Explains that traces come from Pipeline Manager via OTLP_TRACE_URL with service name videoSummary, and that the overlay does not deploy an in-repo OTel collector or trace UI/backend."
       ]

--- a/sample-applications/video-search-and-summarization/chart/Chart.yaml
+++ b/sample-applications/video-search-and-summarization/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: video-search-and-summarization
 description: A helm chart for deploying Intel Video Search and Summarization sample application
-version: 2026.2.0-rc2-helm
+version: 2026.2.0-helm
 dependencies:
   - name: ovms
     version: 2026.2.0-helm

--- a/sample-applications/video-search-and-summarization/chart/subchart/metrics-manager/values.yaml
+++ b/sample-applications/video-search-and-summarization/chart/subchart/metrics-manager/values.yaml
@@ -9,7 +9,7 @@ global:
 
 image:
   repository: intel/metrics-manager
-  tag: "2026.2.0-rc2"
+  tag: "2026.2.0"
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/sample-applications/video-search-and-summarization/chart/subchart/multimodal-dataprep/values.yaml
+++ b/sample-applications/video-search-and-summarization/chart/subchart/multimodal-dataprep/values.yaml
@@ -42,7 +42,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2026.2.0-rc2"
+  tag: "2026.2.0"
 imagePullSecrets: []
 # This is to override the chart name.
 nameOverride: ""

--- a/sample-applications/video-search-and-summarization/chart/subchart/multimodal-embedding-ms/values.yaml
+++ b/sample-applications/video-search-and-summarization/chart/subchart/multimodal-embedding-ms/values.yaml
@@ -32,7 +32,7 @@ image:
     repository: intel/multimodal-embedding-serving
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2026.2.0-rc2"
+  tag: "2026.2.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/sample-applications/video-search-and-summarization/chart/subchart/vector-retriever/values.yaml
+++ b/sample-applications/video-search-and-summarization/chart/subchart/vector-retriever/values.yaml
@@ -6,7 +6,7 @@ image:
   # Leave repository empty to auto-select `intel/vector-retriever-<backend>`
   # from `retriever.backend`.
   repository: ""
-  tag: "2026.2.0-rc2"
+  tag: "2026.2.0"
   pullPolicy: IfNotPresent
 
 retriever:

--- a/sample-applications/video-search-and-summarization/chart/subchart/video-ingestion/values.yaml
+++ b/sample-applications/video-search-and-summarization/chart/subchart/video-ingestion/values.yaml
@@ -35,7 +35,7 @@ videoingestion:
   fullname: videoingestion
   image:
     repository: intel/video-ingestion
-    tag: "2026.2.0-rc2"
+    tag: "2026.2.0"
     pullPolicy: IfNotPresent
 
   containerPort: 8080  # Port on which container application listens internally

--- a/sample-applications/video-search-and-summarization/chart/subchart/video-search/values.yaml
+++ b/sample-applications/video-search-and-summarization/chart/subchart/video-search/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 videosearch:
   image:
     repository: intel/video-search
-    tag: "2026.2.0-rc2"
+    tag: "2026.2.0"
     pullPolicy: IfNotPresent
   resources: {}
   env:

--- a/sample-applications/video-search-and-summarization/chart/subchart/vss-ui/values.yaml
+++ b/sample-applications/video-search-and-summarization/chart/subchart/vss-ui/values.yaml
@@ -8,7 +8,7 @@ global:
 name: vssui
 image:
   repository: intel/vss-ui
-  tag: "2026.2.0-rc2"
+  tag: "2026.2.0"
   pullPolicy: IfNotPresent
   resources: {}
 

--- a/sample-applications/video-search-and-summarization/chart/user_values_override.yaml
+++ b/sample-applications/video-search-and-summarization/chart/user_values_override.yaml
@@ -8,7 +8,7 @@ global:
   #   tag: override the tag for the VSS images above.
   # Example:
   #   registry: "docker.io/intel"
-  #   tag: "2026.2.0-rc2"
+  #   tag: "2026.2.0"
   registry: ""
   tag: ""
   # pullPolicy overrides imagePullPolicy for the VSS service images above.

--- a/sample-applications/video-search-and-summarization/chart/values.yaml
+++ b/sample-applications/video-search-and-summarization/chart/values.yaml
@@ -56,8 +56,9 @@ global:
   modelDownload:
     image:
       repository: intel/model-download
-      # Leave empty to inherit global.tag; if both are empty it falls back to latest.
-      tag: ""
+      # Pinned to the release tag. Set to "" to inherit global.tag instead
+      # (and if both are empty it falls back to latest).
+      tag: "2026.2.0"
       pullPolicy: IfNotPresent
     # OVMS release tag whose export_model.py the openvino plugin uses.
     ovmsReleaseTag: "v2026.1"
@@ -136,7 +137,7 @@ pipelinemanager:
     runAsGroup: 0
   image:
     repository: intel/pipeline-manager
-    tag: "2026.2.0-rc2"
+    tag: "2026.2.0"
     pullPolicy: IfNotPresent
   containerPortName: videosumm-port # Optional name to refer containerPort
   # Readiness gating mirrors the Compose healthcheck for pipeline-manager
@@ -327,7 +328,7 @@ metricsmanager:
   coLocateWithDataPrep: true
   image:
     repository: intel/metrics-manager
-    tag: "2026.2.0-rc2"
+    tag: "2026.2.0"
     pullPolicy: IfNotPresent
 
 # VSS UI subchart alias conditions. Detailed defaults come from subchart/vss-ui/values.yaml.

--- a/sample-applications/video-search-and-summarization/docker/compose.metrics-manager.yaml
+++ b/sample-applications/video-search-and-summarization/docker/compose.metrics-manager.yaml
@@ -3,7 +3,7 @@
 
 services:
   metrics-manager:
-    image: intel/metrics-manager:2026.2.0-rc2
+    image: intel/metrics-manager:2026.2.0
     container_name: metrics-manager
     ports:
       - "${METRICS_MANAGER_HOST_PORT:-9090}:9090"

--- a/sample-applications/video-search-and-summarization/docs/user-guide/deploy-with-helm.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/deploy-with-helm.md
@@ -27,17 +27,17 @@ There are 2 options to get the charts in your workspace:
 Use the following command to pull the Helm chart from Docker Hub:
 
 ```bash
-helm pull oci://registry-1.docker.io/intel/video-search-and-summarization --version 2026.2.0-rc2-helm
+helm pull oci://registry-1.docker.io/intel/video-search-and-summarization --version 2026.2.0-helm
 ```
 
-Use chart version `2026.2.0-rc2-helm` for this release workflow.
+Use chart version `2026.2.0-helm` for this release workflow.
 
 ##### Step 2: Extract the `.tgz` File
 
 After pulling the chart, extract the `.tgz` file:
 
 ```bash
-tar -xvf video-search-and-summarization-2026.2.0-rc2-helm.tgz
+tar -xvf video-search-and-summarization-2026.2.0-helm.tgz
 ```
 
 This will create a directory named `video-search-and-summarization` containing the chart files. Navigate to the extracted directory to access the charts.
@@ -80,8 +80,8 @@ Update or edit the values in YAML file as follows:
 | Key | Description | Example Value |
 | --- | ----------- | ------------- |
 | `global.registry` | Single-source image registry override for all VSS service images (pipeline-manager, video-ingestion, video-search, vss-ui, multimodal-dataprep, multimodal-embedding-serving, vector-retriever). Leave empty to keep each subchart's own default. | `""` or `my-registry.example.com/vss/` |
-| `global.tag` | Single-source image tag override for the VSS service images above. Also used as fallback for `global.modelDownload.image.tag` when that value is empty. | `""` or `2026.2.0-rc2` |
-| `global.modelDownload.image.tag` | Optional explicit model-download image tag. Leave empty to inherit `global.tag` (and if both are empty, chart defaults to `latest`). | `""` or `2026.2.0-rc2` |
+| `global.tag` | Single-source image tag override for the VSS service images above. Also used as fallback for `global.modelDownload.image.tag` when that value is empty. | `""` or `2026.2.0` |
+| `global.modelDownload.image.tag` | model-download image tag, pinned to the release by default. Set to `""` to inherit `global.tag` (and if both are empty, chart defaults to `latest`). | `2026.2.0` or `""` |
 | `global.pullPolicy` | Image pull policy override for the VSS service images above. Leave empty to keep each subchart's default (`IfNotPresent`). Set to `Always` to force a fresh pull on every pod start (e.g. when reusing a mutable tag). | `""`, `Always`, or `IfNotPresent` |
 | `global.metricsManager.enabled` | Deploy Metrics Manager and enable direct DataPrep metric publishing | `true` or `false` |
 | `global.keepPvc` | PVC gets deleted by default once helm is uninstalled. Set this to true to persist PVC (helps avoid delay due to model re-downloads when re-installing chart). | `true` or `false` |
@@ -123,7 +123,7 @@ Update or edit the values in YAML file as follows:
 | `pipelinemanager.env.SEARCH_DATAPREP_TIMEOUT_MS` | Timeout in milliseconds for search dataprep operations (video embedding pipeline). Increase for large videos or slow hardware. | `600000` (default, 10 minutes) |
 | `videoingestion.odModelName` | Name of object detection model (generic YOLO id from the model-download ultralytics hub) used during video ingestion | `yolov8l` |
 | `metricsmanager.image.repository` | Metrics Manager image repository | `docker.io/intel/metrics-manager` |
-| `metricsmanager.image.tag` | Metrics Manager image tag | `2026.2.0-rc2` |
+| `metricsmanager.image.tag` | Metrics Manager image tag | `2026.2.0` |
 
 > **`MM_DATAPREP_ALLOW_DUPLICATE_UPLOADS` override:** You do **not** need to put this in `user_values_override.yaml`. You can set it directly at install/upgrade time with `--set`, for example:
 >

--- a/sample-applications/video-search-and-summarization/docs/user-guide/get-started.md
+++ b/sample-applications/video-search-and-summarization/docs/user-guide/get-started.md
@@ -81,7 +81,7 @@ Before running the application, you need to set several environment variables:
 
    ```bash
    export REGISTRY_URL=intel
-   export TAG=2026.2.0-rc2
+   export TAG=2026.2.0
    ```
 
 2. **Set required credentials for some services**:

--- a/sample-applications/video-search-and-summarization/video-ingestion/docker/Dockerfile
+++ b/sample-applications/video-search-and-summarization/video-ingestion/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM intel/dlstreamer-pipeline-server:2026.2.0-ubuntu24-rc2
+FROM intel/dlstreamer-pipeline-server:2026.2.0-ubuntu24
 
 COPY requirements.txt . 
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION

### Description

- Changed prebuilt image tags from `latest` to `2026.2.0` in various documentation files for multimodal data preparation and VLM OpenVINO serving.
- Updated environment variable `TAG` to `2026.2.0` in SKILL.md files and other relevant scripts.
- Modified user guide and build instructions to reflect the new release version.
- Adjusted Helm chart versioning from `2026.2.0-rc1` to `2026.2.0` across multiple files.
- Ensured consistency in image tags across all subcharts and Dockerfiles for video search and summarization application.
- Updated Docker Compose files to use the new image tags.

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Tested in dev env

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

