### PR TITLE
dependabot.yml: Updates to time series analytics

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # update the submodules on a weekly interval
 version: 2
+multi-ecosystem-groups:
+  time-series-analytics-python:
+    schedule:
+      interval: weekly
 updates:
 
   # ─────────────────────────────────────────
@@ -100,17 +104,6 @@ updates:
         patterns:
           - "*"
 
-
-# ─────────────────────────────────────────
-# Python (pip) — Time Series Analytics 
-# ─────────────────────────────────────────
-
-multi-ecosystem-groups:
-  time-series-analytics-python:
-    schedule:
-      interval: weekly
-
-updates:
   - package-ecosystem: "pip"
     directory: "/microservices/time-series-analytics"
     multi-ecosystem-group: time-series-analytics-python

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,58 +100,45 @@ updates:
         patterns:
           - "*"
 
+
+# ─────────────────────────────────────────
+# Python (pip) — Time Series Analytics 
+# ─────────────────────────────────────────
+
+multi-ecosystem-groups:
+  time-series-analytics-python:
+    schedule:
+      interval: weekly
+
+updates:
   - package-ecosystem: "pip"
     directory: "/microservices/time-series-analytics"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: time-series-analytics-python
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 5
-    groups:
-      python-deps:
-        applies-to: version-updates
-        patterns:
-          - "*"
+    open-pull-requests-limit: 1
 
   - package-ecosystem: "pip"
     directory: "/microservices/time-series-analytics/simulator"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: time-series-analytics-python
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 5
-    groups:
-      python-deps:
-        applies-to: version-updates
-        patterns:
-          - "*"
+    open-pull-requests-limit: 1
 
   - package-ecosystem: "pip"
     directory: "/microservices/time-series-analytics/tests-functional"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: time-series-analytics-python
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 5
-    groups:
-      python-deps:
-        applies-to: version-updates
-        patterns:
-          - "*"
+    open-pull-requests-limit: 1
 
   - package-ecosystem: "pip"
     directory: "/microservices/time-series-analytics/tests"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: time-series-analytics-python
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 5
-    groups:
-      python-deps:
-        applies-to: version-updates
-        patterns:
-          - "*"
-
+    open-pull-requests-limit: 1
+  
   # ─────────────────────────────────────────
   # Python (pip) — Sample Applications
   # ─────────────────────────────────────────

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,6 +106,8 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/microservices/time-series-analytics"
+    schedule:
+      interval: "weekly"
     multi-ecosystem-group: time-series-analytics-python
     cooldown:
       default-days: 7
@@ -113,6 +115,8 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/microservices/time-series-analytics/simulator"
+    schedule:
+      interval: "weekly"
     multi-ecosystem-group: time-series-analytics-python
     cooldown:
       default-days: 7
@@ -120,6 +124,8 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/microservices/time-series-analytics/tests-functional"
+    schedule:
+      interval: "weekly"
     multi-ecosystem-group: time-series-analytics-python
     cooldown:
       default-days: 7
@@ -127,6 +133,8 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/microservices/time-series-analytics/tests"
+    schedule:
+      interval: "weekly"
     multi-ecosystem-group: time-series-analytics-python
     cooldown:
       default-days: 7


### PR DESCRIPTION
### Description

Updated the deps to raise only a single consolidated PR instead of multiple PRs. 

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

The dependabot workflow runs on default branch always and we cannot run on our branch (in the same or forked repo).
The changes I've checked w/ coding agent and should work as expected to create a single PR grouping updates across all time series analytics module.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

